### PR TITLE
Allow configurable sampling steps

### DIFF
--- a/outlines/text/generate/continuation.py
+++ b/outlines/text/generate/continuation.py
@@ -1,8 +1,11 @@
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import torch
 
 from outlines.text.generate.sequence import Sequence
+
+if TYPE_CHECKING:
+    from outlines.text.generate.sample import Sampler
 
 
 class Continuation(Sequence):
@@ -18,9 +21,13 @@ class Continuation(Sequence):
     """
 
     def __init__(
-        self, model, max_tokens: Optional[int] = None, stop: Union[str, List[str]] = []
+        self,
+        model,
+        max_tokens: Optional[int] = None,
+        sampler: Optional["Sampler"] = None,
+        stop: Union[str, List[str]] = [],
     ):
-        super().__init__(model, max_tokens)
+        super().__init__(model, max_tokens, sampler)
         self.eos_token_id = torch.tensor(
             [self.model.tokenizer.eos_token_id], device=self.device
         )
@@ -89,7 +96,11 @@ class Continuation(Sequence):
 
 
 def continuation(
-    model, max_tokens: Optional[int] = None, *, stop: Union[str, List[str]] = []
+    model,
+    max_tokens: Optional[int] = None,
+    *,
+    sampler: Optional["Sampler"] = None,
+    stop: Union[str, List[str]] = [],
 ):
     """Generate text sequences.
 
@@ -99,9 +110,14 @@ def continuation(
         The language model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
+    sampler
+        The function used to draw samples.  Defaults to
+        `outlines.text.generate.sample.multinomial`.  See
+        `outlines.text.generate.sample.Sampler` for the expected form of
+        such functions.
     stop
         A string or list of strings which, when generated, stops
         the generation for this sequence.
 
     """
-    return Continuation(model, max_tokens, stop)
+    return Continuation(model, max_tokens, sampler, stop)

--- a/outlines/text/generate/sample.py
+++ b/outlines/text/generate/sample.py
@@ -1,0 +1,111 @@
+from typing import Protocol
+
+import torch
+
+
+class Sampler(Protocol):
+    def __call__(
+        self, logits: torch.DoubleTensor, samples: int, rng: torch.Generator
+    ) -> torch.DoubleTensor:
+        ...
+
+
+def greedy(logits: torch.DoubleTensor, samples: int, *_) -> torch.DoubleTensor:
+    """Greedy Sampling algorithm.
+
+    Greedy sampling consists in choosing the token with the largest
+    likelihood at every step.
+
+    Parameters
+    ----------
+    logits
+        A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
+        probability distribution of the next token over the vocabulary.
+    samples
+        The number of sequences to produce.  In this case, the top-`samples`
+        logit values are returned.
+    rng
+        A random number generator.
+
+    Returns
+    -------
+    The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+
+    """
+    if samples == 1:
+        next_token_ids = torch.argmax(logits, dim=-1, keepdim=True).T
+    else:
+        next_token_ids = torch.topk(
+            logits, samples, dim=-1, largest=True, sorted=True
+        ).indices.T
+
+    return next_token_ids
+
+
+def multinomial(
+    logits: torch.DoubleTensor, samples: int, rng: torch.Generator
+) -> torch.DoubleTensor:
+    """Multinomial sampling algorithm.
+
+    Multinomial sampling consists in randomly sampling the next token assuming
+    its distribution is a Categorical distribution parametrized by the
+    next-token logits.
+
+    Parameters
+    ----------
+    logits
+        A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
+        probability distribution of the next token over the vocabulary.
+    samples
+        The number of sequences to sample.
+    rng
+        A random number generator.
+
+    Returns
+    -------
+    The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+
+    """
+    probs = torch.nn.functional.softmax(logits, dim=-1)
+    # next_token_ids = torch.multinomial(probs, num_samples=samples, generator=rng)
+    next_token_ids = vectorized_random_choice(rng, probs, samples)
+    return next_token_ids
+
+
+def vectorized_random_choice(
+    rng: torch.Generator,
+    p: torch.FloatTensor,
+    samples: int = 1,
+):
+    """Vectorized implementation of `np.random.choice`.
+
+    `np.random.choice` does not support arrays of probability. This implements
+    the equivalent of this function where the `p` argument can be a matrix.
+
+    Note
+    ----
+    `torch.searchsorted` may be more efficient, but it is not implemented for
+    every backend, for instance MPS.
+
+    Parameters
+    ----------
+    rng
+        Torch random number Generator instance
+    p
+        An array of probability of shape ``(num_probability_vectors, num_items)``
+        that must sum to 1.
+    samples
+        The number of samples to take for each probability vector.
+
+    Returns
+    -------
+    An array of shape ``(num_samples, batch_size)``
+
+    """
+    cumsum = torch.unsqueeze(p.cumsum(axis=-1), 0)
+    rand = torch.rand(
+        (samples,) + p.shape[:-1] + (1,), generator=rng, device=rng.device
+    )
+    idx = (cumsum < rand).sum(axis=-1)
+
+    return idx

--- a/tests/text/generate/test_continuation.py
+++ b/tests/text/generate/test_continuation.py
@@ -53,7 +53,7 @@ def test_continuation_stop_is_finished():
 
     model = continuation(model, stop=["\n"])
 
-    token_ids = torch.tensor([[2, 3]])
+    token_ids = torch.tensor([[2, 3], [2, 3]])
     result = model.is_finished(token_ids)
     assert torch.equal(result, torch.tensor([True, False]))
 

--- a/tests/text/generate/test_sequence.py
+++ b/tests/text/generate/test_sequence.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from outlines.models.tokenizer import Tokenizer
-from outlines.text.generate.sequence import Sequence, vectorized_random_choice
+from outlines.text.generate.sequence import Sequence
 
 
 class MockModel:
@@ -65,38 +65,6 @@ class MockTokenizer(Tokenizer):
 
     def __hash__(self):
         return id(self)
-
-
-def test_vectorized_random_choice():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    probs = torch.tensor([[1, 0, 0, 0]])
-    sample = vectorized_random_choice(rng, probs)
-    assert sample.shape == (1, 1)
-    assert torch.equal(sample, torch.zeros((1, 1)))
-
-    probs = torch.tensor([[1, 0, 0, 0]])
-    sample = vectorized_random_choice(rng, probs, samples=3)
-    assert sample.shape == (3, 1)
-    assert torch.equal(sample, torch.zeros((3, 1)))
-
-    probs = torch.tile(torch.tensor([[1, 0, 0, 0]]), (2, 1))
-    sample = vectorized_random_choice(rng, probs)
-    assert sample.shape == (1, 2)
-    assert torch.equal(sample, torch.zeros((1, 2)))
-
-    probs = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 0]])
-    sample = vectorized_random_choice(rng, probs, samples=3)
-    assert sample.shape == (3, 2)
-    assert torch.equal(sample, torch.tensor([[0, 1], [0, 1], [0, 1]]))
-
-    probs = torch.tensor([[[1, 0, 0, 0], [0, 1, 0, 0]], [[0, 0, 1, 0], [0, 0, 0, 1]]])
-    sample = vectorized_random_choice(rng, probs, samples=3)
-    assert sample.shape == (3, 2, 2)
-    assert torch.equal(
-        sample, torch.tensor([[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[0, 1], [2, 3]]])
-    )
 
 
 def test_sequence_error():


### PR DESCRIPTION
This PR allows one to specify sampler functions that decide exactly how generated token sequences are sampled/produced from the logit values.  In doing so, this PR also adds a greedy "sampler" function (i.e. one that chooses the max logit values).