### PR TITLE
mlx support

### DIFF
--- a/outlines/fsm/fsm.py
+++ b/outlines/fsm/fsm.py
@@ -4,7 +4,11 @@ import interegular
 from lark import Lark
 
 # from outlines.fsm.parsing import PartialLark
-from outlines.fsm.regex import create_fsm_index_tokenizer, make_deterministic_fsm
+import torch
+if torch.backends.mps.is_available:
+    from outlines.fsm.regex_pure_numpy import create_fsm_index_tokenizer, make_deterministic_fsm
+else: 
+    from outlines.fsm.regex import create_fsm_index_tokenizer, make_deterministic_fsm
 
 if TYPE_CHECKING:
     from outlines.models.tokenizer import Tokenizer

--- a/outlines/fsm/regex_pure_numpy.py
+++ b/outlines/fsm/regex_pure_numpy.py
@@ -1,0 +1,567 @@
+from collections import namedtuple
+from functools import lru_cache
+from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Set, Tuple
+
+import numpy as np
+from interegular.fsm import FSM, Alphabet, OblivionError, anything_else
+
+if TYPE_CHECKING:
+    from outlines.models.tokenizer import Tokenizer
+
+class BetterAlphabet(Alphabet):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert anything_else in self._symbol_mapping
+        self.anything_value = self._symbol_mapping[anything_else]
+
+    def __getitem__(self, item):
+        return self._symbol_mapping.get(item, self.anything_value)
+
+    def copy(self):
+        return BetterAlphabet(self._symbol_mapping.copy())
+
+
+class BetterFSM(FSM):
+    flat_transition_map: Dict[Tuple[int, int], int]
+    trans_key_to_states: Dict[int, List[int]]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not isinstance(self.alphabet, BetterAlphabet):
+            self.__dict__["alphabet"] = BetterAlphabet(self.alphabet._symbol_mapping)
+
+        flat_transition_map = {}
+        trans_key_to_states = {}
+        for from_state, trans_map in self.map.items():
+            for trans_key, to_state in trans_map.items():
+                flat_transition_map[(from_state, trans_key)] = to_state
+                trans_key_to_states.setdefault(trans_key, set()).add(from_state)
+
+        self.__dict__["trans_key_to_states"] = trans_key_to_states
+        self.__dict__["flat_transition_map"] = flat_transition_map
+        self.__dict__["_fsm_info"] = None
+
+    def copy(self):
+        return BetterFSM(
+            alphabet=self.alphabet.copy(),
+            states=self.states.copy(),
+            initial=self.initial,
+            finals=self.finals.copy(),
+            map=self.map.copy(),
+            __no_validation__=True,
+        )
+
+    @property
+    def fsm_info(self):
+        if self._fsm_info is None:
+            flat_transition_map_items = np.fromiter(
+                ((a[0], a[1], b) for a, b in self.flat_transition_map.items()),
+                dtype=np.dtype("i8, i8, i8"),
+            )
+            trans_key_to_states_items = np.fromiter(
+                ((k, z) for k, v in self.trans_key_to_states.items() for z in v),
+                dtype=np.dtype("i8, i8"),
+            )
+            alphabet_symbol_mapping_items = np.fromiter(
+                (
+                    it
+                    for it in self.alphabet._symbol_mapping.items()
+                    if it[0] != anything_else
+                ),
+                dtype=np.dtype("U1, i8"),
+            )
+            nb_finals = np.fromiter(self.finals, dtype=np.dtype("i8"))
+            self.__dict__["_fsm_info"] = create_fsm_info(
+                self.initial,
+                nb_finals,
+                flat_transition_map_items,
+                trans_key_to_states_items,
+                self.alphabet.anything_value,
+                alphabet_symbol_mapping_items,
+            )
+
+        return self._fsm_info
+
+
+""" class FSMInfo(namedtuple("FSMInfo", [
+    "initial",
+    "finals",
+    "transitions",
+    "trans_key_to_states",
+    "alphabet_anything_value",
+    "alphabet_symbol_mapping"])):
+    pass
+"""
+
+def create_fsm_info(py_initial, py_finals, flat_transition_map_items,
+                    trans_key_to_states_items, py_anything_value,
+                    alphabet_symbol_mapping_items):
+
+    trans_key_to_states = {}
+    for trans_key, state in trans_key_to_states_items:
+        trans_key_to_states.setdefault(trans_key, []).append(state)
+
+    flat_transition_map = {}
+    for from_state, trans_key, to_state in flat_transition_map_items:
+        flat_transition_map[(from_state, trans_key)] = to_state
+
+    alphabet_symbol_map = {}
+    for symbol, trans_key in alphabet_symbol_mapping_items:
+        alphabet_symbol_map[symbol] = trans_key
+
+    finals = set(py_finals)
+    anything_value = py_anything_value
+
+    return FSMInfo(
+        initial=py_initial,
+        finals=finals,
+        transitions=flat_transition_map,
+        trans_key_to_states=trans_key_to_states,
+        alphabet_anything_value=anything_value,
+        alphabet_symbol_mapping=alphabet_symbol_map,
+    )
+
+FSMInfo = namedtuple(
+    "FSMInfo",
+    [
+        "initial",
+        "finals",
+        "transitions",
+        "trans_key_to_states",
+        "alphabet_anything_value",
+        "alphabet_symbol_mapping",
+    ],
+)
+
+
+def make_deterministic_fsm(fsm: FSM) -> Tuple[BetterFSM, Dict[int, int]]:
+    """Construct an equivalent FSM with deterministic state labels."""
+    old_to_new_trans_keys = {
+        trans_key: i
+        for i, (trans_key, _) in enumerate(
+            sorted(fsm.alphabet.by_transition.items(), key=lambda x: sorted(x[1]))
+        )
+    }
+
+    new_symbol_mapping = {
+        symbol: old_to_new_trans_keys[trans_key]
+        for symbol, trans_key in fsm.alphabet._symbol_mapping.items()
+    }
+
+    new_alphabet = BetterAlphabet(new_symbol_mapping)
+
+    new_map = {
+        from_state: {
+            old_to_new_trans_keys[trans_key]: to_state
+            for trans_key, to_state in trans_map.items()
+        }
+        for from_state, trans_map in fsm.map.items()
+    }
+
+    old_to_new_states = {}
+    old_to_new_states[fsm.initial] = 0
+
+    i = 0
+    seen = {fsm.initial}
+    old_state_queue = [fsm.initial]
+    while old_state_queue:
+        old_state = old_state_queue.pop(-1)
+        transitions = new_map[old_state]
+        sorted_transitions = sorted(transitions.items(), key=lambda v: v[0])
+        for _, old_state in sorted_transitions:
+            if old_state not in seen:
+                old_state_queue.append(old_state)
+                seen.add(old_state)
+            if old_state not in old_to_new_states:
+                i += 1
+                old_to_new_states[old_state] = i
+
+    new_map = dict(
+        sorted(
+            (
+                (
+                    old_to_new_states[from_state],
+                    dict(
+                        sorted(
+                            (
+                                (trans_key, old_to_new_states[to_state])
+                                for trans_key, to_state in trans_map.items()
+                            ),
+                            key=lambda v: v[0],
+                        )
+                    ),
+                )
+                for from_state, trans_map in new_map.items()
+            ),
+            key=lambda v: v[0],
+        )
+    )
+
+    new_initial = 0
+    new_finals = frozenset(
+        sorted(old_to_new_states[old_state] for old_state in fsm.finals)
+    )
+    new_states = frozenset(sorted(new_map.keys()))
+
+    new_fsm = BetterFSM(new_alphabet, new_states, new_initial, new_finals, new_map)
+
+    return new_fsm, old_to_new_states
+
+
+def _walk_fsm(
+    fsm_transitions: Dict[Tuple[int, int], int],
+    alphabet_symbol_mapping: Dict[str, int],
+    alphabet_anything_value: int,
+    fsm_initial: int,
+    fsm_finals: Set[int],
+    input_string: str,
+    start_state: int,
+    full_match: bool = True
+) -> List[int]:
+    state = start_state
+    accepted_states: List[int] = []
+    last_final_idx: int = 0
+
+    for i, symbol in enumerate(input_string):
+        trans_key = alphabet_symbol_mapping.get(symbol, alphabet_anything_value)
+
+        new_state = fsm_transitions.get((state, trans_key))
+
+        if new_state is None:
+            if not full_match and last_final_idx > 0:
+                return accepted_states[:last_final_idx]
+
+            return []
+
+        state = new_state
+
+        if state in fsm_finals:
+            last_final_idx = i + 1
+
+        accepted_states.append(state)
+
+    if full_match and last_final_idx - 1 != i:
+        return []
+
+    return accepted_states
+
+
+
+def walk_fsm(
+    fsm: BetterFSM,
+    input_string: str,
+    start_state: int,
+    full_match: bool = True,
+) -> List[int]:
+    fsm_finals = fsm.finals
+
+    state = start_state
+    accepted_states: List[int] = []
+    last_final_idx: int = 0
+
+    alphabet_symbol_mapping = fsm.alphabet._symbol_mapping
+    alphabet_anything_value = fsm.alphabet.anything_value
+    fsm_transitions = fsm.flat_transition_map
+
+    for i, symbol in enumerate(input_string):
+        trans_key = alphabet_symbol_mapping.get(symbol, alphabet_anything_value)
+
+        new_state = fsm_transitions.get((state, trans_key))
+
+        if new_state is None:
+            if not full_match and last_final_idx > 0:
+                return accepted_states[:last_final_idx]
+
+            return []
+
+        state = new_state
+
+        if state in fsm_finals:
+            last_final_idx = i + 1
+
+        accepted_states.append(state)
+
+    if full_match and last_final_idx - 1 != i:
+        return []
+
+    return accepted_states
+
+
+def fsm_union(
+    fsms: Sequence[FSM],
+) -> Tuple[FSM, Dict[int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]]]:
+    """Construct an FSM representing the union of the FSMs in `fsms`.
+
+    This is an updated version of `interegular.fsm.FSM.union` made to return an
+    extra map of component FSMs to the sets of state transitions that
+    correspond to them in the new FSM.
+
+    """
+
+    alphabet, new_to_old = Alphabet.union(*[fsm.alphabet for fsm in fsms])
+
+    indexed_fsms = tuple(enumerate(fsms))
+
+    initial = {i: fsm.initial for (i, fsm) in indexed_fsms}
+
+    # Dedicated function accepting a "superset" and returning the next
+    # "superset" obtained by following this transition in the new FSM
+    def follow(current_state, new_transition: int):
+        next = {}
+        for i, f in indexed_fsms:
+            old_transition = new_to_old[i][new_transition]
+            if (
+                i in current_state
+                and current_state[i] in f.map
+                and old_transition in f.map[current_state[i]]
+            ):
+                next[i] = f.map[current_state[i]][old_transition]
+        if not next:
+            raise OblivionError
+        return next
+
+    states = [initial]
+    finals: Set[int] = set()
+    map: Dict[int, Dict[int, int]] = {}
+
+    # Map component FSMs to their new state-to-state transitions, finals, and a
+    # map translating component FSM states to aggregate FSM states
+    fsms_to_trans_finals: Dict[
+        int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]
+    ] = {}
+
+    i = 0
+    while i < len(states):
+        state = states[i]
+
+        # Add to the finals of the aggregate FSM whenever we hit a final in a
+        # component FSM
+        if any(state.get(j, -1) in fsm.finals for (j, fsm) in indexed_fsms):
+            finals.add(i)
+
+        # Compute the map for this state
+        map[i] = {}
+        for transition in alphabet.by_transition:
+            try:
+                next = follow(state, transition)
+            except OblivionError:
+                # Reached an oblivion state; don't list it
+                continue
+            else:
+                try:
+                    # TODO: Seems like this could--and should--be avoided
+                    j = states.index(next)
+                except ValueError:
+                    j = len(states)
+                    states.append(next)
+
+                map[i][transition] = j
+
+                for fsm_id, fsm_state in next.items():
+                    (
+                        fsm_transitions,
+                        fsm_finals,
+                        fsm_old_to_new,
+                    ) = fsms_to_trans_finals.setdefault(fsm_id, (set(), set(), {}))
+                    old_from = state[fsm_id]
+                    old_to = fsm_state
+                    fsm_old_to_new.setdefault(old_from, set()).add(i)
+                    fsm_old_to_new.setdefault(old_to, set()).add(j)
+                    fsm_transitions.add((i, j))
+                    if fsm_state in fsms[fsm_id].finals:
+                        fsm_finals.add(j)
+
+        i += 1
+
+    fsm = FSM(
+        alphabet=alphabet,
+        states=range(len(states)),
+        initial=0,
+        finals=finals,
+        map=map,
+        __no_validation__=True,
+    )
+
+    fsm, old_to_new_states = make_deterministic_fsm(fsm)
+    _fsms_to_trans_finals = {
+        fsm_id: (
+            {(old_to_new_states[s1], old_to_new_states[s2]) for s1, s2 in transitions},
+            {old_to_new_states[s] for s in finals},
+            {
+                old_state: {old_to_new_states[new_state] for new_state in new_states}
+                for old_state, new_states in old_to_new.items()
+            },
+        )
+        for fsm_id, (transitions, finals, old_to_new) in sorted(
+            fsms_to_trans_finals.items(), key=lambda x: x[0]
+        )
+    }
+
+    return (
+        fsm,
+        _fsms_to_trans_finals,
+    )
+
+
+def get_sub_fsms_from_seq(
+    state_seq: Sequence[int],
+    fsms_to_trans_finals: Dict[
+        int, Tuple[Set[Tuple[int, int]], Set[int], Dict[int, Set[int]]]
+    ],
+) -> Generator[Tuple[int, bool, bool], None, None]:
+    """Get the indices of the sub-FSMs in `fsm` that could have matched the state sequence `state_seq`.
+
+    Parameters
+    ----------
+    state_seq
+        A state sequence.
+    fsms_to_trans_finals
+        A map from FSM indices to tuples containing sets of their state transitions
+        and sets of the final/accept states.
+
+    Returns
+    -------
+    A generator returning tuples containing each sub-FSM index (in the order
+    they were union-ed to construct `fsm`) and booleans indicating whether or
+    not there is another valid transition from the last state in the sequence
+    for the associated sub-FSM (i.e. if the FSM can continue
+    accepting/matching) and whether or not the sequence ends in a final state
+    of the sub-FSM.
+    """
+    state_seq_transitions = set(zip(state_seq[:-1], state_seq[1:]))
+    last_fsm_state = state_seq[-1]
+    yield from (
+        (
+            # The sub-FMS index
+            fsm_idx,
+            # Is there another possible transition in this sub-FSM?
+            any(last_fsm_state == from_s for (from_s, to_s) in transitions),
+            # Is this sub-FSM in a final state?
+            state_seq[-1] in finals,
+        )
+        for fsm_idx, (transitions, finals, _) in fsms_to_trans_finals.items()
+        if state_seq_transitions.issubset(transitions)
+    )
+
+
+
+def state_scan_tokens(
+    fsm_transitions: Dict[Tuple[int, int], int],
+    alphabet_symbol_mapping: Dict[str, int],
+    alphabet_anything_value: int,
+    fsm_initial: int,
+    fsm_finals: Set[int],
+    vocabulary: Dict[str, List[int]],
+    start_state: int,
+) -> Set[Tuple[int, int]]:
+    res = set()
+
+    for token, token_ids in vocabulary.items():
+        state_seq = _walk_fsm(
+            fsm_transitions,
+            alphabet_symbol_mapping,
+            alphabet_anything_value,
+            fsm_initial,
+            fsm_finals,
+            token,
+            start_state,
+            False,
+        )
+
+        if state_seq is not None and len(state_seq) < len(token):
+            continue
+
+        for token_id in token_ids:
+            res.add((token_id, state_seq[-1]))
+
+    return res
+
+
+def create_fsm_index_end_to_end(
+    fsm_info: FSMInfo,
+    vocabulary: Dict[str, List[int]],
+) -> Dict[int, Set[Tuple[int, int]]]:
+    """Create an FSM state-to-vocabulary map/index through end-to-end token parsing."""
+
+    # TODO: Consider using a `List` of `Set`s instead; that way we can JIT this
+    # code, too.
+    states_to_token_subsets: Dict[int, Set[Tuple[int, int]]] = {}
+    seen: Set[int] = set()
+    next_states = {fsm_info.initial}
+
+    while next_states:
+        start_state = next_states.pop()
+
+        token_ids_end_states = state_scan_tokens(
+            fsm_info.transitions,
+            fsm_info.alphabet_symbol_mapping,
+            fsm_info.alphabet_anything_value,
+            fsm_info.initial,
+            fsm_info.finals,
+            vocabulary,
+            start_state,
+        )
+
+        for token_id_and_end_state in token_ids_end_states:
+            states_to_token_subsets.setdefault(start_state, set()).add(
+                token_id_and_end_state
+            )
+            end_state = token_id_and_end_state[1]
+            if end_state not in seen:
+                next_states.add(end_state)
+
+        seen.add(start_state)
+
+    return states_to_token_subsets
+
+
+# TODO: Cannot cache typed collections to disk, yet.  See
+# https://github.com/numba/numba/issues/4698
+@lru_cache
+def reduced_vocabulary(tokenizer):
+    vocabulary = {}
+    empty_token_ids = set()
+    for token, token_idx in tokenizer.vocabulary.items():
+        if token in tokenizer.special_tokens:
+            continue
+
+        token_str = tokenizer.convert_token_to_string(token)
+
+        if token_str:
+            vocabulary.setdefault(token_str, []).append(token_idx)
+        else:
+            empty_token_ids.add(token_idx)
+
+    return vocabulary, empty_token_ids
+
+
+def create_fsm_index_tokenizer(
+    fsm: BetterFSM,
+    tokenizer: "Tokenizer",
+) -> Tuple[Dict[int, Dict[int, int]], Set[int]]:
+    """Construct an FMS index from a tokenizer.
+
+    This uses the end-to-end approach of `create_fsm_index_end_to_end`.
+
+    .. warning::
+
+        `fsm` needs to be deterministically ordered so that future caching makes sense.
+
+    """
+    vocabulary, empty_token_ids = reduced_vocabulary(tokenizer)
+
+    states_to_token_subsets = create_fsm_index_end_to_end(fsm.fsm_info, vocabulary)
+
+    # Allow transitions to EOS from all terminals FSM states that are
+    # reachable
+    # TODO: Do we really need this anymore?
+    for state in fsm.fsm_info.finals:
+        subset = states_to_token_subsets.get(state)
+        if subset is not None:
+            subset.add((tokenizer.eos_token_id, state))
+
+    # Convert to token-to-end-state maps
+    states_to_token_subsets = {k: dict(v) for k, v in states_to_token_subsets.items()}
+
+    return states_to_token_subsets, empty_token_ids

--- a/outlines/generate/__init__.py
+++ b/outlines/generate/__init__.py
@@ -1,1 +1,8 @@
-from .api import cfg, choice, format, json, regex, text
+import torch
+if torch.backends.mps.is_available():
+    from .api_mlx import cfg, choice, format, json, regex, text
+else: 
+    from .api import cfg, choice, format, json, regex, text
+
+
+

--- a/outlines/generate/api_mlx.py
+++ b/outlines/generate/api_mlx.py
@@ -1,0 +1,253 @@
+import json as pyjson
+from typing import Callable, Iterator, List, Optional, Union
+
+from pydantic import BaseModel
+import mlx.core as mx
+from outlines.fsm.fsm import CFGFSM, FSMState, RegexFSM, StopAtTokenFSM
+from outlines.fsm.json_schema import build_regex_from_object, get_schema_from_signature
+from outlines.fsm.types import python_types_to_regex
+from outlines.generate.generator_mlx import (
+    init_generator_state,
+    sequence_generator,
+    token_generator,
+)
+from outlines.generate.samplers_mlx import Sampler_mlx, multinomial_mlx
+
+
+class SequenceGenerator:
+    def __init__(self, fsm, model, sampler):
+        self.generate_token = token_generator(model, sampler)
+        self.fsm = fsm
+        self.tokenizer = model.tokenizer
+
+    def format_sequence(self, sequence):
+        return sequence
+
+    def __call__(
+        self,
+        prompts: Union[str, List[str]],
+        rng: Optional[mx.array] = None,
+        kv_cache: Optional[mx.array] = None,
+    ) -> Union[str, List[str]]:
+        """Generate the full text sequence.
+
+        Since `SequenceGenerator.stream` calls the tokenizer at every step this
+        method loops over the generator returned by `sequence_generator` itself
+        so the tokenizer is called only once after all token ids have been
+        generated.
+
+        Parameters
+        ----------
+        prompts
+            A string or list of strings that are passed to the model before
+            generating the first token.
+        kv_cache
+            A tensor containing the past key-value cache. It can be for instance
+            used when we are interleaving prompting and model calls. Defaults to
+            `None`.
+        
+        rng
+            The random number generator key: #TODO
+
+        Returns
+        -------
+        A string or list of strings that contain the generated text.
+
+        """
+        
+
+
+
+        self.fsm.reset()
+
+        if isinstance(prompts, str):
+            prompts = [prompts]
+
+        if rng is None:
+            rng = mx.random.key(0)
+
+        init_state = init_generator_state(
+            self.tokenizer, prompts, kv_cache
+        )
+        num_sequences = len(prompts)
+        init_fsm_states = [FSMState(0) for _ in range(num_sequences)]
+
+        states = sequence_generator(
+            self.generate_token, self.fsm, init_state, init_fsm_states, rng
+        )
+
+        while True:
+            try:
+                last_state = next(states)
+            except StopIteration:
+                break
+
+        # Get the number of tokens in the prompts
+        prompt_token_ids = init_state[0]
+        prompt_lengths = [len(prompt_token_ids[i]) for i in range(len(prompts))]
+
+        # Remove the prompts from the generated sequences
+        token_ids = [
+            cur_token_ids[length:]
+            for cur_token_ids, length in zip(last_state.token_ids, prompt_lengths)
+        ]
+
+        generated = self.tokenizer.decode(token_ids)
+        formatted = [self.format_sequence(sequence) for sequence in generated]
+
+        return formatted if len(formatted) > 1 else formatted[0]
+
+    def stream(
+        self,
+        prompts: Union[str, List[str]],
+        rng: Optional[mx.array] = None,
+        kv_cache: Optional[mx.array] = None,
+    ) -> Iterator[Union[List[str], str]]:
+        """Generate the text sequence one token at a time.
+
+        Since `Tokenizer.decode` strips the whitespaces from the tokens we have no
+        choice but to decode the generated token ids at each step and compare the
+        current decoded strings to the previously decoded strings.
+
+        Parameters
+        ----------
+        prompts
+            A string or list of strings that are passed to the model before
+            generating the first token.
+        kv_cache
+            A tensor containing the past key-value cache. It can be for instance
+            used when we are interleaving prompting and model calls. Defaults to
+            `None`.
+
+        rng
+            The random number generator #TODO
+
+        Returns
+        -------
+        A string or list of strings that contain the generated text.
+
+        """
+
+        self.fsm.reset()
+
+        init_state = init_generator_state(
+            self.tokenizer, prompts, kv_cache
+        )
+
+        if rng is None:
+            rng = mx.random.key(0)
+
+        token_ids = init_state[1]
+        num_sequences = token_ids.shape[0]
+
+        init_fsm_states = [FSMState(0) for _ in range(num_sequences)]
+
+        states = sequence_generator(
+            self.generate_token, self.fsm, init_state, init_fsm_states, rng
+        )
+
+        def token_generator() -> Iterator[Union[List[str], str]]:
+            previously_generated_sequences = ["" for _ in range(num_sequences)]
+            num_generated = 0
+            while True:
+                try:
+                    sequence = next(states)
+                    num_generated += 1
+                except StopIteration:
+                    return
+
+                generated_token_ids = sequence.token_ids[:, -num_generated:]
+                generated_sequences = self.tokenizer.decode(generated_token_ids)
+                next_tokens = [
+                    token[len(sequence) :]
+                    for token, sequence in zip(
+                        generated_sequences, previously_generated_sequences
+                    )
+                ]
+                previously_generated_sequences = generated_sequences
+
+                yield next_tokens
+
+        return token_generator()
+
+
+
+def text(model, max_tokens: Optional[int] = None, *, sampler: Sampler_mlx = multinomial_mlx):
+    eos_token = model.tokenizer.eos_token_id
+    fsm = StopAtTokenFSM(model.tokenizer, eos_token, max_tokens)
+
+    generator = SequenceGenerator(fsm, model, sampler)
+
+    return generator
+
+
+def regex(
+    model,
+    regex_str: str,
+    max_tokens: Optional[int] = None,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    fsm = RegexFSM(regex_str, model.tokenizer, max_tokens)
+    generator = SequenceGenerator(fsm, model, sampler)
+    return generator
+
+
+def cfg(
+    model,
+    cfg_str: str,
+    max_tokens: Optional[int] = None,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    fsm = CFGFSM(cfg_str, model.tokenizer, max_tokens)
+
+    generator = SequenceGenerator(fsm, model, sampler)
+
+    return generator
+
+
+def format(
+    model, python_type, max_tokens: Optional[int] = None, sampler: Sampler_mlx = multinomial_mlx
+):
+    regex_str = python_types_to_regex(python_type)
+    return regex(model, regex_str, max_tokens, sampler)
+
+
+def choice(
+    model,
+    choices: List[str],
+    max_tokens: Optional[int] = None,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    regex_str = r"(" + r"|".join(choices) + r")"
+    return regex(model, regex_str, max_tokens, sampler)
+
+
+def json(
+    model,
+    schema_object: Union[str, object, Callable],
+    max_tokens: Optional[int] = None,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    if isinstance(schema_object, type(BaseModel)):
+        schema = pyjson.dumps(schema_object.model_json_schema())
+        regex_str = build_regex_from_object(schema)
+        generator = regex(model, regex_str, max_tokens, sampler)
+        generator.format_sequence = lambda x: schema_object.parse_raw(x)
+    elif callable(schema_object):
+        schema = pyjson.dumps(get_schema_from_signature(schema_object))
+        regex_str = build_regex_from_object(schema)
+        generator = regex(model, regex_str, max_tokens, sampler)
+        generator.format_sequence = lambda x: pyjson.loads(x)
+    elif isinstance(schema_object, str):
+        schema = schema_object
+        regex_str = build_regex_from_object(schema)
+        generator = regex(model, regex_str, max_tokens, sampler)
+        generator.format_sequence = lambda x: pyjson.loads(x)
+    else:
+        raise ValueError(
+            f"Cannot parse schema {schema_object}. The schema must be either "
+            + "a Pydantic object, a function or a string that contains the JSON "
+            + "Schema specification"
+        )
+    
+    return generator

--- a/outlines/generate/generator_mlx.py
+++ b/outlines/generate/generator_mlx.py
@@ -1,0 +1,288 @@
+import dataclasses
+import math
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Tuple, Union,Any
+
+import mlx.core as mx
+import numpy as np 
+
+from outlines.fsm.fsm import FSMState
+from time import time
+if TYPE_CHECKING:
+    from outlines.fsm.fsm import FSM
+    from outlines.generate.samplers_mlx import Sampler_mlx
+    from outlines.models.tokenizer import Tokenizer
+
+
+@dataclasses.dataclass(frozen=True)
+class GenerationState:
+    token_ids: mx.array
+    kv_cache: mx.array
+    logits: mx.array
+    fsm_states: List[FSMState]
+
+
+def init_generator_state(
+    tokenizer: "Tokenizer",
+    prompt: Union[str, List[str]],
+    kv_cache: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array, mx.array]:
+    """Initialize the generation state.
+
+    This method is responsible for encoding the prompt.
+
+    Parameters
+    ----------
+    prompt
+        The prompt on which the generation is conditioned.
+    
+    Returns
+    -------
+    A `GenerationState` object.
+
+    """
+    token_ids, attention_masks = tokenizer.encode(prompt)
+
+    return token_ids, attention_masks, kv_cache
+
+
+def sequence_generator(
+    token_generator: Callable,
+    fsm: "FSM",
+    init_state: Tuple[Any,Any,Any],
+    fsm_states: List[FSMState],
+    rng: mx.array
+) -> Iterator[GenerationState]:
+    """Generates sequences of tokens.
+
+    Parameters
+    ----------
+    token_generator
+        A callable that generate a new token given the current generation state
+        and logits biases.
+    fsm
+        The finite-state machine that drives the text generation.
+    init_state
+        The initial generation state for the batches.
+    fsm_states
+        The initial states of the finite-state machine for each sequence in the batch.
+    rng
+        The state of the random number generator.
+    Yields
+    ------
+    A new sequence.
+
+    """
+    token_ids, attention_masks, kv_cache = init_state
+    while True:
+        allowed_tokens = get_allowed_tokens(fsm, fsm_states)
+
+        next_token_ids, kv_cache, logits, _ = token_generator(
+            token_ids,
+            attention_masks,
+            kv_cache,
+            rng=rng,
+            allowed_tokens=allowed_tokens,
+        )
+
+        token_ids = update_token_ids(token_ids, next_token_ids)
+        attention_masks = expand_attention_masks(attention_masks)
+
+        fsm_states = get_next_fsm_states(fsm, fsm_states, next_token_ids)
+        is_finished = is_generation_finished(fsm, fsm_states)
+
+        if is_finished:
+            yield GenerationState(token_ids, kv_cache, logits, fsm_states)
+            return
+
+        yield GenerationState(token_ids, kv_cache, logits, fsm_states)
+
+
+def token_generator(model, sampler: "Sampler_mlx") -> Callable:
+    """Generate one token at a time.
+
+    This process is designed to be steered by another supervising
+    process that supplies the current sequence and the indices
+    of the tokens to mask before sampling.
+
+    Parameters
+    ----------
+    model
+        A model that takes a sequence of tokens as an input and
+        returns a probability distribution over the next tokens.
+    sampler
+        A function that samples tokens from a probability
+        distribution over the next tokens.
+
+    Returns
+    -------
+    A tuple that contains a tensor with the sampled tokens, a tensor with
+    the K-V cache for the sequence and the tensor that contains the next-token
+    logits that were returned by the model.
+
+    """
+    def generate(
+        token_ids: mx.array,
+        attention_masks: mx.array,
+        kv_cache: mx.array,
+        allowed_tokens: List[List[int]],
+        rng: mx.array,
+    ) -> Union[mx.array, mx.array, mx.array, mx.array]:
+        try:
+            logits, new_kv_cache = model(token_ids, attention_masks, kv_cache)
+        except IndexError:  # Exceeding the context length
+            raise IndexError(
+                "The input length exceeds the context length of the model."
+            )
+
+        biased_logits = bias_logits(logits, allowed_tokens)
+        #sampler to mlx
+        next_token_ids = sampler(biased_logits,1, rng)
+
+        return next_token_ids, new_kv_cache, logits, biased_logits
+
+    return generate
+
+
+def get_next_fsm_states(
+    fsm: "FSM", fsm_states: List[FSMState], next_token_ids: mx.array
+) -> List[FSMState]:
+    """
+
+    Parameters
+    ----------
+    fsm
+        The finite-state machine used to monitor this batch.
+    next_token_ids
+        The tokens that were just generated.
+
+    Returns
+    -------
+    A `mx.array` object that represents the next logit mask.
+
+    """
+    return [
+        fsm.next_state(fsm_state, int(np.array(token_id[0])), idx)
+        for idx, fsm_state, token_id in zip(
+            range(len(fsm_states)), fsm_states, next_token_ids
+        )
+    ]
+
+
+def get_allowed_tokens(fsm: "FSM", fsm_states: List[FSMState]) -> List[List[int]]:
+    """Get the new instructions for each sequence from the finite-state machine.
+
+    Parameters
+    ----------
+    fsm
+        The finite-state machine used to monitor this batch.
+    fsm_states
+        The FSM states corresponding to each sequence in the batch.
+
+    Returns
+    -------
+    A nested list that contains the ids of the logits to keep.
+
+    """
+    return [fsm.allowed_token_ids(state, idx) for idx, state in enumerate(fsm_states)]
+
+
+def is_generation_finished(fsm: "FSM", fsm_states: List[FSMState]) -> bool:
+    """Determine if the generation is finished.
+
+    A generation is considered finished if the FSM of every sequence in the
+    batch is in a final state.
+
+    A better solution is to return finished sequences as soon as their FSM
+    is in a final state.
+
+    Parameters
+    ----------
+    fsm
+        The finite-state machine used to monitor this batch.
+    fsm_states
+        The FSM states corresponding to each sequence in the batch.
+
+    Returns
+    -------
+    Whether all sequences are finished sampling.
+
+    """
+    return all([fsm.is_final_state(state, idx) for idx, state in enumerate(fsm_states)])
+
+
+def update_token_ids(
+    token_ids: mx.array, next_token_ids: mx.array
+) -> mx.array:
+    """Append the sampled tokens to the running sequence of tokens.
+
+    Parameters
+    ----------
+    token_ids
+        The current token sequences
+    next_token_ids
+        The tokens that were just generated and that we need to append
+        to the existing sequences.
+
+    Returns
+    -------
+    A new sequence of token ids that contains the tokens that were
+    just generated.
+
+    """
+    updated_token_ids = mx.concatenate([token_ids, next_token_ids], axis=-1)
+    return updated_token_ids
+
+
+def expand_attention_masks(attention_masks: mx.array) -> mx.array:
+    """Expand the attention masks.
+
+    Parameters
+    ----------
+    attention_masks
+        The attention masks for each sequence in the batch.
+
+    Returns
+    -------
+    The attention masks padded with 1s.
+
+    """
+    expanded_mask = mx.concatenate(
+        [
+            attention_masks,
+            mx.ones(
+                attention_masks.shape[:-1] + [1]
+            ),
+        ],
+        axis=-1,
+    )
+    return expanded_mask
+
+
+def bias_logits(
+    logits: mx.array,
+    ids_to_mask: List[List[int]],
+) -> mx.array:
+    """Mask the logits.
+
+    The function iterates over a nested list where each list corresponds to the
+    indices that need to be masked for each row in the array.
+
+    Parameters
+    ----------
+    logits
+        Two dimensional tensor that contains the next-token probability
+        distribution.
+    ids_to_mask
+        The ids to mask in each dimension.
+
+    Returns
+    -------
+    A view of the original logits tensor where some values are masked.
+
+    """
+    biased_logits = mx.zeros(logits.shape)
+    for i, ids in enumerate(mx.array(ids_to_mask)):
+        mask = mx.full((logits.shape[-1],), -math.inf)
+        mask[ids] = 0
+        biased_logits[i] = logits[i] + mask
+    return biased_logits

--- a/outlines/generate/samplers_mlx.py
+++ b/outlines/generate/samplers_mlx.py
@@ -1,0 +1,43 @@
+from typing import Protocol
+
+import mlx.core as mx
+
+
+class Sampler_mlx(Protocol):
+    def __call__(
+        self, logits: mx.array, samples: int, rng:mx.array, 
+    ) -> mx.array:
+        ...
+
+def multinomial_mlx(
+    logits: mx.array, samples: int,  rng:mx.array
+) -> mx.array:
+        """Multinomial sampling algorithm.
+
+        Multinomial sampling consists in randomly sampling the next token assuming
+        its distribution is a Categorical distribution parametrized by the
+        next-token logits.
+
+        Parameters
+        ----------
+        logits
+            A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
+            probability distribution of the next token over the vocabulary.
+        samples
+            The number of sequences to sample.
+        rng
+            A random number generator key. 
+            Can be seeded using: key = mx.random.key(seed_value)
+            (https://ml-explore.github.io/mlx/build/html/python/random.html)
+
+        Returns
+        -------
+        The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+
+        """
+        #key=rng,
+        #print("rng key:", rng)
+        #mx.random.seed(0)
+
+        next_token_ids = mx.random.categorical(logits=logits, num_samples = samples)
+        return next_token_ids

--- a/outlines/models/Phi2.py
+++ b/outlines/models/Phi2.py
@@ -1,0 +1,150 @@
+import argparse
+from typing import Optional
+from dataclasses import dataclass
+from mlx.utils import tree_unflatten
+from transformers import AutoTokenizer
+
+import mlx.core as mx
+import mlx.nn as nn
+import math
+from pathlib import Path
+
+@dataclass
+class ModelArgs:
+    max_sequence_length: int = 2048
+    num_vocab: int = 51200
+    model_dim: int = 2560
+    num_heads: int = 32
+    num_layers: int = 32
+    rotary_dim: int = 32
+
+
+class LayerNorm(nn.LayerNorm):
+    def __call__(self, x: mx.array) -> mx.array:
+        return super().__call__(x.astype(mx.float32)).astype(x.dtype)
+
+
+class RoPEAttention(nn.Module):
+    def __init__(self, dims: int, num_heads: int, rotary_dim: int):
+        super().__init__()
+
+        self.num_heads = num_heads
+
+        self.rope = nn.RoPE(rotary_dim, traditional=False)
+        self.Wqkv = nn.Linear(dims, 3 * dims)
+        self.out_proj = nn.Linear(dims, dims)
+
+    def __call__(self, x, mask=None, cache=None):
+        qkv = self.Wqkv(x)
+        queries, keys, values = mx.split(qkv, 3, axis=-1)
+
+        # Extract some shapes
+        num_heads = self.num_heads
+        B, L, D = queries.shape
+
+        # Prepare the queries, keys and values for the attention computation
+        queries = queries.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+
+        # Add RoPE to the queries and keys and combine them with the cache
+        if cache is not None:
+            key_cache, value_cache = cache
+            queries = self.rope(queries, offset=key_cache.shape[2])
+            keys = self.rope(keys, offset=key_cache.shape[2])
+            keys = mx.concatenate([key_cache, keys], axis=2)
+            values = mx.concatenate([value_cache, values], axis=2)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        queries = queries.astype(mx.float32)
+        keys = keys.astype(mx.float32)
+
+        # Finally perform the attention computation
+        scale = math.sqrt(1 / queries.shape[-1])
+        scores = (queries * scale) @ keys.transpose(0, 1, 3, 2)
+        if mask is not None:
+            scores = scores + mask
+
+        scores = mx.softmax(scores, axis=-1).astype(values.dtype)
+        values_hat = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.out_proj(values_hat), (keys, values)
+
+
+class ParallelBlock(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        dims = config.model_dim
+        mlp_dims = dims * 4
+        self.mixer = RoPEAttention(dims, config.num_heads, config.rotary_dim)
+        self.ln = LayerNorm(dims)
+        self.fc1 = nn.Linear(dims, mlp_dims)
+        self.fc2 = nn.Linear(mlp_dims, dims)
+        self.act = nn.GELU(approx="precise")
+
+    def __call__(self, x, mask, cache):
+        h = self.ln(x)
+        attn_h, cache = self.mixer(h, mask, cache)
+        ff_h = self.fc2(self.act(self.fc1(h)))
+        return attn_h + ff_h + x, cache
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.h = [ParallelBlock(config) for i in range(config.num_layers)]
+
+    def __call__(self, x, mask, cache):
+        if cache is None:
+            cache = [None] * len(self.h)
+
+        for e, layer in enumerate(self.h):
+            x, cache[e] = layer(x, mask, cache[e])
+        return x, cache
+
+
+class OutputHead(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        self.ln = LayerNorm(config.model_dim)
+        self.linear = nn.Linear(config.model_dim, config.num_vocab)
+
+    def __call__(self, inputs):
+        return self.linear(self.ln(inputs))
+
+
+class Phi2(nn.Module):
+    def __init__(self, config: ModelArgs):
+        self.wte = nn.Embedding(config.num_vocab, config.model_dim)
+        self.transformer = TransformerDecoder(config)
+        self.lm_head = OutputHead(config)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: mx.array = None,
+        cache: mx.array = None,
+    ) -> tuple[mx.array, mx.array]:
+        
+
+        x = self.wte(inputs)
+
+        mask = None
+        if x.shape[1] > 1:
+            mask = nn.MultiHeadAttention.create_additive_causal_mask(x.shape[1])
+            mask = mask.astype(x.dtype)
+
+        y, cache = self.transformer(x, mask, cache)
+        
+        return self.lm_head(y), cache
+
+def load_model(model_name: str):
+
+    model = Phi2(ModelArgs())
+    model_path = "/Users/sachaichbiah/Documents/CARGOHUB/mlx-examples/phi2/"
+    model_path = Path(model_path)
+    weights = mx.load(str(model_path / "weights.npz"))
+    model.update(tree_unflatten(list(weights.items())))
+
+    return model

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -5,6 +5,7 @@ completion, diffusers, etc.) and use routing functions everywhere else in the
 codebase.
 
 """
+from .mlx import MLX, mlx
 from .awq import awq
 from .gptq import gptq
 from .mamba import Mamba, mamba

--- a/outlines/models/llama.py
+++ b/outlines/models/llama.py
@@ -1,0 +1,305 @@
+# Copyright © 2023 Apple Inc.
+
+import argparse
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_unflatten
+from sentencepiece import SentencePieceProcessor
+from transformers import AutoTokenizer
+
+@dataclass
+class ModelArgs:
+    dim: int
+    n_layers: int
+    head_dim: int
+    hidden_dim: int
+    n_heads: int
+    n_kv_heads: int
+    norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    rope_traditional: bool = True
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dims: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = mx.ones((dims,))
+        self.eps = eps
+
+    def _norm(self, x):
+        return x * mx.rsqrt(x.square().mean(-1, keepdims=True) + self.eps)
+
+    def __call__(self, x):
+        output = self._norm(x.astype(mx.float32)).astype(x.dtype)
+        return self.weight * output
+
+
+class RoPE(nn.RoPE):
+    def __init__(self, dims: int, traditional: bool = False, base: float = 10000):
+        super().__init__(dims, traditional)
+        self.base = base
+
+    def __call__(self, x, offset: int = 0):
+        shape = x.shape
+        x = mx.reshape(x, (-1, shape[-2], shape[-1]))
+        N = x.shape[1] + offset
+        costheta, sintheta = RoPE.create_cos_sin_theta(
+            N, self.dims, offset=offset, base=self.base, dtype=x.dtype
+        )
+
+        rope = (
+            self._compute_traditional_rope if self.traditional else self._compute_rope
+        )
+        rx = rope(costheta, sintheta, x)
+
+        return mx.reshape(rx, shape)
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+
+        self.n_heads: int = args.n_heads
+        self.n_kv_heads: int = args.n_kv_heads
+
+        self.repeats = self.n_heads // self.n_kv_heads
+
+        self.scale = self.args.head_dim**-0.5
+
+        self.wq = nn.Linear(args.dim, args.n_heads * args.head_dim, bias=False)
+        self.wk = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wv = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wo = nn.Linear(args.n_heads * args.head_dim, args.dim, bias=False)
+        self.rope = RoPE(
+            args.head_dim, traditional=args.rope_traditional, base=args.rope_theta
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Tuple[mx.array, mx.array]] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.wq(x), self.wk(x), self.wv(x)
+
+        # Prepare the queries, keys and values for the attention computation
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        def repeat(a):
+            a = mx.concatenate([mx.expand_dims(a, 2)] * self.repeats, axis=2)
+            return a.reshape([B, self.n_heads, L, -1])
+
+        keys, values = map(repeat, (keys, values))
+
+        if cache is not None:
+            key_cache, value_cache = cache
+            queries = self.rope(queries, offset=key_cache.shape[2])
+            keys = self.rope(keys, offset=key_cache.shape[2])
+            keys = mx.concatenate([key_cache, keys], axis=2)
+            values = mx.concatenate([value_cache, values], axis=2)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        scores = (queries * self.scale) @ keys.transpose(0, 1, 3, 2)
+        if mask is not None:
+            scores += mask
+        scores = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
+        output = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.wo(output), (keys, values)
+
+
+class FeedForward(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+
+        self.w1 = nn.Linear(args.dim, args.hidden_dim, bias=False)
+        self.w2 = nn.Linear(args.hidden_dim, args.dim, bias=False)
+        self.w3 = nn.Linear(args.dim, args.hidden_dim, bias=False)
+
+    def __call__(self, x) -> mx.array:
+        return self.w2(nn.silu(self.w1(x)) * self.w3(x))
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.n_heads = args.n_heads
+        self.dim = args.dim
+        self.attention = Attention(args)
+        self.feed_forward = FeedForward(args=args)
+        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.args = args
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Tuple[mx.array, mx.array]] = None,
+    ) -> mx.array:
+        r, cache = self.attention(self.attention_norm(x), mask, cache)
+        h = x + r
+        r = self.feed_forward(self.ffn_norm(h))
+        out = h + r
+        return out, cache
+
+"""
+class Llama(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.tok_embeddings = nn.Embedding(args.vocab_size, args.dim)
+        self.layers = [TransformerBlock(args=args) for _ in range(args.n_layers)]
+        self.norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.output = nn.Linear(args.dim, args.vocab_size, bias=False)
+
+    def __call__(self, 
+                 inputs: mx.array,
+                 mask: mx.array = None,
+                 cache: mx.array = None,
+                 ) -> tuple[mx.array, mx.array]:
+        
+        mask = None
+        if x.shape[1] > 1:
+            mask = nn.MultiHeadAttention.create_additive_causal_mask(x.shape[1])
+            mask = mask.astype(self.tok_embeddings.weight.dtype)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        for e, layer in enumerate(self.layers):
+            x, cache[e] = layer(x, mask, cache[e])
+
+        for l in self.layers:
+            x, cache[i] = l(x, mask, cache=cache[i])
+
+        = self.layers[i](x, mask=None, 
+        x = self.norm(x)
+        return self.output(x)"""
+class Llama(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.tok_embeddings = nn.Embedding(args.vocab_size, args.dim)
+        self.layers = [TransformerBlock(args=args) for _ in range(args.n_layers)]
+        self.norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.output = nn.Linear(args.dim, args.vocab_size, bias=False)
+
+    def __call__(self, 
+                 inputs: mx.array,
+                 mask: mx.array = None,
+                 cache: mx.array = None,
+                 ) -> tuple[mx.array, mx.array]:
+        
+        x = self.tok_embeddings(inputs)
+        mask = None
+        if x.shape[1] > 1:
+            mask = nn.MultiHeadAttention.create_additive_causal_mask(x.shape[1])
+            mask = mask.astype(self.tok_embeddings.weight.dtype)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        for e, layer in enumerate(self.layers):
+            x, cache[e] = layer(x, mask, cache[e])
+        x = self.norm(x)
+        return self.output(x), cache
+
+    def generate(self, x, temp=1.0):
+        cache = []
+
+        # Make an additive causal mask. We will need that to process the prompt.
+        mask = nn.MultiHeadAttention.create_additive_causal_mask(x.shape[1])
+        mask = mask.astype(self.tok_embeddings.weight.dtype)
+
+        # First we process the prompt x the same was as in __call__ but
+        # save the caches in cache
+        x = self.tok_embeddings(x)
+        for l in self.layers:
+            x, c = l(x, mask=mask)
+            # We store the per layer cache in a simple python list
+            cache.append(c)
+        x = self.norm(x)
+        # We only care about the last logits that generate the next token
+        y = self.output(x[:, -1])
+        y = mx.random.categorical(y * (1 / temp))
+
+        # y now has size [1]
+        # Since MLX is lazily evaluated nothing is computed yet.
+        # Calling y.item() would force the computation to happen at
+        # this point but we can also choose not to do that and let the
+        # user choose when to start the computation.
+        yield y
+
+        # Now we parsed the prompt and generated the first token we
+        # need to feed it back into the model and loop to generate the
+        # rest.
+        while True:
+            # Unsqueezing the last dimension to add a sequence length
+            # dimension of 1
+            x = y[:, None]
+
+            x = self.tok_embeddings(x)
+            for i in range(len(cache)):
+                # We are overwriting the arrays in the cache list. When
+                # the computation will happen, MLX will be discarding the
+                # old cache the moment it is not needed anymore.
+                x, cache[i] = self.layers[i](x, mask=None, cache=cache[i])
+            x = self.norm(x)
+            y = self.output(x[:, -1])
+            y = mx.random.categorical(y * (1 / temp))
+
+            yield y
+
+
+def tic():
+    return time.time()
+
+
+def toc(msg, start):
+    end = time.time()
+    return f"[INFO] {msg}: {end - start:.3f} s"
+
+
+def load_model(model_name:str):
+    model_path_dict = {"TinyLlama/TinyLlama-1.1B-Chat-v0.6":"/Users/sachaichbiah/Documents/CARGOHUB/mlx-examples/llama/mlx_model"}
+    model_path = model_path_dict[model_name]
+
+    model_path = Path(model_path)
+    weights = mx.load(str(model_path / "weights.npz"))
+    with open(model_path / "config.json", "r") as f:
+        config = json.loads(f.read())
+        config.pop("model_type", None)
+        n_heads = config["n_heads"]
+        if "n_kv_heads" not in config:
+            config["n_kv_heads"] = n_heads
+        if "head_dim" not in config:
+            config["head_dim"] = config["dim"] // n_heads
+        if "hidden_dim" not in config:
+            config["hidden_dim"] = weights["layers.0.feed_forward.w1.weight"].shape[0]
+        if config.get("vocab_size", -1) < 0:
+            config["vocab_size"] = weights["output.weight"].shape[-1]
+        if "rope_theta" not in config:
+            config["rope_theta"] = 10000
+        unused = ["multiple_of", "ffn_dim_multiplier"]
+        for k in unused:
+            if k in config:
+                config.pop(k)
+    model = Llama(ModelArgs(**config))
+    model.update(tree_unflatten(list(weights.items())))
+    return model

--- a/outlines/models/mlx.py
+++ b/outlines/models/mlx.py
@@ -206,15 +206,25 @@ def mlx(
     A `MLXModel` model instance.
 
     """
+
+    complete_model_kwargs = {
+        'quantize': False,
+        'q_group_size': 64,
+        'q_bits': 4,
+        'force_conversion':False
+    }
+
+    # Update default values with any provided arguments
+    complete_model_kwargs.update(model_kwargs)
     
     if model_name == "microsoft/phi-2":
         from outlines.models.mlx_models.Phi2 import load_model
-        model = load_model(model_name)
+        model = load_model(model_name,**complete_model_kwargs)
         tokenizer_kwargs['trust_remote_code']=True
         tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
     elif model_name =="TinyLlama/TinyLlama-1.1B-Chat-v0.6":
         from outlines.models.mlx_models.tiny_llama import load_model
-        model = load_model(model_name)
+        model = load_model(model_name,**complete_model_kwargs)
         tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
     elif model_name =="mistral/7B":
         return NotImplementedError("Mistral is not implemented yet")

--- a/outlines/models/mlx.py
+++ b/outlines/models/mlx.py
@@ -208,16 +208,16 @@ def mlx(
     """
     
     if model_name == "microsoft/phi-2":
-        from outlines.models.Phi2 import load_model
+        from outlines.models.mlx_models.Phi2 import load_model
         model = load_model(model_name)
         tokenizer_kwargs['trust_remote_code']=True
         tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
-    elif model_name =="mistral/7B":
-        return NotImplementedError("Mistral is not implemented yet")
     elif model_name =="TinyLlama/TinyLlama-1.1B-Chat-v0.6":
-        from outlines.models.llama import load_model
+        from outlines.models.mlx_models.tiny_llama import load_model
         model = load_model(model_name)
         tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
+    elif model_name =="mistral/7B":
+        return NotImplementedError("Mistral is not implemented yet")
     else: 
         return NotImplementedError("Unknown model")
 

--- a/outlines/models/mlx.py
+++ b/outlines/models/mlx.py
@@ -1,0 +1,230 @@
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union, Any
+
+
+from outlines.models.tokenizer import Tokenizer
+if TYPE_CHECKING:
+    from transformers import PreTrainedModel, PreTrainedTokenizer
+import mlx.core as mx
+import numpy as np 
+from mlx.utils import tree_unflatten
+from transformers import AutoTokenizer
+
+__all__ = ["transformers"]
+
+ModelType = Any
+
+
+
+def get_llama_tokenizer_types():
+    """Get all the Llama tokenizer types/classes that need work-arounds.
+
+    When they can't be imported, a dummy class is created.
+
+    """
+    try:
+        from transformers.models.llama import LlamaTokenizer
+    except ImportError:
+
+        class LlamaTokenizer:  # type: ignore
+            pass
+
+    try:
+        from transformers.models.llama import LlamaTokenizerFast
+    except ImportError:
+
+        class LlamaTokenizerFast:  # type: ignore
+            pass
+
+    try:
+        from transformers.models.code_llama import CodeLlamaTokenizer
+    except ImportError:
+
+        class CodeLlamaTokenizer:  # type: ignore
+            pass
+
+    try:
+        from transformers.models.code_llama import CodeLlamaTokenizerFast
+    except ImportError:
+
+        class CodeLlamaTokenizerFast:  # type: ignore
+            pass
+
+    return (
+        LlamaTokenizer,
+        LlamaTokenizerFast,
+        CodeLlamaTokenizer,
+        CodeLlamaTokenizerFast,
+    )
+
+class MLX:
+    """Represents a MLX model."""
+
+    def __init__(
+        self,
+        model: ModelType,
+        tokenizer: "PreTrainedTokenizer",
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+
+    def forward(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array,
+        past_key_values: mx.array,
+    ) -> Tuple[mx.array, Optional[mx.array]]:
+        """Compute a forward pass through the transformer model.
+
+        Parameters
+        ----------
+        input_ids
+            The input token ids.  Must be one or two dimensional.
+        attention_mask
+            The attention mask.  Must be one or two dimensional.
+        past_key_values
+            A tuple of tuples containing the cached key and value tensors for each
+            attention head.
+
+        Returns
+        -------
+        The computed logits and the new cached key and value tensors.
+
+        """
+        assert 0 < input_ids.ndim < 3
+
+        if past_key_values:
+            input_ids = input_ids[..., -1][...,None]
+
+        #print("Shape input ids", input_ids.shape)
+
+        logits, kv_cache = self.model(
+            input_ids,
+            cache=past_key_values,
+        )
+
+        return logits, kv_cache
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array,
+        past_key_values: Optional[mx.array] = None,
+    ) -> Tuple[mx.array, mx.array]:
+        logits, kv_cache = self.forward(input_ids,None, past_key_values)
+        next_token_logits = logits[..., -1, :]
+
+        return next_token_logits, kv_cache
+
+
+
+class TransformerTokenizer(Tokenizer):
+    """Represents a tokenizer for models in the `transformers` library."""
+
+    def __init__(self, model_name: str, **kwargs):
+        from transformers import AutoTokenizer
+
+        kwargs.setdefault("padding_side", "left")
+        self.model_name = model_name
+        # TODO: Do something to make this hashable?
+        self.kwargs = kwargs
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+        self.eos_token_id = self.tokenizer.eos_token_id
+        self.eos_token = self.tokenizer.eos_token
+
+        if not self.tokenizer.pad_token_id:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+            self.pad_token_id = self.eos_token_id
+        else:
+            self.pad_token_id = self.tokenizer.pad_token_id
+            self.pad_token = self.tokenizer.pad_token
+
+        self.special_tokens = set(self.tokenizer.all_special_tokens)
+
+        self.vocabulary = self.tokenizer.get_vocab()
+        self.is_llama = isinstance(self.tokenizer, get_llama_tokenizer_types())
+
+    def encode(
+        self, prompt: Union[str, List[str]], **kwargs
+    ) -> Tuple[mx.array, mx.array]:
+        kwargs["padding"] = True 
+        kwargs["return_tensors"] = "np"
+        output = self.tokenizer(prompt, **kwargs)
+        return mx.array(output["input_ids"]), mx.array(output["attention_mask"])
+
+    def decode(self, token_ids: mx.array) -> List[str]:
+        text = self.tokenizer.batch_decode(np.array(token_ids), skip_special_tokens=True)
+        return text
+
+    def convert_token_to_string(self, token: str) -> str:
+        from transformers.file_utils import SPIECE_UNDERLINE
+
+        string = self.tokenizer.convert_tokens_to_string([token])
+
+        if self.is_llama:
+            # A hack to handle missing spaces to HF's Llama tokenizers
+            if token.startswith(SPIECE_UNDERLINE) or token == "<0x20>":
+                return " " + string
+
+        return string
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return other.model_name == self.model_name and other.kwargs == self.kwargs
+        return NotImplemented
+
+    def __hash__(self):
+        from datasets.fingerprint import Hasher
+
+        return hash(Hasher.hash(self.tokenizer))
+
+
+def mlx(
+    model_name: str,
+    device: Optional[str] = None,
+    model_kwargs: dict = {},
+    tokenizer_kwargs: dict = {},  
+):
+    
+    """Instantiate a model from a predefined set of models and its tokenizer from 'transformers'.
+
+    Parameters
+    ----------
+    model_name
+        The name of the model as listed on Hugging Face's model page.
+    device
+        The device(s) on which the model should be loaded. This overrides
+        the `device_map` entry in `model_kwargs` when provided.
+    model_kwargs
+        A dictionary that contains the keyword arguments to pass to the
+        `from_pretrained` method when loading the model.
+    tokenizer_kwargs
+        A dictionary that contains the keyword arguments to pass to the
+        `from_pretrained` method when loading the tokenizer.
+
+    Returns
+    -------
+    A `MLXModel` model instance.
+
+    """
+    
+    if model_name == "microsoft/phi-2":
+        from outlines.models.Phi2 import load_model
+        model = load_model(model_name)
+        tokenizer_kwargs['trust_remote_code']=True
+        tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
+    elif model_name =="mistral/7B":
+        return NotImplementedError("Mistral is not implemented yet")
+    elif model_name =="TinyLlama/TinyLlama-1.1B-Chat-v0.6":
+        from outlines.models.llama import load_model
+        model = load_model(model_name)
+        tokenizer = TransformerTokenizer(model_name, **tokenizer_kwargs)
+    else: 
+        return NotImplementedError("Unknown model")
+
+
+    return MLX(model, tokenizer)
+
+
+
+
+

--- a/outlines/text/generate/__init__.py
+++ b/outlines/text/generate/__init__.py
@@ -1,1 +1,5 @@
-from .api import choice, continuation, format, json, regex
+import torch
+if torch.backends.mps.is_available():
+    from .api_mlx import choice, continuation, format, json, regex
+else: 
+    from .api import choice, continuation, format, json, regex

--- a/outlines/text/generate/api_mlx.py
+++ b/outlines/text/generate/api_mlx.py
@@ -1,0 +1,82 @@
+import warnings
+from typing import Callable, List, Optional, Union
+
+import outlines
+from outlines.generate.samplers_mlx import Sampler_mlx, multinomial_mlx
+
+
+def json(
+    model,
+    schema_object: Union[str, object, Callable],
+    max_tokens: Optional[int] = None,
+    *,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    warnings.warn(
+        "`outlines.text.generate.json` is deprecated, please use `outlines.generate.json` instead. "
+        "The old import path will be removed in Outlines v0.1.0.",
+        DeprecationWarning,
+    )
+    return outlines.generate.json(model, schema_object, max_tokens, sampler=sampler)
+
+
+def regex(
+    model,
+    regex_str: str,
+    max_tokens: Optional[int] = None,
+    *,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    warnings.warn(
+        "`outlines.text.generate.regex` is deprecated, please use `outlines.generate.regex` instead. "
+        "The old import path will be removed in Outlines v0.1.0.",
+        DeprecationWarning,
+    )
+    return outlines.generate.regex(model, regex_str, max_tokens, sampler=sampler)
+
+
+def format(
+    model, python_type, max_tokens: Optional[int] = None, sampler: Sampler_mlx = multinomial_mlx
+):
+    warnings.warn(
+        "`outlines.text.generate.format` is deprecated, please use `outlines.generate.format` instead. "
+        "The old import path will be removed in Outlines v0.1.0.",
+        DeprecationWarning,
+    )
+    return outlines.generate.format(model, python_type, max_tokens, sampler=sampler)
+
+
+def continuation(
+    model,
+    max_tokens: Optional[int] = None,
+    *,
+    sampler: Sampler_mlx = multinomial_mlx,
+    stop: Optional[Union[str, List[str]]] = None,
+):
+    warnings.warn(
+        "`outlines.text.generate.continuation` is deprecated, please use `outlines.generate.text` instead. "
+        "The old import path will be removed in Outlines v0.1.0.",
+        DeprecationWarning,
+    )
+    if stop is not None:
+        raise NotImplementedError(
+            "The `stop` keyword is unavailable in the updated API. Please open an issue "
+            " at https://github.com/outlines-dev/outlines/issues if you need it implemented."
+        )
+
+    return outlines.generate.text(model, max_tokens, sampler=sampler)
+
+
+def choice(
+    model,
+    choices: List[str],
+    max_tokens: Optional[int] = None,
+    *,
+    sampler: Sampler_mlx = multinomial_mlx,
+):
+    warnings.warn(
+        "`outlines.text.generate.choice` is deprecated, please use `outlines.generate.choice` instead. "
+        "The old import path will be removed in Outlines v0.1.0.",
+        DeprecationWarning,
+    )
+    return outlines.generate.choice(model, choices, max_tokens, sampler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "outlines"
+version = "0.0.22"
 authors= [{name = "Outlines Developers"}]
 description = "Probabilistic Generative Model Programming"
 requires-python = ">=3.8"
@@ -38,7 +39,6 @@ dependencies = [
    "jsonschema",
    "requests",
 ]
-dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
@@ -53,7 +53,6 @@ test = [
     "datasets",
     "responses",
 ]
-serve = ["vllm"]
 
 [project.urls]
 homepage = "https://github.com/outlines-dev/outlines"
@@ -70,8 +69,6 @@ packages = ["outlines"]
 [tool.setuptools.package-data]
 "outlines" = ["py.typed"]
 
-[tool.setuptools_scm]
-write_to = "outlines/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -103,7 +100,7 @@ module = [
     "referencing.*",
     "scipy.*",
     "tiktoken.*",
-    "torch.*",
+    "torch",
     "transformers.*",
     "lark.*",
     "interegular.*",
@@ -111,9 +108,6 @@ module = [
     "numba.*",
     "requests.*",
     "responses.*",
-    "vllm.*",
-    "uvicorn.*",
-    "fastapi.*",
 ]
 ignore_missing_imports = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,10 @@ per-file-ignores =
     **/__init__.py:F401,F403
 exclude =
     normalai/_version.py
+
+
+[options]
+include_package_data = True
+package_dir =
+    = ./
+


### PR DESCRIPTION
Loading transformers model uses PyTorch backend. In theory, PyTorch has a mps backend support, but for a reason or another, the backend integration is bad and the models are really slow to run. I am using instead the new mlx library to run some models with outlines on my M1 Pro 16Go, and it works like a charm. 

I lack memory to convert and use Mistral7B, but it should work as well. 
I have only implemented TinyLlama-1.1B-Chat-v0.6 and microsoft/phi-2.

Some resources: 

I took the llms architectures on MLX from the following repo: 
https://github.com/ml-explore/mlx-examples/tree/main
https://github.com/ml-explore/mlx

I love outlines, I love mlx, I just want to merge together two libraries I love. 