### PR TITLE
Fix typos in model usage examples

### DIFF
--- a/docs/source/reference/batching.rst
+++ b/docs/source/reference/batching.rst
@@ -8,7 +8,7 @@ Outlines is sampling-first, and is built to generate several samples from the sa
    import outlines.models as models
 
    sample = models.text_generation.openai("text-davinci-003")
-   answers = complete(
+   answers = sample(
        "When I was 6 my sister was half my age. Now I’m 70 how old is my sister?",
        samples=10
     )

--- a/docs/source/reference/controlled_generation.rst
+++ b/docs/source/reference/controlled_generation.rst
@@ -34,7 +34,7 @@ In some cases we know the output is to be chosen between different options. We c
    import outlines.models as models
 
    complete = models.text_completion.openai("text-davinci-002")
-   answer = model(
+   answer = complete(
        "Pick the odd word out: skirt, dress, pen, jacket",
        is_in=["skirt", "dress", "pen", "jacket"]
    )
@@ -52,7 +52,7 @@ We can ask completions to be restricted to `int`s or `float`s using the `type` k
    import outlines.models as models
 
    complete = models.text_completion.openai("text-davinci-002")
-   answer = model(
+   answer = complete(
        "When I was 6 my sister was half my age. Now I’m 70 how old is my sister?",
        type="int"
    )


### PR DESCRIPTION
Corrected some typos in the documentation which were causing the example code to fail.