### PR TITLE
Use FSMs for scanning during grammar-guided generation

### DIFF
--- a/outlines/text/parsing.py
+++ b/outlines/text/parsing.py
@@ -1,23 +1,36 @@
-from collections import ChainMap, defaultdict
+from collections import ChainMap
 from copy import copy, deepcopy
-from typing import Any, Callable, DefaultDict, Dict, Iterable, Optional, Set, Tuple
+from dataclasses import dataclass
+from functools import cache
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Generator,
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import interegular
-import regex
-from interegular.fsm import FSM, Alphabet, anything_else
+from interegular.fsm import FSM, Alphabet, OblivionError
 from interegular.patterns import Unsupported
 from lark import Lark, Token
 from lark.common import LexerConf, ParserConf
 from lark.exceptions import (
     LexError,
     UnexpectedCharacters,
-    UnexpectedEOF,
+    UnexpectedInput,
     UnexpectedToken,
 )
-from lark.indenter import PythonIndenter
+from lark.indenter import Indenter
 from lark.lexer import (
     BasicLexer,
-    CallChain,
     ContextualLexer,
     LexerState,
     LexerThread,
@@ -29,12 +42,34 @@ from lark.parser_frontends import (
     PostLexConnector,
     _validate_frontend_args,
 )
-from lark.parsers.lalr_analysis import IntParseTable, LALR_Analyzer, ParseTable, Shift
+from lark.parsers.lalr_analysis import (
+    Action,
+    IntParseTable,
+    LALR_Analyzer,
+    ParseTable,
+    Shift,
+)
 from lark.parsers.lalr_interactive_parser import InteractiveParser
 from lark.parsers.lalr_parser import LALR_Parser, ParseConf, ParserState, _Parser
-from lark.utils import get_regexp_width
 
 PartialParseState = Tuple[str, int]
+ParseStateType = Union[int, FrozenSet]
+
+
+@dataclass
+class PartialTerminalInfo:
+    priority: int
+    terminal_name: str
+    can_transition: bool
+    is_final: bool
+
+
+@dataclass
+class PartialTokensInfo:
+    fsm_state_seq: Tuple[int, ...]
+    is_not_finished: bool
+    terminals_and_info: Tuple[PartialTerminalInfo, ...]
+    final_terminals_and_info: Tuple[PartialTerminalInfo, ...]
 
 
 def make_deterministic_fsm(fsm: FSM) -> Tuple[FSM, Dict[int, int]]:
@@ -111,10 +146,6 @@ def make_deterministic_fsm(fsm: FSM) -> Tuple[FSM, Dict[int, int]]:
     return new_fsm, old_to_new_states
 
 
-class PartialTokenEOF(UnexpectedEOF):
-    pass
-
-
 class PartialParserConf(ParserConf):
     __serialize_fields__ = "rules", "start", "parser_type", "deterministic"
 
@@ -171,6 +202,9 @@ class PartialLark(Lark):
             self.options.lexer,
         )
 
+    def parse_from_state(self, parse_state: "PartialParseState", is_end=False):
+        return self.parser.parser.parser.parse_from_state(parse_state, is_end=is_end)
+
 
 class PartialLexerThread(LexerThread):
     def __copy__(self):
@@ -203,6 +237,114 @@ class PartialParsingFrontend(ParsingFrontend):
 
         if lexer_conf.postlex:
             self.lexer = PartialPostLexConnector(self.lexer.lexer, lexer_conf.postlex)
+
+        self._termset_fsm_info = None
+        self._symbols_to_states: Optional[
+            Dict[str, Set[Tuple[ParseStateType, Action]]]
+        ] = None
+        self._reverse_shifts: Optional[
+            Dict[ParseStateType, Dict[str, Set[ParseStateType]]]
+        ] = None
+        # self._state_transition_map: Optional[
+        #     Dict[Tuple[ParseStateType, str], Set[ParseStateType]]
+        # ] = None
+
+    def _compute_maps(
+        self,
+    ):
+        """Compute state transition and symbols-to-states maps."""
+        self._reverse_shifts = {}
+        self._symbols_to_states = {}
+
+        parse_table = self.parser.parser.parse_table
+
+        for from_state, symbols_to_ops in parse_table.states.items():
+            for symbol, op in symbols_to_ops.items():
+                if op[0] == Shift:
+                    symbols_to_from_states = self._reverse_shifts.setdefault(op[1], {})
+                    symbols_to_from_states.setdefault(symbol, set()).add(from_state)
+                self._symbols_to_states.setdefault(symbol, set()).add((from_state, op))
+
+        # # TODO: This approach is very wasteful.
+        # context_lexer = get_contextual_lexer(self)
+        # self._state_transition_map = {}
+        #
+        # for from_state, transitions in parse_table.states.items():
+        #     for symbol, action in transitions.items():
+        #         # TODO: Filter non-terminals
+        #         if symbol not in context_lexer.root_lexer.terminals_by_name:
+        #             continue
+        #
+        #         if action[0] is Shift:
+        #             self._state_transition_map.setdefault(
+        #                 (from_state, symbol), set()
+        #             ).add(action[1])
+        #             continue
+        #
+        #         antecedent_state_seqs = parse_to_terminal(self, [(from_state,)], symbol)
+        #
+        #         for antecedent_state_seq in antecedent_state_seqs:
+        #             antecedent_state = antecedent_state_seq[-1]
+        #             self._state_transition_map.setdefault(
+        #                 (from_state, symbol), set()
+        #             ).add(antecedent_state)
+
+    def _compute_termset_fsm_info(self):
+        """Collect and return information about terminal symbol sets and their FSMs.
+
+        Terminal symbol sets (or "termsets") are ordered sequences of terminal
+        symbols that are used by each parser state.  Associated with each is a
+        collection of FSMs for each terminal and a single parse state FSM that is
+        the union of each terminal's FSM.
+
+        This constructs a list of tuples containing the termset, the set of
+        parse states that use the termsets, parse state FSMs, and information
+        mapping the components of the parse state FSMs to their terminal symbol
+        FSMs.
+
+        """
+        context_lexer = get_contextual_lexer(self)
+        termsets_to_fsms = {}
+        termsets_to_parse_states: Dict[Tuple[str, ...], Set[ParseStateType]] = {}
+        for parse_state, lexer in context_lexer.lexers.items():
+            scanner = lexer.scanner
+            key = tuple(term.name for term in scanner.terminals)
+            termsets_to_fsms[key] = (scanner.fsm, scanner.fsms_to_trans_finals)
+            termsets_to_parse_states.setdefault(key, set()).add(parse_state)
+
+        self._termset_fsm_info = [
+            (
+                termset,
+                frozenset(termsets_to_parse_states[termset]),
+                fsm,
+                fsms_to_trans_finals,
+            )
+            for termset, (fsm, fsms_to_trans_finals) in termsets_to_fsms.items()
+        ]
+
+    @property
+    def termset_fsm_info(self):
+        if self._termset_fsm_info is None:
+            self._compute_termset_fsm_info()
+        return self._termset_fsm_info
+
+    @property
+    def symbols_to_states(self):
+        if self._symbols_to_states is None:
+            self._compute_maps()
+        return self._symbols_to_states
+
+    @property
+    def reverse_shifts(self):
+        if self._reverse_shifts is None:
+            self._compute_maps()
+        return self._reverse_shifts
+
+    # @property
+    # def state_transition_map(self):
+    #     if self._state_transition_map is None:
+    #         self._compute_maps()
+    #     return self._state_transition_map
 
 
 class PartialLALRParser(LALR_Parser):
@@ -273,34 +415,154 @@ class PartialParserState(ParserState):
     def __repr__(self):
         return f"{type(self).__name__}(lexer={self.lexer!r}, state_stack={self.state_stack!r})"
 
+    def feed_token(self, token, is_end=False):
+        if token.type == "partial":
+            current_state = self.state_stack[-1]
+            current_transitions = self.parse_conf.states[current_state]
+            current_lexer = get_contextual_lexer(self.lexer).lexers[current_state]
+
+            if not any(
+                terminal_info.terminal_name in current_transitions
+                or terminal_info.terminal_name in current_lexer.ignore_types
+                for terminal_info in token.value.terminals_and_info
+            ):
+                # If none of the terminals can transition, we should
+                # know sooner than later
+                expected = {
+                    s
+                    for s in self.parse_conf.states[current_state].keys()
+                    if s.isupper()
+                }
+                raise UnexpectedToken(
+                    token, expected, state=self, interactive_parser=None
+                )
+            return
+
+        super().feed_token(token, is_end=is_end)
+
 
 class PartialParser(_Parser):
     def parse(
         self, lexer, start, value_stack=None, state_stack=None, start_interactive=False
     ):
         parse_conf = ParseConf(self.parse_table, self.callbacks, start)
-        parser_state = PartialParserState(parse_conf, lexer, state_stack, value_stack)
+        parser_state = PartialParserState(
+            parse_conf, copy(lexer), state_stack, value_stack
+        )
         if start_interactive:
             return InteractiveParser(self, parser_state, parser_state.lexer)
         return self.parse_from_state(parser_state)
 
+    def parse_from_state(self, state, last_token=None, is_end=False):
+        try:
+            token = last_token
+            for token in state.lexer.lex(state):
+                state.feed_token(token)
+
+            if is_end and (not token or token.type != "partial"):
+                end_token = (
+                    Token.new_borrow_pos("$END", "", token)
+                    if token
+                    else Token("$END", "", 0, 1, 1)
+                )
+                state.feed_token(end_token, True)
+
+            return state
+        except UnexpectedInput as e:
+            try:
+                e.interactive_parser = InteractiveParser(self, state, state.lexer)
+            except NameError:
+                pass
+            raise e
+        except Exception:
+            if self.debug:
+                print("")
+                print("STATE STACK DUMP")
+                print("----------------")
+                for i, s in enumerate(state.state_stack):
+                    print("%d)" % i, s)
+                print("")
+
+            raise
+
 
 class PartialScanner(Scanner):
+    @classmethod
+    @cache
+    def construct_terminal_fsm(cls, terminal):
+        # TODO: This should really be done at the lexer/parser level so that
+        # the lifetime of these objects is tied to the parser itself.
+        regex_str = terminal.pattern.to_regexp()
+        pattern = interegular.parse_pattern(regex_str)
+        fsm, _ = make_deterministic_fsm(pattern.to_fsm().reduce())
+        return fsm, pattern.prefix_postfix
+
     def __init__(self, terminals, g_regex_flags, re_, use_bytes, match_whole=False):
         self.terminals = terminals
         self.g_regex_flags = g_regex_flags
-        self.re_ = regex
         self.use_bytes = use_bytes
         self.match_whole = match_whole
         self.allowed_types = {t.name for t in self.terminals}
-        self._mres = self._build_mres(terminals, len(terminals))
+        self._mres = None
 
-    def match(self, text, pos) -> Optional[Tuple[str, Optional[str], bool]]:
-        for mre in self._mres:
-            m = mre.match(text, pos=pos, partial=True)
-            if m:  # and ((not m.partial) or m.endpos == len(text)):
-                return m.group(0), m.lastgroup, m.partial
-        return None
+        fsms = []
+        for t in self.terminals:
+            fsm, prefix_postfix = self.construct_terminal_fsm(t)
+
+            # TODO FIXME: We don't support this right now.
+            assert prefix_postfix == (0, 0)
+
+            fsms.append(fsm)
+
+        self.fsm, self.fsms_to_trans_finals = fsm_union(fsms)
+
+    def get_terminals_info(
+        self, fsm_state_seq
+    ) -> Tuple[Tuple[PartialTerminalInfo, ...], Tuple[PartialTerminalInfo, ...]]:
+        """Get the possible terminal symbols for an FSM state sequence."""
+        terminals_and_info: Tuple[PartialTerminalInfo, ...] = ()
+        final_terminals_and_info: Tuple[PartialTerminalInfo, ...] = ()
+        for i, (fsm_id, fsm_reads_more, in_final) in enumerate(
+            get_sub_fsms_from_seq(fsm_state_seq, self.fsms_to_trans_finals)
+        ):
+            terminal_name = self.terminals[fsm_id].name
+            info = PartialTerminalInfo(i, terminal_name, fsm_reads_more, in_final)
+            terminals_and_info += (info,)
+            if in_final:
+                final_terminals_and_info += (info,)
+
+        return terminals_and_info, final_terminals_and_info
+
+    def match(self, text, pos, last_fsm_state_seq: Optional[Tuple[int, ...]] = None):
+        """Determine an FSM match over `text` starting at `pos` and continuing `last_fsm_state_seq`."""
+
+        start_pos = pos
+
+        if last_fsm_state_seq:
+            assert len(last_fsm_state_seq) > 1
+            start_pos += len(last_fsm_state_seq) - 1
+            start_state = last_fsm_state_seq[-1]
+        else:
+            start_state = self.fsm.initial
+
+        text_part = text[start_pos:]
+
+        res = find_partial_matches(
+            self.fsm,
+            text_part,
+            start_state=start_state,
+            full_match=self.match_whole,
+        )
+
+        if len(res) == 0:
+            return None
+
+        ((_, state_seq),) = res
+
+        if last_fsm_state_seq:
+            state_seq = last_fsm_state_seq[:-1] + state_seq
+
+        return state_seq
 
 
 class PartialContextualLexer(ContextualLexer):
@@ -311,12 +573,12 @@ class PartialContextualLexer(ContextualLexer):
         trad_conf = copy(conf)
         trad_conf.terminals = terminals
 
-        lexer_by_tokens: Dict = {}
+        lexer_by_symbols: Dict = {}
         self.lexers = {}
         for state, accepts in states.items():
             key = frozenset(accepts)
             try:
-                lexer = lexer_by_tokens[key]
+                lexer = lexer_by_symbols[key]
             except KeyError:
                 accepts = set(accepts) | set(conf.ignore) | set(always_accept)
                 lexer_conf = copy(trad_conf)
@@ -324,100 +586,153 @@ class PartialContextualLexer(ContextualLexer):
                     terminals_by_name[n] for n in accepts if n in terminals_by_name
                 ]
                 lexer = PartialBasicLexer(lexer_conf)
-                lexer_by_tokens[key] = lexer
+                lexer_by_symbols[key] = lexer
 
             self.lexers[state] = lexer
 
         assert trad_conf.terminals is terminals
         self.root_lexer = PartialBasicLexer(trad_conf)
 
+    def lex(self, lexer_state: LexerState, parser_state: Any) -> Iterator[Token]:
+        try:
+            while True:
+                lexer = self.lexers[parser_state.position]
+                yield lexer.next_token(lexer_state, parser_state)
+        except EOFError:
+            pass
+
 
 class PartialBasicLexer(BasicLexer):
     def __init__(self, conf: "LexerConf"):
         super().__init__(conf)
 
-        # This is used to determine the token type for partial matches
-        self.terminal_to_regex = {}
-        for name, terminal in self.terminals_by_name.items():
-            self.terminal_to_regex[name] = self.re.compile(
-                terminal.pattern.to_regexp(), self.g_regex_flags
-            )
-
     def _build_scanner(self):
+        # This seems incredibly convoluted: `lark` creates callback-triggered
+        # nested scanners for regex-defined terminals that overlap with
+        # string-defined terminals when both types of terminals have the same
+        # priority.  Unless I'm missing something important, why not simply
+        # reorder the terminals so that the string-defined ones come before the
+        # regex-defined ones?
         terminals, self.callback = _create_unless(
             self.terminals, self.g_regex_flags, self.re, self.use_bytes
         )
-        assert all(self.callback.values())
 
-        for type_, f in self.user_callbacks.items():
-            if type_ in self.callback:
-                # Already a callback there, probably UnlessCallback
-                self.callback[type_] = CallChain(
-                    self.callback[type_], f, lambda t: t.type == type_
-                )
-            else:
-                self.callback[type_] = f
+        # We can't let people arbitrarily mess with the scanning process.
+        assert not self.user_callbacks
+        # for type_, f in self.user_callbacks.items():
+        #     if type_ in self.callback:
+        #         # Already a callback there, probably UnlessCallback
+        #         self.callback[type_] = CallChain(
+        #             self.callback[type_], f, lambda t: t.type == type_
+        #         )
+        #     else:
+        #         self.callback[type_] = f
+
+        # We used the "callback" results to reorder the terminals (see the
+        # comments above).
+        for terminal_name, callback in self.callback.items():
+            terminal = self.terminals_by_name[terminal_name]
+            for sub_terminal in callback.scanner.terminals:
+                self.terminals.remove(sub_terminal)
+                idx = self.terminals.index(terminal)
+                self.terminals.insert(idx, sub_terminal)
 
         self._scanner = PartialScanner(
-            terminals, self.g_regex_flags, self.re, self.use_bytes
+            self.terminals, self.g_regex_flags, self.re, self.use_bytes
         )
 
-    def partial_matches(self, value, type_):
-        partial_matches = set()
-
-        # TODO: It's unfortunate that we have to do this costly search (again).
-        # It would be better if we could *not* short-circuit the first time we
-        # scan in the call to `self.match`.
-        for term_name, term_regex in self.terminal_to_regex.items():
-            if term_name == type_:
-                # A standard lexed token result could actual indicate a partial
-                # match
-                regex_min, regex_max = get_regexp_width(term_regex.pattern)
-                if regex_min <= len(value) < regex_max:
-                    partial_matches.add(term_name)
-            else:
-                m = term_regex.match(value, partial=True)
-                if m:
-                    partial_matches.add(term_name)
-
-        return partial_matches
+    def match(self, text, pos, last_fsm_state_seq=None):
+        return self.scanner.match(text, pos, last_fsm_state_seq)
 
     def next_token(self, lex_state: LexerState, parser_state: Any = None) -> Token:
+        last_token = lex_state.last_token
+
+        last_fsm_state_seq = None
+        if last_token and last_token.type == "partial":
+            # Continue from last partial lexer state
+            last_fsm_state_seq = last_token.value.fsm_state_seq
+
         line_ctr = lex_state.line_ctr
-        while line_ctr.char_pos < len(lex_state.text):
-            res = self.match(lex_state.text, line_ctr.char_pos)
+        end_pos = line_ctr.char_pos + (
+            len(last_fsm_state_seq) - 1 if last_fsm_state_seq else 0
+        )
+        while end_pos < len(lex_state.text):
+            res = self.match(lex_state.text, line_ctr.char_pos, last_fsm_state_seq)
 
             if not res:
-                allowed = self.scanner.allowed_types - self.ignore_types
-                if not allowed:
-                    allowed = {"<END-OF-FILE>"}
-                raise UnexpectedCharacters(
-                    lex_state.text,
-                    line_ctr.char_pos,
-                    line_ctr.line,
-                    line_ctr.column,
-                    allowed=allowed,
-                    token_history=lex_state.last_token and [lex_state.last_token],
-                    state=parser_state,
-                    terminals_by_name=self.terminals_by_name,
+                if (
+                    not last_fsm_state_seq
+                    or last_fsm_state_seq[-1] not in self.scanner.fsm.finals
+                ):
+                    allowed = self.scanner.allowed_types - self.ignore_types
+                    if not allowed:
+                        allowed = {"<END-OF-FILE>"}
+                    raise UnexpectedCharacters(
+                        lex_state.text,
+                        line_ctr.char_pos,
+                        line_ctr.line,
+                        line_ctr.column,
+                        allowed=allowed,
+                        token_history=lex_state.last_token and [lex_state.last_token],
+                        state=parser_state,
+                        terminals_by_name=self.terminals_by_name,
+                    )
+
+                # The partial match might be complete now
+                fsm_state_seq = last_token.value.fsm_state_seq
+                terminals_and_info = last_token.value.terminals_and_info
+                final_terminals_and_info = last_token.value.final_terminals_and_info
+            else:
+                fsm_state_seq = res
+                (
+                    terminals_and_info,
+                    final_terminals_and_info,
+                ) = self.scanner.get_terminals_info(fsm_state_seq)
+
+            priority_terminal_info = (
+                final_terminals_and_info[0]
+                if final_terminals_and_info
+                else terminals_and_info[0]
+            )
+
+            is_not_finished = (
+                not priority_terminal_info.is_final
+                or priority_terminal_info.can_transition
+                or len(terminals_and_info) > 1
+            )
+
+            start_pos = line_ctr.char_pos
+            end_pos = start_pos + len(fsm_state_seq) - 1
+
+            if end_pos >= len(lex_state.text) and is_not_finished:
+                type_name = "partial"
+                token_value = PartialTokensInfo(
+                    fsm_state_seq,
+                    is_not_finished,
+                    terminals_and_info,
+                    final_terminals_and_info,
                 )
-
-            value, type_, partial = res
-
-            # Don't advance the lexing state if we're at the end; there could
-            # be ambiguous token types that aren't finished.
-            if line_ctr.char_pos + len(value) >= len(lex_state.text):
-                partial_matches = self.partial_matches(value, type_)
-                if partial_matches or partial:
-                    raise PartialTokenEOF(partial_matches)
+                # Don't update the line counter states until we've finished
+                value = ""
+            else:
+                type_name = priority_terminal_info.terminal_name
+                # The token value should contain all partial scan parts in this
+                # case
+                value = token_value = lex_state.text[start_pos:end_pos]
 
             assert isinstance(self.callback, Dict)
 
-            if type_ not in self.ignore_types:
+            if type_name not in self.ignore_types:
                 t = Token(
-                    type_, value, line_ctr.char_pos, line_ctr.line, line_ctr.column
+                    type_name,
+                    token_value,
+                    line_ctr.char_pos,
+                    line_ctr.line,
+                    line_ctr.column,
                 )
-                line_ctr.feed(value, type_ in self.newline_types)
+
+                line_ctr.feed(value, type_name in self.newline_types)
+
                 t.end_line = line_ctr.line
                 t.end_column = line_ctr.column
                 t.end_pos = line_ctr.char_pos
@@ -430,18 +745,20 @@ class PartialBasicLexer(BasicLexer):
                 lex_state.last_token = t
                 return t
 
-            if type_ in self.callback:
+            if type_name in self.callback:
                 t2 = Token(
-                    type_, value, line_ctr.char_pos, line_ctr.line, line_ctr.column
+                    type_name, value, line_ctr.char_pos, line_ctr.line, line_ctr.column
                 )
-                self.callback[type_](t2)
+                self.callback[type_name](t2)
 
-            line_ctr.feed(value, type_ in self.newline_types)
+            line_ctr.feed(value, type_name in self.newline_types)
+
+            last_fsm_state_seq = None
 
         raise EOFError(self)
 
 
-class PartialPythonIndenter(PythonIndenter):
+class PartialIndenter(Indenter):
     """An `Indenter` that doesn't reset its state every time `process` is called."""
 
     def process(self, stream):
@@ -463,9 +780,21 @@ class PartialPythonIndenter(PythonIndenter):
             else:
                 yield token
 
+        # TODO: What do we want to do here?
         # while len(self.indent_level) > 1:
         #     self.indent_level.pop()
         #     yield Token(self.DEDENT_type, "")
+
+    def accepts_token_type(self, token_type):
+        if token_type in self.CLOSE_PAREN_types and self.paren_level - 1 < 0:
+            return False
+
+        # TODO:
+        # if token_type == self.NL_type and self.paren_level == 0:
+        #     ...
+        #     return False
+
+        return True
 
     def __copy__(self):
         res = type(self)()
@@ -477,30 +806,25 @@ class PartialPythonIndenter(PythonIndenter):
         return f"{type(self).__name__}(paren_level={self.paren_level!r}, indent_level={self.indent_level!r})"
 
 
-def parse_to_end(
-    parser_state: PartialParserState,
-) -> Tuple[PartialParserState, Set[str]]:
-    """Continue parsing from the current parse state and return partial next tokens.
+class PartialPythonIndenter(PartialIndenter):
+    NL_type = "_NEWLINE"
+    OPEN_PAREN_types = ["LPAR", "LSQB", "LBRACE"]
+    CLOSE_PAREN_types = ["RPAR", "RSQB", "RBRACE"]
+    INDENT_type = "_INDENT"
+    DEDENT_type = "_DEDENT"
+    tab_len = 8
 
-    .. warning::
-        The parse state `parser_state` is updated in-place and must be patched
-        to work with this function.
 
-    """
-
-    expected_next_tokens: Set[str] = set()
-    try:
-        for token in parser_state.lexer.lex(parser_state):
-            parser_state.feed_token(token)
-    except PartialTokenEOF as e:
-        expected_next_tokens = e.expected
-
-    return parser_state, expected_next_tokens
+def get_contextual_lexer(x: Union[PartialLexerThread, PartialParsingFrontend]):
+    if isinstance(x.lexer, ContextualLexer):
+        return x.lexer
+    else:
+        return x.lexer.lexer
 
 
 def find_partial_matches(
-    fsm: FSM, input_string: str, start_state: Optional[int] = None
-) -> Set[Tuple[Optional[int], Tuple[int, ...]]]:
+    fsm: FSM, input_string: str, start_state: Optional[int] = None, full_match=True
+) -> Set[Tuple[int, Tuple[int, ...]]]:
     """Find the states in the finite state machine `fsm` that accept `input_string`.
 
     This will consider all possible states in the finite state machine (FSM)
@@ -517,17 +841,19 @@ def find_partial_matches(
         A single fixed starting state to consider.  For example, if this value
         is set to `fsm.initial`, it attempt to read `input_string` from the
         beginning of the FSM/regular expression.
+    full_match
+        Matches must cover the entire string.
 
     Returns
     -------
     A set of tuples corresponding to each valid starting state in the FSM.  The
-    first element of each tuple contains either ``None`` or an integer
-    indicating the position in `input_string` at which the FSM terminated.  The
-    second element is the tuple of states visited during execution of the FSM
-    plus the next, unvisited transition state.
+    first element of each tuple contains an integer indicating the position in
+    `input_string` at which the FSM stopped.  The second element is the tuple
+    of states visited during execution of the FSM plus the next, unvisited
+    transition state.
 
     """
-    if len(input_string) == 0 or input_string[0] not in fsm.alphabet:
+    if len(input_string) == 0:
         return set()
 
     trans_key = fsm.alphabet[input_string[0]]
@@ -540,20 +866,30 @@ def find_partial_matches(
         fsm_map = ChainMap({fsm.initial: trans}, fsm.map)
         state = fsm.initial
         accepted_states: Tuple[int, ...] = ()
+        last_final_idx = -1
 
         for i, symbol in enumerate(input_string):
-            if anything_else in fsm.alphabet and symbol not in fsm.alphabet:
-                symbol = anything_else
-
             trans_key = fsm.alphabet[symbol]
 
-            if not (state in fsm_map and trans_key in fsm_map[state]):
-                if state in fsm.finals:
-                    i -= 1
-                    break
+            trans_map = fsm_map.get(state)
+
+            if trans_map is None or trans_key not in trans_map:
+                if full_match:
+                    if state in fsm.finals:
+                        i -= 1
+                        break
+                else:
+                    if last_final_idx > -1:
+                        i = last_final_idx
+                        accepted_states = accepted_states[: last_final_idx + 1]
+                        break
+
                 return None, None
 
-            state = fsm_map[state][trans_key]
+            state = trans_map[trans_key]
+
+            if state in fsm.finals:
+                last_final_idx = i
 
             accepted_states += (state,)
 
@@ -561,7 +897,7 @@ def find_partial_matches(
         if not terminated and state == fsm.initial:
             return None, None
 
-        return None if not terminated else i, accepted_states
+        return i, accepted_states
 
     res = set()
     transition_maps = (
@@ -569,9 +905,9 @@ def find_partial_matches(
     )
     for state, trans in transition_maps.items():
         if trans_key in trans:
-            n_matched, path = _partial_match(trans)
-            if path is not None:
-                res.add((n_matched, (state,) + path))
+            last_match_idx, path = _partial_match(trans)
+            if last_match_idx is not None and path is not None:
+                res.add((last_match_idx, (state,) + path))
 
     return res
 
@@ -654,41 +990,158 @@ def map_partial_states_to_vocab(
     return pstate_to_vocab, possible_paths
 
 
-def terminals_to_lalr_states(lp: PartialLark) -> DefaultDict[str, Set[int]]:
-    terminals_to_states = defaultdict(set)
-    parse_table = lp.parser.parser.parser.parse_table
-    for state, tokens_to_ops in parse_table.states.items():
-        for token, op in tokens_to_ops.items():
-            if op[0] == Shift:
-                # `op[1]` is the state we shift to when `token` is observed
-                terminals_to_states[token].add(op[1])
+def fsm_union(
+    fsms: Sequence[FSM],
+) -> Tuple[FSM, Dict[int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]]]:
+    """Construct an FSM representing the union of the FSMs in `fsms`.
 
-    return terminals_to_states
+    This is an updated version of `interegular.fsm.FSM.union` made to return an
+    extra map of component FSMs to the sets of state transitions that
+    correspond to them in the new FSM.
 
+    """
 
-def create_pmatch_parser_states(
-    lp: PartialLark,
-    terminals_to_states: Dict[str, Set[int]],
-    term_type: str,
-    ptoken: str,
-    pmatch: Tuple[int, Tuple[int, ...]],
-) -> Tuple[PartialParserState, ...]:
-    parse_table = lp.parser.parser.parser.parse_table
+    alphabet, new_to_old = Alphabet.union(*[fsm.alphabet for fsm in fsms])
 
-    # TODO: We need to effectively disable the callbacks that build the
-    # trees, because we aren't actually parsing a valid state that can, say,
-    # be reduced
-    def noop(*args, **kwargs):
-        pass
+    indexed_fsms = tuple(enumerate(fsms))
 
-    callbacks = {rule: noop for rule, cb in lp._callbacks.items()}
-    parse_conf = ParseConf(parse_table, callbacks, lp.options.start[0])
-    lexer_thread = lp.parser._make_lexer_thread(ptoken)
-    lexer_state = lexer_thread.state
-    lexer_state.line_ctr.char_pos = pmatch[0] + 1
-    lexer_state.last_token = Token(term_type, "")
-    res = tuple(
-        PartialParserState(parse_conf, lexer_thread, [state], None)
-        for state in terminals_to_states[term_type]
+    initial = {i: fsm.initial for (i, fsm) in indexed_fsms}
+
+    # Dedicated function accepting a "superset" and returning the next
+    # "superset" obtained by following this transition in the new FSM
+    def follow(current_state, new_transition: int):
+        next = {}
+        for i, f in indexed_fsms:
+            old_transition = new_to_old[i][new_transition]
+            if (
+                i in current_state
+                and current_state[i] in f.map
+                and old_transition in f.map[current_state[i]]
+            ):
+                next[i] = f.map[current_state[i]][old_transition]
+        if not next:
+            raise OblivionError
+        return next
+
+    states = [initial]
+    finals: Set[int] = set()
+    map: Dict[int, Dict[int, int]] = {}
+
+    # Map component FSMs to their new state-to-state transitions, finals, and a
+    # map translating component FSM states to aggregate FSM states
+    fsms_to_trans_finals: Dict[
+        int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]
+    ] = {}
+
+    i = 0
+    while i < len(states):
+        state = states[i]
+
+        # Add to the finals of the aggregate FSM whenever we hit a final in a
+        # component FSM
+        if any(state.get(j, -1) in fsm.finals for (j, fsm) in indexed_fsms):
+            finals.add(i)
+
+        # Compute the map for this state
+        map[i] = {}
+        for transition in alphabet.by_transition:
+            try:
+                next = follow(state, transition)
+            except OblivionError:
+                # Reached an oblivion state; don't list it
+                continue
+            else:
+                try:
+                    # TODO: Seems like this could--and should--be avoided
+                    j = states.index(next)
+                except ValueError:
+                    j = len(states)
+                    states.append(next)
+
+                map[i][transition] = j
+
+                for fsm_id, fsm_state in next.items():
+                    (
+                        fsm_transitions,
+                        fsm_finals,
+                        fsm_old_to_new,
+                    ) = fsms_to_trans_finals.setdefault(fsm_id, (set(), set(), {}))
+                    old_from = state[fsm_id]
+                    old_to = fsm_state
+                    fsm_old_to_new.setdefault(old_from, set()).add(i)
+                    fsm_old_to_new.setdefault(old_to, set()).add(j)
+                    fsm_transitions.add((i, j))
+                    if fsm_state in fsms[fsm_id].finals:
+                        fsm_finals.add(j)
+
+        i += 1
+
+    fsm = FSM(
+        alphabet=alphabet,
+        states=range(len(states)),
+        initial=0,
+        finals=finals,
+        map=map,
+        __no_validation__=True,
     )
-    return res
+
+    fsm, old_to_new_states = make_deterministic_fsm(fsm)
+    _fsms_to_trans_finals = {
+        fsm_id: (
+            {(old_to_new_states[s1], old_to_new_states[s2]) for s1, s2 in transitions},
+            {old_to_new_states[s] for s in finals},
+            {
+                old_state: {old_to_new_states[new_state] for new_state in new_states}
+                for old_state, new_states in old_to_new.items()
+            },
+        )
+        for fsm_id, (transitions, finals, old_to_new) in sorted(
+            fsms_to_trans_finals.items(), key=lambda x: x[0]
+        )
+    }
+
+    return (
+        fsm,
+        _fsms_to_trans_finals,
+    )
+
+
+def get_sub_fsms_from_seq(
+    state_seq: Sequence[int],
+    fsms_to_trans_finals: Dict[
+        int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]
+    ],
+) -> Generator[Tuple[int, bool, bool], None, None]:
+    """Get the indices of the sub-FSMs in `fsm` that could have matched the state sequence `state_seq`.
+
+    Parameters
+    ----------
+    state_seq
+        A state sequence.
+    fsms_to_trans_finals
+        A map from FSM indices to tuples containing sets of their state transitions
+        and sets of the final/accept states.
+
+    Returns
+    -------
+    A generator returning tuples containing each sub-FSM index (in the order
+    they were union-ed to construct `fsm`) and booleans indicating whether or
+    not there is another valid transition from the last state in the sequence
+    for the associated sub-FSM (i.e. if the FSM can continue
+    accepting/matching) and whether or not the sequence ends in a final state
+    of the sub-FSM.
+    """
+    state_seq_transitions = set(zip(state_seq[:-1], state_seq[1:]))
+    last_fsm_state = state_seq[-1]
+    yield from (
+        (
+            # The sub-FMS index
+            fsm_idx,
+            # Is there another possible transition in this sub-FSM?
+            any(last_fsm_state == from_s for (from_s, to_s) in transitions),
+            # Is this sub-FSM in a final state?
+            state_seq[-1] in finals,
+        )
+        for fsm_idx, (transitions, finals, _) in fsms_to_trans_finals.items()
+        if state_seq_transitions.issubset(transitions)
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ test = [
     "coverage[toml]>=5.1",
     "diff-cover",
     "lark",
-    "regex",
     "interegular",
 ]
 
@@ -99,7 +98,6 @@ module = [
     "torch",
     "transformers.*",
     "lark.*",
-    "regex.*",
     "interegular.*",
 ]
 ignore_missing_imports = true

--- a/tests/text/partial_python.lark
+++ b/tests/text/partial_python.lark
@@ -1,0 +1,314 @@
+// Python 3 grammar for Lark
+//
+// This grammar should parse all python 3.x code successfully.
+//
+// Adapted from: https://docs.python.org/3/reference/grammar.html
+//
+// This version is actually a subset of Lark's Python grammar without the
+// regex look-arounds in the string terminals.
+//
+// Start symbols for the grammar:
+//       single_input is a single interactive statement;
+//       file_input is a module or sequence of commands read from an input file;
+//       eval_input is the input for the eval() functions.
+// NB: compound_stmt in single_input is followed by extra NEWLINE!
+//
+
+single_input: _NEWLINE | simple_stmt | compound_stmt _NEWLINE
+file_input: (_NEWLINE | stmt)*
+eval_input: testlist _NEWLINE*
+
+decorator: "@" dotted_name [ "(" [arguments] ")" ] _NEWLINE
+decorators: decorator+
+decorated: decorators (classdef | funcdef | async_funcdef)
+
+async_funcdef: "async" funcdef
+funcdef: "def" name "(" [parameters] ")" ["->" test] ":" suite
+
+parameters: paramvalue ("," paramvalue)* ["," SLASH ("," paramvalue)*] ["," [starparams | kwparams]]
+          | starparams
+          | kwparams
+
+SLASH: "/" // Otherwise the it will completely disappear and it will be undisguisable in the result
+starparams: (starparam | starguard) poststarparams
+starparam: "*" typedparam
+starguard: "*"
+poststarparams: ("," paramvalue)* ["," kwparams]
+kwparams: "**" typedparam ","?
+
+?paramvalue: typedparam ("=" test)?
+?typedparam: name (":" test)?
+
+
+lambdef: "lambda" [lambda_params] ":" test
+lambdef_nocond: "lambda" [lambda_params] ":" test_nocond
+lambda_params: lambda_paramvalue ("," lambda_paramvalue)* ["," [lambda_starparams | lambda_kwparams]]
+          | lambda_starparams
+          | lambda_kwparams
+?lambda_paramvalue: name ("=" test)?
+lambda_starparams: "*" [name]  ("," lambda_paramvalue)* ["," [lambda_kwparams]]
+lambda_kwparams: "**" name ","?
+
+
+?stmt: simple_stmt | compound_stmt
+?simple_stmt: small_stmt (";" small_stmt)* [";"] _NEWLINE
+?small_stmt: (expr_stmt | assign_stmt | del_stmt | pass_stmt | flow_stmt | import_stmt | global_stmt | nonlocal_stmt | assert_stmt)
+expr_stmt: testlist_star_expr
+assign_stmt: annassign | augassign | assign
+
+annassign: testlist_star_expr ":" test ["=" test]
+assign: testlist_star_expr ("=" (yield_expr|testlist_star_expr))+
+augassign: testlist_star_expr augassign_op (yield_expr|testlist)
+!augassign_op: "+=" | "-=" | "*=" | "@=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>=" | "**=" | "//="
+?testlist_star_expr: test_or_star_expr
+                   | test_or_star_expr ("," test_or_star_expr)+ ","?  -> tuple
+                   | test_or_star_expr ","  -> tuple
+
+// For normal and annotated assignments, additional restrictions enforced by the interpreter
+del_stmt: "del" exprlist
+pass_stmt: "pass"
+?flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
+break_stmt: "break"
+continue_stmt: "continue"
+return_stmt: "return" [testlist]
+yield_stmt: yield_expr
+raise_stmt: "raise" [test ["from" test]]
+import_stmt: import_name | import_from
+import_name: "import" dotted_as_names
+// note below: the ("." | "...") is necessary because "..." is tokenized as ELLIPSIS
+import_from: "from" (dots? dotted_name | dots) "import" ("*" | "(" import_as_names ")" | import_as_names)
+!dots: "."+
+import_as_name: name ["as" name]
+dotted_as_name: dotted_name ["as" name]
+import_as_names: import_as_name ("," import_as_name)* [","]
+dotted_as_names: dotted_as_name ("," dotted_as_name)*
+dotted_name: name ("." name)*
+global_stmt: "global" name ("," name)*
+nonlocal_stmt: "nonlocal" name ("," name)*
+assert_stmt: "assert" test ["," test]
+
+?compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | match_stmt
+              | with_stmt | funcdef | classdef | decorated | async_stmt
+async_stmt: "async" (funcdef | with_stmt | for_stmt)
+if_stmt: "if" test ":" suite elifs ["else" ":" suite]
+elifs: elif_*
+elif_: "elif" test ":" suite
+while_stmt: "while" test ":" suite ["else" ":" suite]
+for_stmt: "for" exprlist "in" testlist ":" suite ["else" ":" suite]
+try_stmt: "try" ":" suite except_clauses ["else" ":" suite] [finally]
+        | "try" ":" suite finally   -> try_finally
+finally: "finally" ":" suite
+except_clauses: except_clause+
+except_clause: "except" [test ["as" name]] ":" suite
+// NB compile.c makes sure that the default except clause is last
+
+
+with_stmt: "with" with_items ":" suite
+with_items: with_item ("," with_item)*
+with_item: test ["as" name]
+
+match_stmt: "match" test ":" _NEWLINE _INDENT case+ _DEDENT
+
+case: "case" pattern ["if" test] ":" suite
+
+?pattern: sequence_item_pattern "," _sequence_pattern -> sequence_pattern
+        | as_pattern
+?as_pattern: or_pattern ("as" NAME)?
+?or_pattern: closed_pattern ("|" closed_pattern)*
+?closed_pattern: literal_pattern
+               | NAME -> capture_pattern
+               | "_" -> any_pattern
+               | attr_pattern
+               | "(" as_pattern ")"
+               | "[" _sequence_pattern "]" -> sequence_pattern
+               | "(" (sequence_item_pattern "," _sequence_pattern)? ")" -> sequence_pattern
+               | "{" (mapping_item_pattern ("," mapping_item_pattern)* ","?)?"}" -> mapping_pattern
+               | "{" (mapping_item_pattern ("," mapping_item_pattern)* ",")? "**" NAME ","? "}" -> mapping_star_pattern
+               | class_pattern
+
+literal_pattern: inner_literal_pattern
+
+?inner_literal_pattern: "None" -> const_none
+                      | "True" -> const_true
+                      | "False" -> const_false
+                      | STRING -> string
+                      | number
+
+attr_pattern: NAME ("." NAME)+ -> value
+
+name_or_attr_pattern: NAME ("." NAME)* -> value
+
+mapping_item_pattern: (literal_pattern|attr_pattern) ":" as_pattern
+
+_sequence_pattern: (sequence_item_pattern ("," sequence_item_pattern)* ","?)?
+?sequence_item_pattern: as_pattern
+                      | "*" NAME -> star_pattern
+
+class_pattern: name_or_attr_pattern "(" [arguments_pattern ","?] ")"
+arguments_pattern: pos_arg_pattern ["," keyws_arg_pattern]
+                 | keyws_arg_pattern -> no_pos_arguments
+
+pos_arg_pattern: as_pattern ("," as_pattern)*
+keyws_arg_pattern: keyw_arg_pattern ("," keyw_arg_pattern)*
+keyw_arg_pattern: NAME "=" as_pattern
+
+
+
+suite: simple_stmt | _NEWLINE _INDENT stmt+ _DEDENT
+
+?test: or_test ("if" or_test "else" test)?
+     | lambdef
+     | assign_expr
+
+assign_expr: name ":=" test
+
+?test_nocond: or_test | lambdef_nocond
+
+?or_test: and_test ("or" and_test)*
+?and_test: not_test_ ("and" not_test_)*
+?not_test_: "not" not_test_ -> not_test
+         | comparison
+?comparison: expr (comp_op expr)*
+star_expr: "*" expr
+
+?expr: or_expr
+?or_expr: xor_expr ("|" xor_expr)*
+?xor_expr: and_expr ("^" and_expr)*
+?and_expr: shift_expr ("&" shift_expr)*
+?shift_expr: arith_expr (_shift_op arith_expr)*
+?arith_expr: term (_add_op term)*
+?term: factor (_mul_op factor)*
+?factor: _unary_op factor | power
+
+!_unary_op: "+"|"-"|"~"
+!_add_op: "+"|"-"
+!_shift_op: "<<"|">>"
+!_mul_op: "*"|"@"|"/"|"%"|"//"
+// <> isn't actually a valid comparison operator in Python. It's here for the
+// sake of a __future__ import described in PEP 401 (which really works :-)
+!comp_op: "<"|">"|"=="|">="|"<="|"<>"|"!="|"in"|"not" "in"|"is"|"is" "not"
+
+?power: await_expr ("**" factor)?
+?await_expr: AWAIT? atom_expr
+AWAIT: "await"
+
+?atom_expr: atom_expr "(" [arguments] ")"      -> funccall
+          | atom_expr "[" subscriptlist "]"  -> getitem
+          | atom_expr "." name               -> getattr
+          | atom
+
+?atom: "(" yield_expr ")"
+     | "(" _tuple_inner? ")" -> tuple
+     | "(" comprehension{test_or_star_expr} ")" -> tuple_comprehension
+     | "[" _exprlist? "]"  -> list
+     | "[" comprehension{test_or_star_expr} "]"  -> list_comprehension
+     | "{" _dict_exprlist? "}" -> dict
+     | "{" comprehension{key_value} "}" -> dict_comprehension
+     | "{" _exprlist "}" -> set
+     | "{" comprehension{test} "}" -> set_comprehension
+     | name -> var
+     | number
+     | string_concat
+     | "(" test ")"
+     | "..." -> ellipsis
+     | "None"    -> const_none
+     | "True"    -> const_true
+     | "False"   -> const_false
+
+
+?string_concat: string+
+
+_tuple_inner: test_or_star_expr (("," test_or_star_expr)+ [","] | ",")
+
+?test_or_star_expr: test
+                 | star_expr
+
+?subscriptlist: subscript
+              | subscript (("," subscript)+ [","] | ",") -> subscript_tuple
+?subscript: test | ([test] ":" [test] [sliceop]) -> slice
+sliceop: ":" [test]
+?exprlist: (expr|star_expr)
+         | (expr|star_expr) (("," (expr|star_expr))+ [","]|",")
+?testlist: test | testlist_tuple
+testlist_tuple: test (("," test)+ [","] | ",")
+_dict_exprlist: (key_value | "**" expr) ("," (key_value | "**" expr))* [","]
+
+key_value: test ":"  test
+
+_exprlist: test_or_star_expr (","  test_or_star_expr)* [","]
+
+classdef: "class" name ["(" [arguments] ")"] ":" suite
+
+
+
+arguments: argvalue ("," argvalue)*  ("," [ starargs | kwargs])?
+         | starargs
+         | kwargs
+         | comprehension{test}
+
+starargs: stararg ("," stararg)* ("," argvalue)* ["," kwargs]
+stararg: "*" test
+kwargs: "**" test ("," argvalue)*
+
+?argvalue: test ("=" test)?
+
+
+comprehension{comp_result}: comp_result comp_fors [comp_if]
+comp_fors: comp_for+
+comp_for: [ASYNC] "for" exprlist "in" or_test
+ASYNC: "async"
+?comp_if: "if" test_nocond
+
+// not used in grammar, but may appear in "node" passed from Parser to Compiler
+encoding_decl: name
+
+yield_expr: "yield" [testlist]
+          | "yield" "from" test -> yield_from
+
+number: DEC_NUMBER | HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | FLOAT_NUMBER | IMAG_NUMBER
+string: STRING // | LONG_STRING
+
+// Other terminals
+
+_NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
+
+%ignore /[\t \f]+/  // WS
+%ignore /\\[\t \f]*\r?\n/   // LINE_CONT
+%ignore COMMENT
+%declare _INDENT _DEDENT
+
+
+// Python terminals
+
+!name: NAME | "match" | "case"
+NAME: /[^\W\d]\w*/
+COMMENT: /#[^\n]*/
+
+// We only need a usable approximation for something like this until we fully
+// implement look-arounds, or use a regex/FSM library that supports them.
+// STRING: /([ubf]?r?|r[ubf])("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
+// Also, we're not dealing with this case now.
+// LONG_STRING: /([ubf]?r?|r[ubf])(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
+
+STRING: SINGLE_QUOTE_STRING | DOUBLE_QUOTE_STRING
+DOUBLE_QUOTE_STRING: /([ubf]?r?|r[ubf])("([^\\"]|.)*?")/i
+SINGLE_QUOTE_STRING: /([ubf]?r?|r[ubf])('([^\\']|.)*?')/i
+
+
+_SPECIAL_DEC: "0".."9"        ("_"?  "0".."9"                       )*
+DEC_NUMBER:   "1".."9"        ("_"?  "0".."9"                       )*
+// Again, no look-arounds yet
+//           |   "0"             ("_"?  "0"                            )* /(?![1-9])/
+HEX_NUMBER.2: "0" ("x" | "X") ("_"? ("0".."9" | "a".."f" | "A".."F"))+
+OCT_NUMBER.2: "0" ("o" | "O") ("_"?  "0".."7"                       )+
+BIN_NUMBER.2: "0" ("b" | "B") ("_"?  "0".."1"                       )+
+
+_EXP: ("e"|"E") ["+" | "-"] _SPECIAL_DEC
+DECIMAL: "." _SPECIAL_DEC | _SPECIAL_DEC "." _SPECIAL_DEC?
+FLOAT_NUMBER.2: _SPECIAL_DEC _EXP | DECIMAL _EXP?
+IMAG_NUMBER.2: (_SPECIAL_DEC      | FLOAT_NUMBER) ("J" | "j")
+
+
+// Comma-separated list (with an optional trailing comma)
+cs_list{item}: item ("," item)* ","?
+_cs_list{item}: item ("," item)* ","?


### PR DESCRIPTION
This PR is the first step to closing #170 using the approach described in our paper ["Efficient Guided Generation for Large Language Models"](https://arxiv.org/abs/2307.09702).

In other words, the changes in this PR allow us to create "index" `dict`s for full grammars.  By "index" we mean a `dict` that maps partial parse states to subsets of a vocabulary that are valid continuations of the parse state.

NOTE: The indexing work is being split off into its own PR.

TODO:
- [ ] Use a more efficient DFA implementation. 
- [ ] Use DFA minimization on the parse state FSMs.
    This will remove a large number of unnecessary states and decrease the overall cost of constructing indices.
- [x] We need to do something about ignored tokens in `terminal_symbol_scan`.
    They are currently being _completely_ ignored, which incorrectly excludes vocabulary strings consisting of only ignored tokens (e.g. `" "` in a Python grammar).
- [x] Convert the terminal symbol FSM states used to compute the indices to their corresponding parser state (aggregate/unioned) FSM states.
