### PR TITLE
Add support for OpenAI functions

### DIFF
--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from outlines.text.fsm import create_fsm_index_tokenizer, make_deterministic_fsm
 from outlines.text.generate.continuation import Continuation
-from outlines.text.json_schema import build_regex_from_object, get_schema_from_signature
+from outlines.text.json_schema import build_regex_from_object, get_model_from_signature
 from outlines.text.types import python_types_to_regex
 
 if TYPE_CHECKING:
@@ -389,7 +389,9 @@ def json(
         schema = pyjson.dumps(schema_object.model_json_schema())
         format_fn = lambda x: schema_object.model_validate(pyjson.loads(x))
     elif callable(schema_object):
-        schema = pyjson.dumps(get_schema_from_signature(schema_object))
+        schema = pyjson.dumps(
+            get_model_from_signature(schema_object).model_json_schema()
+        )
         # TODO: Convert string fields to their respective types
         format_fn = lambda x: pyjson.loads(x)
     else:

--- a/outlines/text/json_schema.py
+++ b/outlines/text/json_schema.py
@@ -58,7 +58,8 @@ def build_regex_from_object(object: Union[str, Callable, BaseModel]):
     if isinstance(object, type(BaseModel)):
         schema = object.model_json_schema()
     elif callable(object):
-        schema = get_schema_from_signature(object)
+        model = get_model_from_signature(object)
+        schema = model.model_json_schema()
     else:
         schema = json.loads(object)
 
@@ -239,7 +240,7 @@ def to_regex(resolver: Resolver, instance: dict):
     )
 
 
-def get_schema_from_signature(fn: Callable) -> str:
+def get_model_from_signature(fn: Callable):
     """Turn a function signature into a JSON schema.
 
     Every JSON object valid to the output JSON Schema can be passed
@@ -256,4 +257,4 @@ def get_schema_from_signature(fn: Callable) -> str:
 
     model = create_model("Arguments", **arguments)
 
-    return model.model_json_schema()
+    return model

--- a/tests/text/test_json_schema.py
+++ b/tests/text/test_json_schema.py
@@ -13,7 +13,7 @@ from outlines.text.json_schema import (
     STRING,
     STRING_INNER,
     build_regex_from_object,
-    get_schema_from_signature,
+    get_model_from_signature,
     to_regex,
 )
 
@@ -22,7 +22,8 @@ def test_function_basic():
     def test_function(foo: str, bar: List[int]):
         ...
 
-    result = get_schema_from_signature(test_function)
+    result = get_model_from_signature(test_function)
+    result = result.model_json_schema()
     assert result["type"] == "object"
     assert list(result["properties"].keys()) == ["foo", "bar"]
     assert result["properties"]["foo"]["type"] == "string"
@@ -35,7 +36,7 @@ def test_function_no_type():
         ...
 
     with pytest.raises(ValueError):
-        get_schema_from_signature(test_function)
+        get_model_from_signature(test_function)
 
 
 def test_from_pydantic():


### PR DESCRIPTION
We would like to integrate OpenAI functions to make it easy to compare guided generation on OSS model with the feature offered by OpenAI. Here are the design requirement:

- Usage should be very similar to guided generation, and users should be able to change a single line to switch between OpenAI and OSS models. Since OpenAI's function API does not necessarily return valid JSON I am not sure about dispatching `outlines.text.generate.json` to different functions depending on the model type. This however makes the model switch even easier;
- When inferring the output format from the function's docstring we should extract the docstring and add it as the model's description since OpenAI uses this information in their prompt;
- Output format should be the same as with the current `outlines.text.generate.json` interface: Pydantic model instance when the input format is a Pydantic model, dictionary when it is a function or a JSON schema.