### PR TITLE
Fixed loading quantized model

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -22,10 +22,10 @@ class Transformers:
         device: Optional[str] = None,
     ):
         self.device = device if device is not None else "cpu"
-        if isinstance(getattr(model.config, "quantization_config", None), dict):
-            self.model = model
-        else:
+        if getattr(model.config, "quantization_config", None) is None:
             self.model = model.to(device)
+        else:
+            self.model = model
         self.tokenizer = tokenizer
 
     def __call__(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -22,10 +22,10 @@ class Transformers:
         device: Optional[str] = None,
     ):
         self.device = device if device is not None else "cpu"
-        if getattr(model.config, "quantization_config", None) is None:
-            self.model = model.to(device)
-        else:
+        if isinstance(getattr(model.config, "quantization_config", None), dict):
             self.model = model
+        else:
+            self.model = model.to(device)
         self.tokenizer = tokenizer
 
     def __call__(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -22,7 +22,10 @@ class Transformers:
         device: Optional[str] = None,
     ):
         self.device = device if device is not None else "cpu"
-        self.model = model.to(self.device) if model.config.quantization_config is None else model
+        if getattr(model.config, "quantization_config", None) is None:
+            self.model = model.to(device)
+        else:
+            self.model = model
         self.tokenizer = tokenizer
 
     def __call__(


### PR DESCRIPTION
When loading a quantized model e.g.
```model = models.transformers("stabilityai/StableBeluga-7B", device_map="auto", load_in_4bit=True)```
you get an error:
```ValueError: `.to` is not supported for `4-bit` or `8-bit` models. Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.```
changed the code so that it only places model on device if the model does not have a quantization config