### PR TITLE
Fix Documentation Inconsistency in Joke Class Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,13 +345,15 @@ description passed to the prompt we define a custom Jinja filter that can
 extract the expected response's schema:
 
 ``` python
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import outlines.text as text
 
 
 class Joke(BaseModel):
-    joke: str
-    explanation: str
+    joke: str = Field(description="The joke")
+    explanation: str = Field(
+        description="The explanation of why the joke is funny"
+    )
 
 
 @text.prompt
@@ -364,6 +366,7 @@ def joke_ppt(response_model):
 
 
 joke_ppt(Joke)
+
 # Tell a joke and explain why the joke is funny.
 #
 # RESPONSE FORMAT:


### PR DESCRIPTION
# Fix Documentation Inconsistency in Joke Class Example

This pull request addresses an inconsistency found in the `Joke` class example within the README file of the `outlines` repository. The changes ensure that the inline documentation correctly reflects the actual output format.

## Changes Made
- Updated the `Joke` class definition to use `Field` descriptors for `joke` and `explanation` attributes.

## Issue Identified
The previous version of the README included an example where the `Joke` class did not use `Field` descriptors, leading to a discrepancy between the class definition and the output format described in the comments. This could potentially cause confusion for users trying to understand the expected behavior of the `joke_ppt` function.

## Resolution
By introducing `Field` descriptors in the `Joke` class, the documentation now accurately reflects the structure and output format of the `joke_ppt` function, enhancing clarity and correctness.

I believe these updates will make the documentation more accurate and helpful for users. Your feedback and further suggestions are always welcome.

Thank you for considering this pull request.