### PR TITLE
Correct `auto-gpt` name in exception

### DIFF
--- a/outlines/models/gptq.py
+++ b/outlines/models/gptq.py
@@ -13,7 +13,7 @@ def gptq(
         from auto_gptq import AutoGPTQForCausalLM
     except ImportError:
         raise ImportError(
-            "The `auto_gptq` library needs to be installed in order to use `AutoGPTQ` models."
+            "The `auto-gptq` library needs to be installed in order to use `AutoGPTQ` models."
         )
 
     if device is not None:


### PR DESCRIPTION
it was a bit confusing to use `auto_gptq` while the library installation from pypi refers to `auto-gptq` 

https://github.com/PanQiWei/AutoGPTQ

The change should be helpful if the `ImportError` is raised