### PR TITLE
Modify the openai model to conform to the new openai sdk v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore::numba.core.errors.NumbaPendingDeprecationWarning",
+    "ignore::pydantic.warnings.PydanticDeprecatedSince20",
     "ignore::FutureWarning:transformers.*",
     "ignore::UserWarning:torch.cuda.*"
 ]

--- a/tests/text/generate/test_sequence.py
+++ b/tests/text/generate/test_sequence.py
@@ -5,13 +5,17 @@ import numpy as np
 import pytest
 import torch
 
-from outlines import models
+from outlines.models import OpenAIAPI
 from outlines.models.tokenizer import Tokenizer
 from outlines.text.generate.sequence import Sequence
 
 
 def test_openai_error():
-    model = models.openai("text-davinci-003")
+    class Mock(OpenAIAPI):
+        def __init__(self):
+            pass
+
+    model = Mock()
     with pytest.raises(TypeError):
         Sequence(model)
 


### PR DESCRIPTION
This PR aims at solving this issue: https://github.com/outlines-dev/outlines/issues/361

The new Python sdk of Openai allows us to instantiate a client that we can then use for API calls. I thought it would make sense to put the instantiation of the client (and the import of the openai library) in the `__init__` of the `OpenAIAPI` class. 

An issue I ran into was that the functions `call_chat_completion_api` and `call_completion_api` would then receive the client as an argument which would cause problems with the `cache` decorator. I'm not sure what's the best way to handle that. I created two intermediary functions `cached_call_completion_api` and `cached_call_chat_completion_api` in the `__init__` of the `OpenAIAPI` class as it looked like the solution that required the fewest modifications to the existing logic.

The new sdk handles the retry logic itself so I removed the `retry` decorator (and added a `max_retries` argument to `OpenAIAPI` instead)