### PR TITLE
Add optional `api_key` parameter

### DIFF
--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -72,15 +72,15 @@ class OpenAIAPI:
             prompt: str, max_tokens: int, is_in: List[str], samples: int, api_key: str
         ) -> Union[List[str], str]:
             """Generate a sequence that must be one of many options.
-            `
-                        .. warning::
 
-                            This function will call the API once for every token generated.
+            .. warning::
 
-                        We tokenize every choice, iterate over the token lists, create a mask
-                        with the current tokens and generate one token. We progressively
-                        eliminate the choices that don't start with the currently decoded
-                        sequence.
+                This function will call the API once for every token generated.
+
+            We tokenize every choice, iterate over the token lists, create a mask
+            with the current tokens and generate one token. We progressively
+            eliminate the choices that don't start with the currently decoded
+            sequence.
 
             """
             try:


### PR DESCRIPTION
This PR allows users to supply an optional Openai API key, this is useful for services that allow users to supply their own API keys (like web services). 