### PR TITLE
Restore the ability to stop when a specified string has been generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ answer = outlines.generate.format(model, float)(prompt)
 
 ### Efficient regex-guided generation
 
-Outlines also comes with fast regex-guided generation. In fact, the `choice`,
-`integer` and `float` functions above all use regex-guided generation under the
+Outlines also comes with fast regex-guided generation. In fact, the `choice` and
+`format` functions above all use regex-guided generation under the
 hood:
 
 ``` python
@@ -92,12 +92,11 @@ import outlines
 model = outlines.models.transformers("mistralai/Mistral-7B-v0.1")
 
 prompt = "What is the IP address of the Google DNS servers? "
-unguided = outlines.generate.text(model, max_tokens=30)(prompt)
+unguided = outlines.generate.text(model)(prompt, max_tokens=30)
 guided = outlines.generate.regex(
     model,
     r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)",
-    max_tokens=30,
-)(prompt)
+)(prompt, max_tokens=30)
 
 print(unguided)
 # What is the IP address of the Google DNS servers?
@@ -325,7 +324,7 @@ def labelling(to_label, examples):
 
 model = outlines.models.transformers("mistralai/Mistral-7B-v0.1")
 prompt = labelling("Just awesome", examples)
-answer = outlines.generate.text(model, max_tokens=100)(prompt)
+answer = outlines.generate.text(model)(prompt, max_tokens=100)
 ```
 
 ## Join us

--- a/examples/cfg.py
+++ b/examples/cfg.py
@@ -51,8 +51,8 @@ model = models.transformers("hf-internal-testing/tiny-random-gpt2")
 batch_size = 10
 max_tokens = 30
 for grammar in [nlamb_grammar, calc_grammar]:
-    generator = generate.cfg(model, grammar, max_tokens=max_tokens)
-    sequences = generator([" "] * batch_size)
+    generator = generate.cfg(model, grammar)
+    sequences = generator([" "] * batch_size, max_tokens=max_tokens)
     for seq in sequences:
         try:
             parse = generator.fsm.parser.parse(seq)

--- a/outlines/fsm/fsm.py
+++ b/outlines/fsm/fsm.py
@@ -191,7 +191,8 @@ class RegexFSM(FSM):
         The new state of the FSM.
 
         """
-        self.num_tokens_generated += 1
+        if idx == 0:
+            self.num_tokens_generated += 1
 
         if token_id == self.end_token_id:
             return FSMState(-1)

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -254,7 +254,9 @@ class SequenceGenerator:
             num_generated = 0
             is_stop_at_reached = [False for _ in range(num_sequences)]
             while True:
-                if (max_tokens and num_generated >= max_tokens) or all(is_stop_at_reached):
+                if (max_tokens and num_generated >= max_tokens) or all(
+                    is_stop_at_reached
+                ):
                     return
                 try:
                     sequence = next(states)
@@ -266,14 +268,21 @@ class SequenceGenerator:
                 next_tokens = [
                     token[len(sequence) :] if not stop else ""
                     for token, sequence, stop in zip(
-                        generated_sequences, previously_generated_sequences, is_stop_at_reached
+                        generated_sequences,
+                        previously_generated_sequences,
+                        is_stop_at_reached,
                     )
                 ]
                 previously_generated_sequences = generated_sequences
                 if stop_sequences:
                     is_stop_at_reached = [
-                        stop or self.is_stop_sequence_reached([generated_sequence], stop_sequences)
-                        for generated_sequence, stop in zip(generated_sequences, is_stop_at_reached)
+                        stop
+                        or self.is_stop_sequence_reached(
+                            [generated_sequence], stop_sequences
+                        )
+                        for generated_sequence, stop in zip(
+                            generated_sequences, is_stop_at_reached
+                        )
                     ]
                 yield next_tokens
 

--- a/outlines/text/generate/api.py
+++ b/outlines/text/generate/api.py
@@ -9,7 +9,6 @@ def json(
     model,
     schema_object: Union[str, object, Callable],
     max_tokens: Optional[int] = None,
-    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -18,16 +17,13 @@ def json(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.json(
-        model, schema_object, max_tokens, stop, sampler=sampler
-    )
+    return outlines.generate.json(model, schema_object, max_tokens, sampler=sampler)
 
 
 def regex(
     model,
     regex_str: str,
     max_tokens: Optional[int] = None,
-    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -36,14 +32,13 @@ def regex(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.regex(model, regex_str, max_tokens, stop, sampler=sampler)
+    return outlines.generate.regex(model, regex_str, max_tokens, sampler=sampler)
 
 
 def format(
     model,
     python_type,
     max_tokens: Optional[int] = None,
-    stop: Optional[Union[str, List[str]]] = None,
     sampler: Sampler = multinomial,
 ):
     warnings.warn(
@@ -51,15 +46,13 @@ def format(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.format(
-        model, python_type, max_tokens, stop, sampler=sampler
-    )
+    return outlines.generate.format(model, python_type, max_tokens, sampler=sampler)
 
 
 def continuation(
     model,
     max_tokens: Optional[int] = None,
-    stop: Optional[Union[str, List[str]]] = None,
+    stop_at: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -69,14 +62,13 @@ def continuation(
         DeprecationWarning,
     )
 
-    return outlines.generate.text(model, max_tokens, stop, sampler=sampler)
+    return outlines.generate.text(model, max_tokens, stop_at, sampler=sampler)
 
 
 def choice(
     model,
     choices: List[str],
     max_tokens: Optional[int] = None,
-    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -85,4 +77,4 @@ def choice(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.choice(model, choices, max_tokens, stop, sampler=sampler)
+    return outlines.generate.choice(model, choices, max_tokens, sampler=sampler)

--- a/outlines/text/generate/api.py
+++ b/outlines/text/generate/api.py
@@ -9,6 +9,7 @@ def json(
     model,
     schema_object: Union[str, object, Callable],
     max_tokens: Optional[int] = None,
+    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -17,13 +18,16 @@ def json(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.json(model, schema_object, max_tokens, sampler=sampler)
+    return outlines.generate.json(
+        model, schema_object, max_tokens, stop, sampler=sampler
+    )
 
 
 def regex(
     model,
     regex_str: str,
     max_tokens: Optional[int] = None,
+    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -32,45 +36,47 @@ def regex(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.regex(model, regex_str, max_tokens, sampler=sampler)
+    return outlines.generate.regex(model, regex_str, max_tokens, stop, sampler=sampler)
 
 
 def format(
-    model, python_type, max_tokens: Optional[int] = None, sampler: Sampler = multinomial
+    model,
+    python_type,
+    max_tokens: Optional[int] = None,
+    stop: Optional[Union[str, List[str]]] = None,
+    sampler: Sampler = multinomial,
 ):
     warnings.warn(
         "`outlines.text.generate.format` is deprecated, please use `outlines.generate.format` instead. "
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.format(model, python_type, max_tokens, sampler=sampler)
+    return outlines.generate.format(
+        model, python_type, max_tokens, stop, sampler=sampler
+    )
 
 
 def continuation(
     model,
     max_tokens: Optional[int] = None,
+    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
-    stop: Optional[Union[str, List[str]]] = None,
 ):
     warnings.warn(
         "`outlines.text.generate.continuation` is deprecated, please use `outlines.generate.text` instead. "
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    if stop is not None:
-        raise NotImplementedError(
-            "The `stop` keyword is unavailable in the updated API. Please open an issue "
-            " at https://github.com/outlines-dev/outlines/issues if you need it implemented."
-        )
 
-    return outlines.generate.text(model, max_tokens, sampler=sampler)
+    return outlines.generate.text(model, max_tokens, stop, sampler=sampler)
 
 
 def choice(
     model,
     choices: List[str],
     max_tokens: Optional[int] = None,
+    stop: Optional[Union[str, List[str]]] = None,
     *,
     sampler: Sampler = multinomial,
 ):
@@ -79,4 +85,4 @@ def choice(
         "The old import path will be removed in Outlines v0.1.0.",
         DeprecationWarning,
     )
-    return outlines.generate.choice(model, choices, max_tokens, sampler)
+    return outlines.generate.choice(model, choices, max_tokens, stop, sampler=sampler)

--- a/tests/generate/test_integration_transfomers.py
+++ b/tests/generate/test_integration_transfomers.py
@@ -22,9 +22,6 @@ def test_deprecation():
     with pytest.warns(DeprecationWarning):
         outlines.text.generate.continuation(model, max_tokens=10)
 
-        with pytest.raises(NotImplementedError):
-            outlines.text.generate.continuation(model, max_tokens=10, stop="string")
-
     with pytest.warns(DeprecationWarning):
         outlines.text.generate.choice(model, ["A", "B"], max_tokens=10)
 


### PR DESCRIPTION
This PR aims at solving [#417](https://github.com/outlines-dev/outlines/issues/417)

The proposed change does 2 main things:
- break the generation loop in `SequenceGenerator.__call__` if all sequences contain at least one of the stop_sequences provided by the user
- format the generated sequences to truncate them once the first stop_sequence is found in them

A downside of adding this logic at the level of the `SequenceGenerator` is that we generate text that is later discarded. However, incorporating this logic in the fsm would require much bigger change as we need to decode the token_ids to check whether the stop_sequences are found. Maybe this could be a first solution before some future refactoring.

As suggested in [#433](https://github.com/outlines-dev/outlines/issues/433), I think we could treat the max_tokens parameter in a similar way as what's proposed here for the stop_sequences

I've only modified the tests required to pass the tests and the linting, but will modify them further along with documentation in another commit if you think this PR is going in the right direction.