### PR TITLE
Fix and simplify `walk_fsm`

### DIFF
--- a/outlines/text/parsing.py
+++ b/outlines/text/parsing.py
@@ -573,7 +573,7 @@ class PartialScanner(Scanner):
         text_part = text[start_pos:]
 
         state_seq = walk_fsm(
-            self.fsm.fsm_info,
+            self.fsm,
             text_part,
             start_state,
             full_match=self.match_whole,


### PR DESCRIPTION
This PR fixes a bug in `walk_fsm`, simplifies it, and provides a Python-only version for use with the parser (because it's faster due to less Numba dispatching overhead).