### PR TITLE
Add a `outlines.text.random.Choice` Op

### DIFF
--- a/outlines/image/models/model.py
+++ b/outlines/image/models/model.py
@@ -57,13 +57,14 @@ class ImageModel(Op):
 
         return Apply(self, [prompt], [out])
 
-    def perform(self, prompt: str) -> Tuple[PILImage]:  # type: ignore
+    def perform(self, inputs) -> Tuple[PILImage]:  # type: ignore
         """Perform the operations represented by this `Op` on the input prompt.
 
         This defaults to sampling a new image. Other decoding methods act by
         patching this method.
 
         """
+        (prompt,) = inputs
         return (self.sample(prompt),)
 
     def sample(self, prompt: str) -> PILImage:

--- a/outlines/program.py
+++ b/outlines/program.py
@@ -11,6 +11,7 @@ from rich.panel import Panel
 
 from outlines.graph import Variable, io_toposort
 from outlines.text.models import LanguageModel
+from outlines.text.random import IntConstant
 from outlines.text.var import StringConstant
 
 COLORS = itertools.cycle(["deep_sky_blue2", "gold3", "deep_pink2"])
@@ -252,10 +253,10 @@ def chain(input_vars, output_vars) -> Callable:
 
         for node in sorted_nodes:
             for i in node.inputs:
-                if isinstance(i, StringConstant):
+                if isinstance(i, (StringConstant, IntConstant)):
                     storage_map[i] = i.value
             inputs = [storage_map[i] for i in node.inputs]
-            results = node.op.perform(*inputs)
+            results = node.op.perform(inputs)
             for i, o in enumerate(node.outputs):
                 storage_map[o] = results[i]
 

--- a/outlines/text/basic.py
+++ b/outlines/text/basic.py
@@ -13,7 +13,8 @@ class Add(Op):
         out = StringVariable()
         return Apply(self, [s, t], [out])
 
-    def perform(self, s, t):
+    def perform(self, inputs):
+        s, t = inputs
         return (s + t,)
 
 

--- a/outlines/text/models/hugging_face.py
+++ b/outlines/text/models/hugging_face.py
@@ -54,7 +54,7 @@ class HFCausalLM(LanguageModel):
         super().__init__(name=f"HuggingFace {model}")
         self.model_name = model
 
-    def perform(self, prompt):
+    def perform(self, inputs):
         """Sample new tokens give the tokenized prompt.
 
         Since HuggingFace's `generate` method returns the prompt along with the
@@ -68,6 +68,8 @@ class HFCausalLM(LanguageModel):
             tokenizers.
 
         """
+        (prompt,) = inputs
+
         tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         model = AutoModelForCausalLM.from_pretrained(self.model_name)
 

--- a/outlines/text/models/openai.py
+++ b/outlines/text/models/openai.py
@@ -47,7 +47,9 @@ class OpenAI(LanguageModel):
         super().__init__(name=f"OpenAI {model}")
         self.model = model
 
-    def perform(self, prompt):
+    def perform(self, inputs):
+        (prompt,) = inputs
+
         try:
             resp = openai.Completion.create(
                 model=self.model,

--- a/outlines/text/random.py
+++ b/outlines/text/random.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from outlines.graph import Apply, Op, Variable
+from outlines.text.var import StringVariable, as_string
+
+
+class IntVariable(Variable):
+    """Represents an integer value.
+
+    This is needed to define the operations on `ListVariable`s. We should instead
+    rely on Aesara for all of this.
+    """
+
+
+class IntConstant(IntVariable):
+    """Represents an integer value.
+
+    This is needed to define the operations on `ListVariable`s. We should instead
+    rely on Aesara for all of this.
+    """
+
+    def __init__(self, value):
+        self.value = value
+        super().__init__()
+
+
+class Choice(Op):
+    def __call__(self, choices, k=1):
+        return super().__call__(choices, k)
+
+    def make_node(self, choices, k):
+        var_choices = []
+        for choice in choices:
+            if not isinstance(choice, StringVariable):
+                choice = as_string(choice)
+            var_choices.append(choice)
+
+        out = [StringVariable() for _ in range(k)]
+        k = IntConstant(k)
+
+        return Apply(self, var_choices + [k], out)
+
+    def perform(self, inputs):
+        values, k = inputs[:-1], inputs[-1]
+        rng = np.random.default_rng()
+        idx = list(rng.integers(len(values), size=k))
+        return [values[i] for i in idx]
+
+
+choice = Choice()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ classifiers = [
 ]
 dependencies = [
    "mako",
+   "numpy",
    "pillow",
-   "rich"
+   "rich",
 ]
 dynamic = ["version"]
 

--- a/tests/text/test_basic.py
+++ b/tests/text/test_basic.py
@@ -13,7 +13,7 @@ def test_add_symbolic():
     assert len(w.owner.outputs) == 1
 
     a = Add()
-    assert a.perform("a", "string")[0] == "astring"
+    assert a.perform(("a", "string"))[0] == "astring"
 
     w = s + t
     assert isinstance(w, StringVariable)

--- a/tests/text/test_random.py
+++ b/tests/text/test_random.py
@@ -1,0 +1,16 @@
+from outlines.text.random import choice
+from outlines.text.var import StringVariable
+
+
+def test_choice():
+    a = ["string1", "string2"]
+
+    s = choice(a)
+    assert isinstance(s, StringVariable)
+
+    s = choice(a, k=2)
+    assert isinstance(s, list)
+    assert isinstance(s[0], StringVariable)
+    assert len(s) == 2
+
+    assert isinstance(s[0].eval(), str)


### PR DESCRIPTION
This `Op` selects and returns at random one or several of the strings passed as inputs.

```python
import outlines.text as text

few_shots = ["A thing", "a new thing", "a newer thing", "a newer newer thing"]

@text.prompt
def test_few_shots(examples):
    """A selection of examples:

    % for example in examples:
    EXAMPLE: ${example}
    % endfor
    """

examples = text.random.choice(few_shots, k=2)
prompt = test_few_shots(examples)
print(prompt.eval())
# A selection of examples:\n\nEXAMPLE: a newer newer thing\nEXAMPLE: a new thing
```

The further I explore the more it becomes obvious that we should implement a `StringType` in Aesara and use Aesara as a backend for this library (images, audio, etc are simply implemented as wrappers around `TensorVariable`). In this PR I had to implement a dummy `IntVariable` in order to keep track of the number of values to sample from the original list. The backend is already largely inspired by Aesara's internals, and the more I progress the more Aesara code I end up re-implementing (introducing bugs). We should thus seriously re-think the backend implementation sooner rather than later.