### PR TITLE
Add decorator to turn python functions into an Op

### DIFF
--- a/outlines/__init__.py
+++ b/outlines/__init__.py
@@ -28,6 +28,7 @@ References
 .. [1] Dohan, David, et al. "Language model cascades." arXiv preprint arXiv:2207.10342 (2022).
 
 """
+from outlines.function import fn
 from outlines.image import as_image
 from outlines.program import program
 from outlines.text import as_string, compose
@@ -35,6 +36,6 @@ from outlines.text import as_string, compose
 __all__ = [
     "as_image",
     "as_string",
-    "program",
+    "fn" "program",
     "compose",
 ]

--- a/outlines/function.py
+++ b/outlines/function.py
@@ -1,0 +1,73 @@
+"""Functionalities to wrap user-defined functions as Ops.
+
+The content of this module is heavily inspired by the design of
+`Aesara <https://github.com/aesara-devs/aesara>`_.
+
+"""
+import inspect
+from typing import Callable, Sequence, Type
+
+from outlines.graph import Op, Variable
+from outlines.text.var import StringVariable
+
+
+class FromFunctionOp(Op):
+    """Build an outlines Op around a function."""
+
+    def __init__(
+        self,
+        fn: Callable,
+        input_types: Sequence[Type[Variable]],
+        output_types: Sequence[Type[Variable]],
+    ):
+        self._fn = fn
+        self.input_types = input_types
+        self.output_types = output_types
+
+    def __str__(self):
+        return f"FromFunctionOp({self._fn.__name__})"
+
+    def perform(self, *inputs):
+        outs = self._fn(*inputs)
+        if not isinstance(outs, (list, tuple)):
+            outs = (outs,)
+
+        return outs
+
+
+def fn(function: Callable):
+    """Decorator that converts a Python function into an Outlines `Op`
+    that will call the function as its implementation.
+
+    The user must specify the types of the inputs and outputs as type
+    hints.
+
+    """
+    sig = inspect.signature(function)
+
+    inputs = []
+    for name, parameter in sig.parameters.items():
+        if parameter.annotation == str:
+            inputs.append(StringVariable)
+        elif parameter.annotation == inspect._empty:
+            raise TypeError(
+                "You need to specify the function's input types as type hints."
+            )
+        else:
+            raise TypeError(
+                "The `fn` decorator currently only supports string arguments."
+            )
+
+    outputs = []
+    if sig.return_annotation == str:
+        outputs.append(StringVariable)
+    elif sig.return_annotation == inspect._empty:
+        raise TypeError(
+            "You need to specify the function's output types as type hints."
+        )
+    else:
+        raise TypeError(
+            "The `fn` decorator currently only supports string return types"
+        )
+
+    return FromFunctionOp(function, input_types=inputs, output_types=outputs)

--- a/outlines/graph.py
+++ b/outlines/graph.py
@@ -16,7 +16,17 @@ operations on arrays. It is possible that Aesara may be used as a backend for
 Outlines in the near future.
 
 """
-from typing import Any, Iterable, List, Optional, Reversible, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Iterable,
+    List,
+    Optional,
+    Reversible,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 
 class Node:
@@ -149,6 +159,9 @@ class Op:
 
     """
 
+    input_types: Optional[Sequence[Type[Variable]]] = None
+    output_types: Optional[Sequence[Type[Variable]]] = None
+
     def make_node(self, *inputs: Variable) -> Apply:
         r"""Construct an `Apply` node that represents the application of this
         operation to the given inputs.
@@ -166,7 +179,24 @@ class Op:
         The constructed `Apply` node.
 
         """
-        raise NotImplementedError
+        if self.input_types is None:
+            raise NotImplementedError(
+                "You need to either provide `input_types` and `output_types` or implement the `make_node` method."
+            )
+
+        if self.output_types is None:
+            raise NotImplementedError(
+                "You need to either provide `input_types` and `output_types` or implement the `make_node` method."
+            )
+
+        if len(inputs) != len(self.input_types):
+            raise ValueError(
+                f"You need to provide an input type for each input. Got {len(self.input_types)} type definitions and {len(inputs)} inputs."
+            )
+
+        # Check that the input types are valid
+
+        return Apply(self, inputs, [o() for o in self.output_types])
 
     def __call__(self, *inputs: Variable) -> Union[Variable, List[Variable]]:
         """Calls :meth:`Op.make_node` to construct an `Apply` node."""

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,0 +1,47 @@
+import pytest
+
+import outlines
+
+
+def test_function_no_types():
+    with pytest.raises(TypeError, match="input types"):
+
+        @outlines.fn
+        def constant(inp):
+            return "constant"
+
+        constant("")
+
+    with pytest.raises(TypeError, match="only supports string arguments"):
+
+        @outlines.fn
+        def constant(inp: float):
+            return "constant"
+
+        constant("")
+
+    with pytest.raises(TypeError, match="output types"):
+
+        @outlines.fn
+        def constant(inp: str):
+            return "constant"
+
+        constant("")
+
+    with pytest.raises(TypeError, match="only supports string return types"):
+
+        @outlines.fn
+        def constant(inp: str) -> float:
+            return 1
+
+        constant("")
+
+
+def test_function_decorator():
+    @outlines.fn
+    def constant(inp: str) -> str:
+        return "constant"
+
+    inp = outlines.text.string()
+    out = constant(inp)
+    assert str(out.owner.op) == "FromFunctionOp(constant)"


### PR DESCRIPTION
Allows to use any Python function in an Outlines graph. The input and output types are inferred from the type annotations:

```python
import outlines

@outlines.fn
def constant_fn(inp: str) -> str:
    return "constant"

s = outlines.text.string()
out = constant(s)
```