### PR TITLE
Added a fix for missed match tensor size #213

### DIFF
--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -133,10 +133,9 @@ class Regex(Continuation):
             self.pstates = new_pstates
 
         masks = []
+        mask_shape = (logits.shape[-1],)
         for pstate in self.pstates:
-            mask = torch.full(
-                (len(self.model.tokenizer.vocabulary),), -math.inf, device=self.device
-            )
+            mask = torch.full(mask_shape, -math.inf, device=self.device)
 
             if pstate[1] > -1:
                 next_support = self.pstate_to_vocab[pstate[:2]]


### PR DESCRIPTION

Findings with pythia-70m-deduped
Vocab size is 50304 (mentioned in original config) in https://huggingface.co/EleutherAI/pythia-70m-deduped/blob/main/config.json
Vocab size is 50254 (when we run - tokenizer.vocab_size from AutoTokenizer)
Vocab size is 50277 (when we run - len(tokenizer.get_vocab()) from AutoTokenizer)
Logit size is 50304 (when we call self.model(...) )

Now for GPT2 Vocab size and Logit size both are same 50257

This fix would create mask with size of Logit rather than vocab