### PR TITLE
Avoid unhashable `additional_special_tokens` values in `special_tokens_map`

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -99,7 +99,8 @@ class TransformersTokenizer(Tokenizer):
 
         kwargs.setdefault("padding_side", "left")
         self.model_name = model_name
-        self.kwargs = frozenset(kwargs.items())
+        # TODO: Do something to make this hashable?
+        self.kwargs = kwargs
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token
@@ -111,7 +112,7 @@ class TransformersTokenizer(Tokenizer):
             self.pad_token_id = self.tokenizer.pad_token_id
             self.pad_token = self.tokenizer.pad_token
 
-        self.special_tokens = set(self.tokenizer.special_tokens_map.values())
+        self.special_tokens = set(self.tokenizer.all_special_tokens)
 
         self.vocabulary = self.tokenizer.get_vocab()
         self.is_llama = isinstance(self.tokenizer, get_llama_tokenizer_types())

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -37,6 +37,12 @@ def test_tokenizer():
     isinstance(text[0], str)
     isinstance(text[1], str)
 
+    tokenizer = TransformersTokenizer(
+        TEST_MODEL, additional_special_tokens=["<t1>", "<t2>"]
+    )
+    assert "<t1>" in tokenizer.special_tokens
+    assert "<t2>" in tokenizer.special_tokens
+
 
 def test_llama_tokenizer():
     tokenizer = TransformersTokenizer("hf-internal-testing/llama-tokenizer")


### PR DESCRIPTION
This PR changes the way that `transformer`'s special tokens are used in order to account for unhashable `special_tokens_map` values.