### PR TITLE
Add HuggingFace embedding consistent with cloud service

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -7,5 +7,5 @@ codebase.
 """
 from . import image_generation, text_completion
 from .hf_diffusers import HuggingFaceDiffuser
-from .hf_transformers import HuggingFaceCompletion
+from .hf_transformers import HuggingFaceCompletion, HuggingFaceEmbeddings
 from .openai import OpenAICompletion, OpenAIEmbeddings, OpenAIImageGeneration

--- a/outlines/models/embeddings.py
+++ b/outlines/models/embeddings.py
@@ -1,4 +1,6 @@
 """Router for embedding models."""
+from .hf_transformers import HuggingFaceEmbeddings
 from .openai import OpenAIEmbeddings
 
 openai = OpenAIEmbeddings
+huggingface = HuggingFaceEmbeddings

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -465,7 +465,7 @@ def HuggingFaceEmbeddings(model_name: str):
         sentences
             The strings to be embedded
         batch_size
-        The batch size. If it is not provided, or if a negative value is given, the embeddings will be run as a single batch.
+            The batch size. If it is not provided, or if a negative value is given, the embeddings will be run as a single batch.
 
 
         Returns

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -462,7 +462,7 @@ def HuggingFaceEmbeddings(model_name: str):
 
         Parameters
         ----------
-        sentences: List[str] | str
+        sentences
             The strings to be embedded
         batch_size: Optional[int]
         The batch size. If it is not provided, or if a negative value is given, the embeddings will be run as a single batch.

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -464,7 +464,7 @@ def HuggingFaceEmbeddings(model_name: str):
         ----------
         sentences
             The strings to be embedded
-        batch_size: Optional[int]
+        batch_size
         The batch size. If it is not provided, or if a negative value is given, the embeddings will be run as a single batch.
 
 

--- a/tests/models/test_hf_transformers.py
+++ b/tests/models/test_hf_transformers.py
@@ -2,11 +2,16 @@ import outlines
 
 outlines.disable_cache()
 
+import numpy as np  # noqa
 import pytest  # noqa
 
-from outlines.models.hf_transformers import HuggingFaceCompletion  # noqa
+from outlines.models.hf_transformers import (  # noqa
+    HuggingFaceCompletion,
+    HuggingFaceEmbeddings,
+)
 
 TEST_MODEL = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+EMBED_MODEL = "sentence-transformers/all-MiniLM-L12-v2"
 
 
 def test_samples():
@@ -76,3 +81,27 @@ def test_is_in_multiple_samples():
 def test_stop_at_multiple_samples():
     model = HuggingFaceCompletion(TEST_MODEL, max_tokens=10)
     model("test", stop_at=[" "], samples=2)
+
+
+def test_single_embedding():
+    model = HuggingFaceEmbeddings(EMBED_MODEL)
+    out = model("This is a test sentence")
+    assert isinstance(out, np.ndarray)
+    assert out.shape[0] == 1
+    assert out.shape[1] == 384
+
+
+def test_multiple_embedding():
+    model = HuggingFaceEmbeddings(EMBED_MODEL)
+    out = model(["This is a test sentence", "Another test sentence"])
+    assert isinstance(out, np.ndarray)
+    assert out.shape[0] == 2
+    assert out.shape[1] == 384
+
+
+def test_batch_embeddings():
+    model = HuggingFaceEmbeddings(EMBED_MODEL)
+    out = model(["This is a test sentence", "Another test sentence"], batch_size=4)
+    assert isinstance(out, np.ndarray)
+    assert out.shape[0] == 2
+    assert out.shape[1] == 384


### PR DESCRIPTION
I've added HuggingFace models to the embeddings options in outlines.

Some things:

- There would be less code if we just used `sentence_transformers`, but this is consistent with what happens in `cloud` right now (a light re-write of that code. Ben's argument for doing manual pooling is to reduce dependency bloat.)
- It adds a `batch_size` parameter to the generated function, in the case where you want to do batching. The default processes the input all in one batch. Would it be better for the default to do batches of 1?
- I haven't tested it with a gpu, but it should be lowered properly if a gpu is available 
- I've written some tests that all pass. ~But for some reason, a lot of the other tests are failing on my machine.~ It turns out I was using Python 3.11, which explains all of this.
- It's been through the pre-commit circus.

lmk what you think needs changing etc.