### PR TITLE
Do not import `transformers` at top level in Exllama2 integration

### DIFF
--- a/outlines/models/exllamav2.py
+++ b/outlines/models/exllamav2.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
 import torch
-from transformers import PreTrainedTokenizer
 
 from .transformers import TransformerTokenizer
 
 if TYPE_CHECKING:
     from exllamav2 import ExLlamaV2, ExLlamaV2Cache
+    from transformers import PreTrainedTokenizer
 
 
 class ExLlamaV2Model:


### PR DESCRIPTION
The Exllama2 integration currently imports `transformers` at the top level, when it's only needed for type checking. This will raise exceptions for anyone using the library with no intention to use `transformers` models.