### PR TITLE
Allow disabling caching

### DIFF
--- a/examples/react.py
+++ b/examples/react.py
@@ -12,11 +12,8 @@ References
 """
 import requests  # type: ignore
 
-import outlines
 import outlines.models as models
 import outlines.text as text
-
-outlines.cache.disable()
 
 
 @text.prompt

--- a/outlines/__init__.py
+++ b/outlines/__init__.py
@@ -1,7 +1,10 @@
 """Outlines is a Generative Model Programming Framework."""
-import outlines.cache as cache
+from outlines.caching import clear_cache, disable_cache, get_cache
 from outlines.text import prompt
 
 __all__ = [
+    "clear_cache",
+    "disable_cache",
+    "get_cache",
     "prompt",
 ]

--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -1,4 +1,5 @@
 import os
+from typing import Callable
 
 from perscache import Cache, NoCache
 from perscache.serializers import JSONSerializer
@@ -9,7 +10,11 @@ cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
 memory = Cache(serializer=JSONSerializer(), storage=LocalFileStorage(cache_dir))
 
 
-def get():
+def cache(fn: Callable):
+    return memory.cache()(fn)
+
+
+def get_cache():
     """Get the context object that contains previously-computed return values.
 
     The cache is used to avoid unnecessary computations and API calls, which can
@@ -23,7 +28,7 @@ def get():
     return memory
 
 
-def disable():
+def disable_cache():
     """Disable the cache for this session.
 
     Generative models output different results each time they are called when
@@ -47,7 +52,7 @@ def disable():
     memory = NoCache()
 
 
-def clear():
+def clear_cache():
     """Erase the cache completely."""
-    cache = get()
-    cache.storage.clear()
+    global memory
+    memory.storage.clear()

--- a/outlines/models/hf_diffusers.py
+++ b/outlines/models/hf_diffusers.py
@@ -1,9 +1,7 @@
 """Integration with HuggingFace's `diffusers` library."""
 from PIL.Image import Image as PILImage
 
-import outlines.cache as cache
-
-memory = cache.get()
+from outlines.caching import cache
 
 
 def HuggingFaceDiffuser(model_name: str) -> PILImage:
@@ -22,7 +20,7 @@ def HuggingFaceDiffuser(model_name: str) -> PILImage:
     return call
 
 
-@memory.cache()
+@cache
 def call_stable_diffusion_pipeline(
     model_name: str, prompt: str, samples: int
 ) -> PILImage:

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -1,9 +1,7 @@
 """Integration with HuggingFace's `transformers` library."""
 from typing import Callable, Optional
 
-import outlines.cache as cache
-
-memory = cache.get()
+from outlines.caching import cache
 
 
 def HuggingFaceCompletion(
@@ -52,7 +50,7 @@ def HuggingFaceCompletion(
     return call
 
 
-@memory.cache()
+@cache
 def call_model_generate_method(
     model_name: str,
     prompt: str,

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -9,7 +9,7 @@ import numpy as np
 from PIL import Image
 from PIL.Image import Image as PILImage
 
-import outlines.cache as cache
+from outlines.caching import cache
 
 __all__ = [
     "OpenAITextCompletion",
@@ -17,8 +17,6 @@ __all__ = [
     "OpenAIEmbeddings",
     "OpenAIImageGeneration",
 ]
-
-memory = cache.get()
 
 
 def OpenAITextCompletion(
@@ -48,7 +46,7 @@ def OpenAITextCompletion(
     """
 
     @error_handler
-    @memory.cache()
+    @cache
     def call_completion_api(
         model: str,
         prompt: str,
@@ -182,7 +180,7 @@ def OpenAIChatCompletion(
     """
 
     @error_handler
-    @memory.cache()
+    @cache
     def call_chat_completion_api(
         model: str,
         messages: List[Dict[str, str]],
@@ -344,7 +342,7 @@ def OpenAIEmbeddings(model_name: str):
     """
 
     @error_handler
-    @memory.cache()
+    @cache
     def call_embeddings_api(
         model: str,
         input: str,
@@ -388,7 +386,7 @@ def OpenAIImageGeneration(model_name: str = "", size: str = "512x512"):
     """
 
     @error_handler
-    @memory.cache()
+    @cache
     def call_image_generation_api(prompt: str, size: str, samples: int):
         import openai
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -34,10 +34,10 @@ def test_cache(refresh_environment):
         os.environ["OUTLINES_CACHE_DIR"] = tempdir
         import outlines
 
-        memory = outlines.cache.get()
+        memory = outlines.get_cache()
         assert memory.storage.location == Path(tempdir)
 
-        yield memory
+        yield outlines.caching.cache
 
         memory.storage.clear()
 
@@ -45,7 +45,7 @@ def test_cache(refresh_environment):
 def test_get_cache(test_cache):
     import outlines
 
-    memory = outlines.cache.get()
+    memory = outlines.get_cache()
     assert isinstance(memory, perscache.Cache)
     assert isinstance(memory.storage, perscache.storage.LocalFileStorage)
 
@@ -54,7 +54,7 @@ def test_get_cache(test_cache):
     # second time `f` is called.
     store = list()
 
-    @memory.cache()
+    @test_cache
     def f(x):
         store.append(1)
         return x
@@ -73,15 +73,14 @@ def test_disable_cache(test_cache):
     """Make sure that we can disable the cache."""
     import outlines
 
-    outlines.cache.disable()
-    memory = outlines.cache.get()
+    outlines.disable_cache()
 
     # If the cache is disabled then the size
     # of `store` should increase every time
     # `f` is called.
     store = list()
 
-    @memory.cache()
+    @test_cache
     def f(x):
         store.append(1)
         return x
@@ -94,10 +93,11 @@ def test_disable_cache(test_cache):
 
 def test_clear_cache(test_cache):
     """Make sure that we can clear the cache."""
+    import outlines
 
     store = list()
 
-    @test_cache.cache
+    @test_cache
     def f(x):
         store.append(1)
         return x
@@ -111,6 +111,6 @@ def test_clear_cache(test_cache):
 
     # The size of `store` should increase if we call `f`
     # after clearing the cache.
-    test_cache.storage.clear()
+    outlines.clear_cache()
     f(1)
     assert len(store) == store_size + 1


### PR DESCRIPTION
The current use of caching does not allow the user to disable it should they want to. This PR changes this; to disable the cache one needs to call

```
import outlines
outlines.disable_cache()
```

at the top of their script.