### PR TITLE
Build a JSON schema from a function's signature

### DIFF
--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -1,1 +1,55 @@
-# JSON
+# Make the LLM follow a JSON Schema
+
+Outlines can make any open source model return a JSON object that follows a structure that is specified by the user. This is useful whenever we want the output of the model to be processed by code downstream: code does not understand natural language but rather the structured language it has been programmed to understand.
+
+There are mostly two reasons why someone would want to get an output formatted as JSON from a LLM:
+
+1. Parse the answer (e.g. with Pydantic), store it somewhere, return it to a user, etc.
+2. Call a function with the result
+
+Outlines has you covered in both cases! Indeed, to define the structure of the JSON you want the model to follow you can either provide a Pydantic model, or a function. No need to duplicate code!
+
+## Using Pydantic
+
+Outlines can infer the structure of the output from a Pydantic model. The result is an instance of the model that contains the values returned by the LLM:
+
+```python
+from pydantic import BaseModel
+
+from outlines import models
+from outlines import text
+
+
+class User(BaseModel):
+    name: str
+    last_name: str
+    id: int
+
+
+model = models.transformers("mistralai/Mistral-7B")
+generator = text.generate.json(model, User)
+result = generator("Create a user profile with the fields name, last_name and id")
+print(result)
+# User(name="John", last_name="Doe", id=11)
+```
+
+## From a function's signature
+
+Outlines can infer the structure of the output from the signature of a function. The result is a dictionary, and can be passed directly to the function using the usual dictionary expansion syntax `**`:
+
+```python
+from outlines import models
+from outlines import text
+
+def concat(a: int, b: int):
+    return a + b
+
+model = models.transformers("mistralai/Mistral-7B")
+generator = text.generate.json(model, add)
+result = generator("Return two integers named a and b respectively. a is odd and b even.")
+
+print(add(**result))
+# 3
+```
+
+A great advantage of passing functions directly to specify the structure is that the structure of the LLM will change with the function's definition. No need to change the code at several places!

--- a/examples/dating_profile.py
+++ b/examples/dating_profile.py
@@ -121,11 +121,8 @@ model = models.transformers(
 new_description = "I'm a laid-back lawyer who spends a lot of his free-time gaming. I work in a corporate office, but ended up here after the start-up I cofounded got acquired, so still play ping pong with my cool coworkers every day. I have a bar at home where I make cocktails, which is great for entertaining friends. I secretly like to wear suits and get a new one tailored every few months. I also like weddings because I get to wear those suits, and it's a good excuse for a date. I watch the latest series because I'm paying, with my hard-earned money, for every streaming service."
 
 prompt = dating_profile_prompt(description=new_description, examples=samples)
-profile = text.generate.json(model, DatingProfile)(prompt)
+profile = text.generate.json(model, DatingProfile)(prompt)  # type: ignore
 print(profile)
-
-parsed_profile = DatingProfile.model_validate_json(profile)
-print(parsed_profile)
 
 # Sample generated profiles
 """

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -237,6 +237,22 @@ def test_transformers_json_union():
     )
 
 
+def test_transformers_json_function():
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model = models.transformers(model_name)
+    prompt = "Output arguments for the function"
+
+    def function(foo: int, bar: List[int]):
+        return foo + sum(bar)
+
+    rng = torch.Generator()
+    rng.manual_seed(4)
+
+    sequence = generate.json(model, function, max_tokens=100)(prompt, rng=rng)
+    assert isinstance(sequence, dict)
+    assert isinstance(function(**sequence), int)
+
+
 def test_transformers_logits_vocab_size():
     model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
     model = models.transformers(model_name, device="cpu")

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -1,4 +1,3 @@
-import json
 import re
 from enum import Enum
 from typing import List, Union
@@ -75,7 +74,7 @@ def test_transformers_integration_integer():
     rng.manual_seed(0)
 
     model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+    model = models.transformers(model_name)
     prompt = "Write a short sentence"
     sequence = generate.integer(model, max_tokens=10)(prompt, rng=rng)
 
@@ -88,7 +87,7 @@ def test_transformers_integration_integer_array():
     rng.manual_seed(0)
 
     model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+    model = models.transformers(model_name)
     prompts = ["Give me a number", "And another one"]
     sequence = generate.integer(model, max_tokens=10)(prompts, rng=rng)
     assert isinstance(sequence, list)
@@ -102,7 +101,7 @@ def test_transformers_integration_float():
     rng.manual_seed(0)
 
     model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+    model = models.transformers(model_name)
     prompt = "Write a short sentence"
     sequence = generate.float(model, max_tokens=10)(prompt, rng=rng)
 
@@ -143,13 +142,13 @@ def test_transformers_json_basic():
     rng = torch.Generator()
     rng.manual_seed(0)  # make sure that `bar` is not an int
 
-    sequence = generate.json(model, Spam, max_tokens=1000)(prompt, rng=rng)
-    parsed = json.loads(sequence)
-    assert isinstance(parsed["foo"], int)
-    assert isinstance(parsed["bar"], int)
-    assert isinstance(parsed["spam"], str)
-    assert isinstance(parsed["fuzz"], bool)
-    assert len(parsed["spam"]) == 10
+    result = generate.json(model, Spam, max_tokens=1000)(prompt, rng=rng)
+    assert isinstance(result, BaseModel)
+    assert isinstance(result.foo, int)
+    assert isinstance(result.bar, float)
+    assert isinstance(result.spam, str)
+    assert isinstance(result.fuzz, bool)
+    assert len(result.spam) == 10
 
 
 def test_transformers_json_str_enum():
@@ -169,10 +168,10 @@ def test_transformers_json_str_enum():
         user_id: int
         name: Name
 
-    sequence = generate.json(model, User)(prompt, rng=rng)
-    parsed = json.loads(sequence)
-    assert isinstance(parsed["user_id"], int)
-    assert parsed["name"] in ["John", "Marc", "Michel"]
+    result = generate.json(model, User)(prompt, rng=rng)
+    assert isinstance(result, BaseModel)
+    assert isinstance(result.user_id, int)
+    assert result.name in ["John", "Marc", "Michel"]
 
 
 def test_transformers_json_int_enum():
@@ -190,10 +189,10 @@ def test_transformers_json_int_enum():
     class User(BaseModel):
         user_id: Id
 
-    sequence = generate.json(model, User)(prompt, rng=rng)
-    parsed = json.loads(sequence)
-    assert isinstance(parsed["user_id"], int)
-    assert parsed["user_id"] in [1, 2]
+    result = generate.json(model, User)(prompt, rng=rng)
+    assert isinstance(result, BaseModel)
+    assert isinstance(result.user_id, int)
+    assert result.user_id in [1, 2]
 
 
 def test_transformers_json_array():
@@ -208,11 +207,11 @@ def test_transformers_json_array():
     rng = torch.Generator()
     rng.manual_seed(0)
 
-    sequence = generate.json(model, User)(prompt, rng=rng)
-    parsed = json.loads(sequence)
-    assert isinstance(parsed["user_id"], int)
-    assert isinstance(parsed["value"], list)
-    for value in parsed["value"]:
+    result = generate.json(model, User)(prompt, rng=rng)
+    assert isinstance(result, BaseModel)
+    assert isinstance(result.user_id, int)
+    assert isinstance(result.value, list)
+    for value in result.value:
         assert isinstance(value, float) or isinstance(value, int)
 
 
@@ -229,11 +228,11 @@ def test_transformers_json_union():
     rng.manual_seed(4)
 
     sequence = generate.json(model, Spam, max_tokens=100)(prompt, rng=rng)
-    parsed = json.loads(sequence)
+    assert isinstance(sequence, BaseModel)
     assert (
-        isinstance(parsed["bar"], int)
-        or isinstance(parsed["bar"], float)
-        or isinstance(parsed["bar"], str)
+        isinstance(sequence.bar, int)
+        or isinstance(sequence.bar, float)
+        or isinstance(sequence.bar, str)
     )
 
 

--- a/tests/text/test_fsm.py
+++ b/tests/text/test_fsm.py
@@ -429,7 +429,7 @@ def test_json_index_performance():
     from pydantic import BaseModel, constr
 
     import outlines.models as models
-    from outlines.text.generate.regex import Regex, build_regex_from_schema
+    from outlines.text.generate.regex import Regex, build_regex_from_object
 
     class Weapon(str, Enum):
         sword = "sword"
@@ -457,7 +457,7 @@ def test_json_index_performance():
     json_schema = json.dumps(Character.model_json_schema())
 
     def build_regex():
-        regex_str = build_regex_from_schema(json_schema)
+        regex_str = build_regex_from_object(json_schema)
         Regex(model, regex_str, 100)
 
     profiler = LineProfiler(create_fsm_index_end_to_end)


### PR DESCRIPTION
A common use case for JSON-guided generation is to extract values that are then passed to a function (see autonomous agents applications. This PR adds the possibility to extract the JSON specification from the signature of  a function. Under the hood we create a Pydantic model from the extract argument names and type annotation. 

The use interface is the following:

```python
from outlines import models
from outlines.text import generate

def do_something_with_result(foo: str, bar: List[int]):
    pass

model = models.transformers("mistalai/Mistral-7b")

generator = generate.json(model, do_something_with_result)
args = generator("Generate arguments for the function")
do_something_with_result(**args)
```

Closes #350. Closes #351 

# TODO

- [x] Write documentation (waiting for #331 to be merged)
- [x] Return a `BaseModel` instance when input schema object is a Pydantic model