### PR TITLE
add ctranslate2 models

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -6,8 +6,8 @@ codebase.
 
 """
 from . import embeddings, image_generation, text_completion
+from .ctranslate2 import ctranslate2
 from .hf_diffusers import HuggingFaceDiffuser
 from .hf_transformers import HuggingFaceCompletion
 from .openai import OpenAICompletion, OpenAIEmbeddings, OpenAIImageGeneration
 from .transformers import transformers
-from .ctranslate2 import ctranslate2

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -10,3 +10,4 @@ from .hf_diffusers import HuggingFaceDiffuser
 from .hf_transformers import HuggingFaceCompletion
 from .openai import OpenAICompletion, OpenAIEmbeddings, OpenAIImageGeneration
 from .transformers import transformers
+from .ctranslate2 import ctranslate2

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -14,7 +14,7 @@ __all__ = ["ctranslate2"]
 
 
 class CTranslate2_Model:
-    """Represents a `transformers` model."""
+    """Represents a `ctranslate2` model."""
 
     def __init__(
         self,
@@ -64,7 +64,7 @@ class TransformersTokenizer(Tokenizer):
         kwargs["padding"] = True
         kwargs["return_tensors"] = "pt"
         output = self.tokenizer(prompt, **kwargs)
-        
+
         return output["input_ids"], output["attention_mask"]
 
     def decode(self, token_ids: torch.LongTensor) -> List[str]:
@@ -76,9 +76,11 @@ class TransformersTokenizer(Tokenizer):
         return string
 
 
-def ctranslate2(ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs):
+def ctranslate2(
+    ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs
+):
     import ctranslate2
-    
+
     model = ctranslate2.Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -2,8 +2,9 @@ import math
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
+import numpy as np
 
-from outlines.models.tokenizer import Tokenizer
+from outlines.models.transformers import TransformersTokenizer
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer
@@ -30,57 +31,21 @@ class CTranslate2_Model:
         self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor
     ) -> torch.FloatTensor:
         # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
+        
         tokens = [self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids]
         logits = self.model.forward_batch(tokens, return_log_probs=True)
-        logits = torch.as_tensor(logits) # this could be making the code slow
+        if self.device == 'cpu':
+            # See: https://github.com/OpenNMT/CTranslate2/issues/1386
+            logits = np.array(logits)
+        logits = torch.as_tensor(logits)
         next_token_logits = logits[:, -1, :]
 
         return next_token_logits
 
 
-class TransformersTokenizer(Tokenizer):
-    """Represents a tokenizer for models in the `transformers` library."""
-
-    def __init__(self, model_name: str, **kwargs):
-        from transformers import AutoTokenizer
-
-        kwargs.setdefault("padding_side", "left")
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
-        self.eos_token_id = self.tokenizer.eos_token_id
-        self.eos_token = self.tokenizer.eos_token
-
-        if not self.tokenizer.pad_token_id:
-            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
-            self.pad_token_id = self.eos_token_id
-        else:
-            self.pad_token_id = self.tokenizer.pad_token_id
-            self.pad_token = self.tokenizer.pad_token
-
-        self.vocabulary = self.tokenizer.get_vocab()
-
-    def encode(
-        self, prompt: Union[str, List[str]], **kwargs
-    ) -> Tuple[torch.LongTensor, torch.LongTensor]:
-        kwargs["padding"] = True
-        kwargs["return_tensors"] = "pt"
-        output = self.tokenizer(prompt, **kwargs)
-
-        return output["input_ids"], output["attention_mask"]
-
-    def decode(self, token_ids: torch.LongTensor) -> List[str]:
-        text = self.tokenizer.batch_decode(token_ids)
-        return text
-
-    def convert_token_to_string(self, token: str) -> str:
-        string = self.tokenizer.convert_tokens_to_string([token])
-        return string
-
-
-def ctranslate2(
-    ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs
-):
+def ctranslate2(ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs):
     import ctranslate2
-
+    
     model = ctranslate2.Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -32,7 +32,7 @@ class CTranslate2_Model:
         # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
         tokens = [self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids]
         logits = self.model.forward_batch(tokens, return_log_probs=True)
-        logits = torch.as_tensor(logits)
+        logits = torch.as_tensor(logits) # this could be making the code slow
         next_token_logits = logits[:, -1, :]
 
         return next_token_logits

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -31,7 +31,7 @@ class CTranslate2_Model:
     ) -> torch.FloatTensor:
         # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
         tokens = [self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids]
-        logits = self.model.forward_batch([tokens], return_log_probs=True)
+        logits = self.model.forward_batch(tokens, return_log_probs=True)
         logits = torch.as_tensor(logits)
         next_token_logits = logits[:, -1, :]
 

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -1,14 +1,13 @@
-import math
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional
 
-import torch
 import numpy as np
+import torch
 
 from outlines.models.transformers import TransformersTokenizer
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizer
     from ctranslate2 import Generator
+    from transformers import PreTrainedTokenizer
 
 
 __all__ = ["ctranslate2"]
@@ -31,10 +30,12 @@ class CTranslate2_Model:
         self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor
     ) -> torch.FloatTensor:
         # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
-        
-        tokens = [self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids]
+
+        tokens = [
+            self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids
+        ]
         logits = self.model.forward_batch(tokens, return_log_probs=True)
-        if self.device == 'cpu':
+        if self.device == "cpu":
             # See: https://github.com/OpenNMT/CTranslate2/issues/1386
             logits = np.array(logits)
         logits = torch.as_tensor(logits)
@@ -43,9 +44,11 @@ class CTranslate2_Model:
         return next_token_logits
 
 
-def ctranslate2(ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs):
+def ctranslate2(
+    ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs
+):
     import ctranslate2
-    
+
     model = ctranslate2.Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -30,7 +30,7 @@ class CTranslate2_Model:
         self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor
     ) -> torch.FloatTensor:
         # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
-        tokens = self.tokenizer.tokenizer.convert_ids_to_tokens(input_ids.squeeze())
+        tokens = [self.tokenizer.tokenizer.convert_ids_to_tokens(iids) for iids in input_ids]
         logits = self.model.forward_batch([tokens], return_log_probs=True)
         logits = torch.as_tensor(logits)
         next_token_logits = logits[:, -1, :]

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -1,0 +1,85 @@
+import math
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+import torch
+
+from outlines.models.tokenizer import Tokenizer
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
+    from ctranslate2 import Generator
+
+
+__all__ = ["ctranslate2"]
+
+
+class CTranslate2_Model:
+    """Represents a `transformers` model."""
+
+    def __init__(
+        self,
+        model: "Generator",
+        tokenizer: "PreTrainedTokenizer",
+        device: Optional[str] = None,
+    ):
+        self.device = device if device is not None else "cpu"
+        self.model = model
+        self.tokenizer = tokenizer
+
+    def __call__(
+        self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor
+    ) -> torch.FloatTensor:
+        # `forward_batch` method of `Generator` accepts `tokens` in a list of list of str
+        tokens = self.tokenizer.tokenizer.convert_ids_to_tokens(input_ids.squeeze())
+        logits = self.model.forward_batch([tokens], return_log_probs=True)
+        logits = torch.as_tensor(logits)
+        next_token_logits = logits[:, -1, :]
+
+        return next_token_logits
+
+
+class TransformersTokenizer(Tokenizer):
+    """Represents a tokenizer for models in the `transformers` library."""
+
+    def __init__(self, model_name: str, **kwargs):
+        from transformers import AutoTokenizer
+
+        kwargs.setdefault("padding_side", "left")
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+        self.eos_token_id = self.tokenizer.eos_token_id
+        self.eos_token = self.tokenizer.eos_token
+
+        if not self.tokenizer.pad_token_id:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+            self.pad_token_id = self.eos_token_id
+        else:
+            self.pad_token_id = self.tokenizer.pad_token_id
+            self.pad_token = self.tokenizer.pad_token
+
+        self.vocabulary = self.tokenizer.get_vocab()
+
+    def encode(
+        self, prompt: Union[str, List[str]], **kwargs
+    ) -> Tuple[torch.LongTensor, torch.LongTensor]:
+        kwargs["padding"] = True
+        kwargs["return_tensors"] = "pt"
+        output = self.tokenizer(prompt, **kwargs)
+        
+        return output["input_ids"], output["attention_mask"]
+
+    def decode(self, token_ids: torch.LongTensor) -> List[str]:
+        text = self.tokenizer.batch_decode(token_ids)
+        return text
+
+    def convert_token_to_string(self, token: str) -> str:
+        string = self.tokenizer.convert_tokens_to_string([token])
+        return string
+
+
+def ctranslate2(ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs):
+    import ctranslate2
+    
+    model = ctranslate2.Generator(ctr2_model, device=device)
+    tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
+
+    return CTranslate2_Model(model, tokenizer)

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -53,7 +53,7 @@ def ctranslate2(
         raise ImportError(
             "The `ctranslate2` library needs to be installed in order to use `ctranslate2` models."
         )
-    
+
     model = Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 __all__ = ["ctranslate2"]
 
 
-class CTranslate2_CausalLM:
+class CTranslate2:
     """Represents a `ctranslate2` CausalLM."""
 
     def __init__(
@@ -47,9 +47,14 @@ class CTranslate2_CausalLM:
 def ctranslate2(
     ctr2_model: str, tokenizer_name: str, device: Optional[str] = None, **model_kwargs
 ):
-    import ctranslate2
-
-    model = ctranslate2.Generator(ctr2_model, device=device)
+    try:
+        from ctranslate2 import Generator
+    except ImportError:
+        raise ImportError(
+            "The `ctranslate2` library needs to be installed in order to use `ctranslate2` models."
+        )
+    
+    model = Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 
-    return CTranslate2_CausalLM(model, tokenizer)
+    return CTranslate2(model, tokenizer)

--- a/outlines/models/ctranslate2.py
+++ b/outlines/models/ctranslate2.py
@@ -6,15 +6,15 @@ import torch
 from outlines.models.transformers import TransformersTokenizer
 
 if TYPE_CHECKING:
-    from ctranslate2 import Generator
+    from ctranslate2 import Generator  # type: ignore
     from transformers import PreTrainedTokenizer
 
 
 __all__ = ["ctranslate2"]
 
 
-class CTranslate2_Model:
-    """Represents a `ctranslate2` model."""
+class CTranslate2_CausalLM:
+    """Represents a `ctranslate2` CausalLM."""
 
     def __init__(
         self,
@@ -52,4 +52,4 @@ def ctranslate2(
     model = ctranslate2.Generator(ctr2_model, device=device)
     tokenizer = TransformersTokenizer(tokenizer_name, **model_kwargs)
 
-    return CTranslate2_Model(model, tokenizer)
+    return CTranslate2_CausalLM(model, tokenizer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "lark",
     "regex",
     "interegular",
+    "ctranslate2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
    "scipy",
    "tenacity",
    "torch",
-   "ctranslate2",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
    "scipy",
    "tenacity",
    "torch",
+   "ctranslate2",
 ]
 dynamic = ["version"]
 
@@ -51,7 +52,6 @@ test = [
     "lark",
     "regex",
     "interegular",
-    "ctranslate2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Inspired by Hamel's [benchmarks](https://hamel.dev/notes/llm/03_inference.html) on fast transfomer inference, I propose adding the [`ctranslate2`](https://github.com/OpenNMT/CTranslate2) library. 

This almost works, but fails for multiple samples. The way to sample multiple sequences natively in ctranslate2 is to use
```python
generator = ctranslate2.Generator("redpj", device="cuda")
ans = generator.generate_batch([tokens], beam_size=4, num_hypothesis=4)
```



First compile the HF model:
```
ct2-transformers-converter --model togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --output_dir redpj --quantization bfloat16 
```
This code works: 
```python
import outlines.models as models
model = models.ctranslate2("redpj", "togethercomputer/RedPajama-INCITE-Instruct-3B-v1", "cuda")

prompt = "Hey What's up? In the"
output = text.generate.continuation(model, max_tokens=250)(prompt)
print(output)
```

But this fails:
```python
output = text.generate.continuation(model, max_tokens=250)(prompt, samples=5)
```
