### PR TITLE
Add logits method to Sequence class

### DIFF
--- a/outlines/text/generate/sequence.py
+++ b/outlines/text/generate/sequence.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import torch
 
@@ -79,7 +79,7 @@ class Sequence:
         token_ids: torch.LongTensor,
         attention_mask: torch.LongTensor,
         samples: int = 1,
-    ) -> Tuple[torch.LongTensor, torch.FloatTensor]:
+    ) -> torch.LongTensor:
         """Generate one or several tokens that complete the input sequence.
 
         The sampling step consists in using a model to generate next-token
@@ -103,8 +103,7 @@ class Sequence:
         -------
         A tuple with an array of shape `new_batch_shape + (num_tokens+1,)`that
         contains the completed sequences (input token ids and generated token
-        ids) and an array of shape `new_batch_shape + (vocab_size,)` that
-        contains the next token probabilities.
+        ids).
         `new_batch_shape` is computed by removing dimensions of size one in
         `(samples,) + batch_shape`.
 
@@ -135,7 +134,7 @@ class Sequence:
         token_ids = torch.atleast_2d(token_ids.squeeze())
         probs = torch.atleast_2d(probs.squeeze())
 
-        return token_ids, probs
+        return token_ids
 
     def expand_attention_mask(
         self, attention_mask: torch.LongTensor
@@ -234,7 +233,7 @@ class Sequence:
         num_prompt_tokens = token_ids.shape[-1]
 
         if samples > 1:
-            token_ids, _ = self.step(
+            token_ids = self.step(
                 rng, num_prompt_tokens, token_ids, attention_mask, samples
             )
             is_finished = self.is_finished(token_ids)
@@ -252,7 +251,7 @@ class Sequence:
             if torch.all(is_finished) or num_generated_tokens == self.max_tokens:
                 break
 
-            updated_token_ids, _ = self.step(
+            updated_token_ids = self.step(
                 rng,
                 num_prompt_tokens,
                 token_ids[~is_finished],

--- a/outlines/text/generate/sequence.py
+++ b/outlines/text/generate/sequence.py
@@ -60,7 +60,7 @@ class Sequence:
 
         Returns
         -------
-        An array of shape `(batch_size, vocab_size)` containing the logits 
+        An array of shape `(batch_size, vocab_size)` containing the logits
         (unnormalised log probabilities) for the next token generation.
 
         """
@@ -68,7 +68,9 @@ class Sequence:
         num_prompt_tokens = token_ids.shape[-1]
         token_ids = token_ids.to(self.device)
         attention_mask = attention_mask.to(self.device)
-        return self._next_token_logits(num_prompt_tokens, token_ids, attention_mask).squeeze()
+        return self._next_token_logits(
+            num_prompt_tokens, token_ids, attention_mask
+        ).squeeze()
 
     def step(
         self,

--- a/tests/text/generate/test_sequence.py
+++ b/tests/text/generate/test_sequence.py
@@ -116,9 +116,11 @@ def test_sequence_step():
     sequence = Sequence(model)
 
     input_ids = torch.tensor([[1, 2]])
-    token_ids, probs = sequence.step(rng, 2, input_ids, torch.ones((1, 2)))
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((1, 2)))
     assert torch.equal(token_ids, torch.tensor([[1, 2, 1]]))
-    assert probs.shape == (1, 4)
+
+    logits_out = sequence._next_token_logits(2, input_ids, torch.ones((1, 2)))
+    assert logits_out.shape == (1, 4)
 
 
 def test_sequence_step_batch():
@@ -131,9 +133,11 @@ def test_sequence_step_batch():
     sequence = Sequence(model)
 
     input_ids = torch.tensor([[1, 2], [3, 4]])
-    token_ids, probs = sequence.step(rng, 2, input_ids, torch.ones((2, 2)))
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((2, 2)))
     assert torch.equal(token_ids, torch.tensor([[1, 2, 1], [3, 4, 1]]))
-    assert probs.shape == (2, 4)
+
+    logits_out = sequence._next_token_logits(2, input_ids, torch.ones((2, 2)))
+    assert logits_out.shape == (2, 4)
 
 
 def test_sequence_step_sample():
@@ -145,9 +149,8 @@ def test_sequence_step_sample():
 
     sequence = Sequence(model)
     input_ids = torch.tensor([[1, 2]])
-    token_ids, probs = sequence.step(rng, 2, input_ids, torch.ones((1, 2)), samples=3)
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((1, 2)), samples=3)
     assert torch.equal(token_ids, torch.tensor([[1, 2, 1], [1, 2, 1], [1, 2, 1]]))
-    assert probs.shape == (3, 4)
 
 
 def test_sequence_step_sample_batch():
@@ -159,7 +162,7 @@ def test_sequence_step_sample_batch():
 
     sequence = Sequence(model)
     input_ids = torch.tensor([[1, 2, 1], [3, 4, 1]])
-    token_ids, probs = sequence.step(rng, 3, input_ids, torch.ones((2, 3)), samples=3)
+    token_ids = sequence.step(rng, 3, input_ids, torch.ones((2, 3)), samples=3)
     assert torch.equal(
         token_ids,
         torch.tensor(
@@ -170,7 +173,6 @@ def test_sequence_step_sample_batch():
             ]
         ),
     )
-    assert probs.shape == (3, 2, 4)
 
 
 def test_sequence_step_loop():
@@ -183,25 +185,22 @@ def test_sequence_step_loop():
 
     sequence = Sequence(model)
     input_ids = torch.tensor([[1, 2]])
-    token_ids, _ = sequence.step(rng, 2, input_ids, torch.ones((1, 2)))
-    token_ids, probs = sequence.step(rng, 2, token_ids, torch.ones((1, 3)))
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((1, 2)))
+    token_ids = sequence.step(rng, 2, token_ids, torch.ones((1, 3)))
     assert torch.equal(token_ids, torch.tensor([[1, 2, 1, 1]]))
-    assert probs.shape == (1, 4)
 
     input_ids = torch.tensor([[1, 2], [3, 4]])
-    token_ids, _ = sequence.step(rng, 2, input_ids, torch.ones((2, 2)))
-    token_ids, probs = sequence.step(rng, 2, token_ids, torch.ones((2, 3)))
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((2, 2)))
+    token_ids = sequence.step(rng, 2, token_ids, torch.ones((2, 3)))
     assert torch.equal(token_ids, torch.tensor([[1, 2, 1, 1], [3, 4, 1, 1]]))
-    assert probs.shape == (2, 4)
 
     # The number of samples becomes the batch size at the next iteration.
     input_ids = torch.tensor([[1, 2]])
-    token_ids, _ = sequence.step(rng, 2, input_ids, torch.ones((1, 2)), samples=3)
-    token_ids, probs = sequence.step(rng, 2, token_ids, torch.ones((3, 3)))
+    token_ids = sequence.step(rng, 2, input_ids, torch.ones((1, 2)), samples=3)
+    token_ids = sequence.step(rng, 2, token_ids, torch.ones((3, 3)))
     assert torch.equal(
         token_ids, torch.tensor([[1, 2, 1, 1], [1, 2, 1, 1], [1, 2, 1, 1]])
     )
-    assert probs.shape == (3, 4)
 
 
 def test_sequence_step_loop_general():
@@ -213,8 +212,8 @@ def test_sequence_step_loop_general():
 
     sequence = Sequence(model)
     input_ids = torch.tensor([[1, 2, 1], [3, 4, 1]])
-    token_ids, _ = sequence.step(rng, 3, input_ids, torch.ones((1, 3)), samples=3)
-    result, _ = sequence.step(rng, 3, token_ids, torch.ones((3, 4)))
+    token_ids = sequence.step(rng, 3, input_ids, torch.ones((1, 3)), samples=3)
+    result = sequence.step(rng, 3, token_ids, torch.ones((3, 4)))
     assert result.shape == (3, 2, 5)
     assert torch.equal(
         result,


### PR DESCRIPTION
Allows the user to access the next token logits for a given prompt (including with regex!)

```python
prompt = "What is the IP address of the Google DNS servers? "
unguided_logits = generate.continuation(model, max_tokens=30).logits(prompt)
guided_logits = generate.regex(
    model,
    r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)",
    max_tokens=30,
).logits(prompt)
```