### PR TITLE
Add kwargs for tokenizer

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -90,6 +90,6 @@ def transformers(model_name: str, device: Optional[str] = None, **model_kwargs):
     from transformers import AutoModelForCausalLM
 
     model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)
-    tokenizer = TransformersTokenizer(model_name)
+    tokenizer = TransformersTokenizer(model_name, **model_kwargs)
 
     return Transformers(model, tokenizer, device)


### PR DESCRIPTION
Currently we don't pass any kwargs to the tokenizer. This can cause errors for some HF models like `Salesforce/xgen-7b-4k-base`. See: https://huggingface.co/Salesforce/xgen-7b-4k-base#how-to-run

This code gives an error:
```python
from transformers import AutoTokenizer

model_name = "Salesforce/xgen-7b-4k-base"
tokenizer = AutoTokenizer.from_pretrained(model_name)
```

but adding `trust_remote_code=True` works
```python
from transformers import AutoTokenizer

model_name = "Salesforce/xgen-7b-4k-base"
tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
```

Therefore, we must allow for passing kwargs. I have only seen `trust_remote_code` kwarg being passed to the tokenizer. We can either pop all the other model_kwargs or just pass along them all. 
