### PR TITLE
Remove unnecessary array allocations in generation process and enable caching

### DIFF
--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -108,9 +108,7 @@ class Regex(Continuation):
         assert generated_token_ids.ndim == 2
 
         if len(self.last_fsm_states) == 0:
-            self.last_fsm_states = [
-                self.initial_state for _ in range(generated_token_ids.shape[0])
-            ]
+            self.last_fsm_states = [self.initial_state for _ in range(logits.shape[0])]
 
         masks = []
 

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -86,12 +86,9 @@ def test_model():
     assert logits.ndim == 2
     assert logits.shape[0] == 3
 
-    input_ids = torch.tensor([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [0, 1, 2]]])
-    logits = model(input_ids, torch.ones_like(input_ids))
-    assert logits.ndim == 3
-    assert logits.shape[0] == 2
-    assert logits.shape[1] == 2
-    assert torch.equal(logits[0][0], logits[1][1])
+    with pytest.raises(AssertionError):
+        input_ids = torch.tensor([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [0, 1, 2]]])
+        logits = model(input_ids, torch.ones_like(input_ids))
 
 
 def test_tokenizer_eq_hash():

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -58,8 +58,16 @@ def test_transformers_various_regexes():
     model = models.transformers(model_name, device="cpu")
     prompt = "Write an email address"
     regex_str = r"([a-z]{10})@([a-z]{5})\.([a-z]{3})"
-    sequence = generate.regex(model, regex_str)(prompt, rng=rng)
+    generator = generate.regex(model, regex_str)
+
+    # One prompt
+    sequence = generator(prompt, rng=rng)
     assert re.fullmatch(regex_str, sequence) is not None
+
+    # Two prompts
+    sequence = generator([prompt, prompt], rng=rng)
+    assert re.fullmatch(regex_str, sequence[0]) is not None
+    assert re.fullmatch(regex_str, sequence[1]) is not None
 
 
 def test_transformers_integration_integer():


### PR DESCRIPTION
This PR removes some unnecessary array allocations during the generation process that affect scaling in max tokens and adds KV caching.

Perhaps the biggest non-cache-based change is that the method `Sequence.update_token_ids` has been removed; otherwise, the dimensions for arrays returned by `Sequence.step` are fixed (i.e. no squeezing).  This makes the dimensions in `Sequence.__call__` clearer and allows us to simplify the loop (e.g. no need to duplicate the steps in the auto-regression loop before starting the loop).