### PR TITLE
Allow users to choose devices for models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
    "scipy",
    "tenacity",
    "torch",
+   "accelerate",
 ]
 dynamic = ["version"]
 

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -39,12 +39,12 @@ def test_tokenizer():
 
 
 def test_model():
-    with pytest.raises(RuntimeError, match="Expected one of cpu, cuda"):
+    with pytest.raises(ValueError, match="When passing device_map as a string"):
         transformers(TEST_MODEL, device="non_existent")
 
     model = transformers(TEST_MODEL, device="cpu")
     assert isinstance(model.tokenizer, TransformersTokenizer)
-    assert model.device == "cpu"
+    assert model.device.type == "cpu"
 
     input_ids = torch.tensor([[0, 1, 2]])
     logits = model(input_ids, torch.ones_like(input_ids))

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -114,7 +114,7 @@ def test_transformers_integration_choice():
 
 def test_transformers_integration_with_pad_token():
     model_name = "hf-internal-testing/tiny-random-XLMRobertaXLForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+    model = models.transformers(model_name, device="meta")
     assert model.tokenizer.pad_token_id == 1
     assert model.tokenizer.pad_token == "<pad>"
 


### PR DESCRIPTION
Currently, there are some issues when loading a transformers model because it explicitly calls `.to(device)`. The default is "cpu" (which is already the default in transformers to begin with). So I recommend to remove `device` as an argument completely and let the user decide how they want to load the model. That allows things like device_map and loading in `kbit`. Internally inside the `Transformers` class nothing changes, but we set `self.device` to `model.device` to ensure that everything stays compatible in the rest of the library.

closes #238 