### PR TITLE
Track usage, add system prompt and timeout

### DIFF
--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -57,7 +57,7 @@ class OpenAIConfig:
 
     """
 
-    model: str
+    model: str = ""
     frequency_penalty: float = 0
     logit_bias: Dict[int, int] = field(default_factory=dict)
     max_tokens: Optional[int] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ module = [
     "jinja2",
     "joblib.*",
     "jsonschema.*",
-    "openai",
+    "openai.*",
     "nest_asyncio",
     "numpy.*",
     "perscache.*",


### PR DESCRIPTION
A few improvements to the openai client.

- Added a function to wrap the call to async generate_chat, s.t. it can process the usage data and add an additional parameter (the system prompt).

- Added the system_prompt parameter: not groundbreaking, but just required a small change. It may reduce the need to do prompt composition. There was issue about this was closed as not planned. #246

- Added a timeout parameter: Without it sometimes the script was waiting for minutes and minutes for a 1-token response.

- Added the processing of usage: Accumulated usage is stored within each instance of the client. #387