### PR TITLE
wip: support empty and recursive schemas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,5 @@ repos:
   rev: v1.2.0
   hooks:
     - id: mypy
-      args: [--allow-redefinition]
+      args: [--allow-redefinition, --install-types]
       exclude: ^examples/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,5 @@ repos:
   rev: v1.2.0
   hooks:
     - id: mypy
-      args: [--allow-redefinition, --install-types]
+      args: [--allow-redefinition, --install-types, --non-interactive]
       exclude: ^examples/

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -2,7 +2,7 @@ import inspect
 import itertools as it
 import json
 import re
-from typing import Any, Callable, Type, Union
+from typing import Any, Callable, Optional, Type, Union
 
 from jsonschema.protocols import Validator
 from jsonschema.validators import validator_for
@@ -103,7 +103,7 @@ def build_regex_from_object(
     return to_regex(resolver, content)
 
 
-def to_regex(resolver: None | Resolver, instance: Schema) -> str:
+def to_regex(resolver: Optional[Resolver], instance: Schema) -> str:
     """Translate a JSON Schema instance into a regex that validates the schema.
 
     Note
@@ -133,7 +133,7 @@ def to_regex(resolver: None | Resolver, instance: Schema) -> str:
     class Regex(str):
         pass
 
-    definitions: dict[str, Path | Regex] = {
+    definitions: dict[str, Union[Path, Regex]] = {
         name: Regex(regex) for name, regex in DEFINITIONS.items()
     }
 

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -11,7 +11,6 @@ from referencing import Registry, Resource
 from referencing._core import Resolver
 from referencing.jsonschema import DRAFT202012, Schema
 
-
 DEFINITIONS = {
     "__whitespace__": r"(?:[ \t\n\r]*)",
     "__json_object__": r"\{\s*(?&__members__)?\s*\}",

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -2,20 +2,41 @@ import inspect
 import itertools as it
 import json
 import re
-from typing import Callable, Union
+from typing import Any, Callable, Type, Union
 
 from jsonschema.protocols import Validator
+from jsonschema.validators import validator_for
 from pydantic import BaseModel, create_model
 from referencing import Registry, Resource
 from referencing._core import Resolver
-from referencing.jsonschema import DRAFT202012
+from referencing.jsonschema import DRAFT202012, Schema
 
-STRING_INNER = r'(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)'
-STRING = f'"{STRING_INNER}*"'
-INTEGER = r"(0|[1-9][0-9]*)"
-NUMBER = rf"(-)?({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"
-BOOLEAN = r"(true|false)"
-NULL = r"null"
+
+DEFINITIONS = {
+    "__whitespace__": r"(?:[ \t\n\r]*)",
+    "__json_object__": r"\{\s*(?&__members__)?\s*\}",
+    "__members__": r"(?&__member__)(\s*,\s*(?&__member__))*",
+    "__member__": r"(?&__string__)\s*:\s*(?&__json_value__)",
+    "__json_array__": r"\[\s*((?&__json_value__)(\s*,\s*(?&__json_value__))*)?\s*\]",
+    "__string_inner__": r"""(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)""",
+    "__string__": r'"(?&__string_inner__)*"',
+    "__number__": r"(?&__integer__)(?&__fraction__)?(?&__exponent__)?",
+    "__integer__": r"-?(?:0|[1-9][0-9]*)",
+    "__fraction__": r"\.[0-9]*",
+    "__exponent__": r"[eE][-+]?[0-9]+",
+    "__boolean__": r"true|false",
+    "__null__": r"null",
+    "__json_value__": r"(?&__string__)|(?&__number__)|(?&__json_object__)|(?&__json_array__)|(?&__boolean__)|(?&__null__)",
+}
+
+WHITESPACE = r"(?&__whitespace__)"
+STRING_INNER = r"(?&__string_inner__)"
+STRING = r"(?&__string__)"
+INTEGER = r"(?&__integer__)"
+NUMBER = r"(?&__number__)"
+BOOLEAN = r"(?&__boolean__)"
+NULL = r"(?&__null__)"
+JSON_VALUE = r"(?&__json_value__)"
 
 type_to_regex = {
     "string": STRING,
@@ -26,7 +47,9 @@ type_to_regex = {
 }
 
 
-def build_regex_from_object(object: Union[str, Callable, BaseModel]):
+def build_regex_from_object(
+    object: Union[str, Callable, BaseModel, Type[BaseModel]]
+) -> str:
     """Turn a JSON schema into a regex that matches any JSON object that follows
     this schema.
 
@@ -41,7 +64,8 @@ def build_regex_from_object(object: Union[str, Callable, BaseModel]):
     Parameters
     ----------
     schema
-        A string that represents a JSON Schema.
+        A JSON schema or a Python object that can be converted to a JSON schema.
+        See [0] for more information.
 
     Returns
     -------
@@ -55,26 +79,32 @@ def build_regex_from_object(object: Union[str, Callable, BaseModel]):
 
     """
 
-    if isinstance(object, type(BaseModel)):
+    # Extract the schema from the object
+    schema: Schema
+    if isinstance(object, BaseModel):
+        schema = object.model_json_schema()
+    elif isinstance(object, type) and issubclass(object, BaseModel):
         schema = object.model_json_schema()
     elif callable(object):
         schema = get_schema_from_signature(object)
     else:
         schema = json.loads(object)
 
-    Validator.check_schema(schema)
+    # Validate the schema against the JSON Schema specification
+    validator: Validator = validator_for(schema)
+    validator.check_schema(schema)  # type: ignore
 
     # Build reference resolver
-    schema = Resource(contents=schema, specification=DRAFT202012)
-    uri = schema.id() if schema.id() is not None else ""
-    registry = Registry().with_resource(uri=uri, resource=schema)
+    resource = Resource(contents=schema, specification=DRAFT202012)
+    uri = resource.id() or ""
+    registry = Registry().with_resource(uri=uri, resource=resource)
     resolver = registry.resolver()
 
-    content = schema.contents
+    content = resource.contents
     return to_regex(resolver, content)
 
 
-def to_regex(resolver: Resolver, instance: dict):
+def to_regex(resolver: None | Resolver, instance: Schema) -> str:
     """Translate a JSON Schema instance into a regex that validates the schema.
 
     Note
@@ -97,158 +127,180 @@ def to_regex(resolver: Resolver, instance: dict):
     instance
         The instance to translate
     """
-    whitespace = r"[\n ]*"
 
-    if "properties" in instance:
-        regex = ""
-        regex += r"\{"
-        for i, (name, value) in enumerate(instance["properties"].items()):
-            regex += f'{whitespace}"{name}"{whitespace}:{whitespace}'
-            regex += to_regex(resolver, value)
+    definitions = DEFINITIONS
 
-            # No comma after the last key-value pair in JSON
-            if i < len(instance["properties"]) - 1:
-                regex += f"{whitespace},"
-
-        regex += f"{whitespace}" + r"\}"
-
-        return regex
-
-    # To validate against allOf, the given data must be valid against all of the
-    # given subschemas.
-    elif "allOf" in instance:
-        subregexes = [to_regex(resolver, t) for t in instance["allOf"]]
-        subregexes_str = [f"{subregex}" for subregex in subregexes]
-        return rf"({''.join(subregexes_str)})"
-
-    # To validate against `anyOf`, the given data must be valid against
-    # any (one or more) of the given subschemas.
-    elif "anyOf" in instance:
-        subregexes = [to_regex(resolver, t) for t in instance["anyOf"]]
-        combinations = [
-            "(" + "".join(c) + ")"
-            for r in range(1, len(subregexes) + 1)
-            for c in it.permutations(subregexes, r)
-        ]
-
-        return rf"({'|'.join(combinations)})"
-
-    # To validate against oneOf, the given data must be valid against exactly
-    # one of the given subschemas.
-    elif "oneOf" in instance:
-        subregexes = [to_regex(resolver, t) for t in instance["oneOf"]]
-
-        xor_patterns = []
-        # json schema validation ensured there is no overlapping schemas in oneOf
-        for subregex in subregexes:
-            other_subregexes = filter(lambda r: r != subregex, subregexes)
-            other_subregexes_str = "|".join([f"{s}" for s in other_subregexes])
-            negative_lookahead = f"(?!.*({other_subregexes_str}))"
-            xor_patterns.append(f"({subregex}){negative_lookahead}")
-
-        return rf"({'|'.join(xor_patterns)})"
-
-    # The enum keyword is used to restrict a value to a fixed set of values. It
-    # must be an array with at least one element, where each element is unique.
-    elif "enum" in instance:
-        choices = []
-        for choice in instance["enum"]:
-            if type(choice) in [int, float, bool, None]:
-                choices.append(re.escape(str(choice)))
-            elif type(choice) == str:
-                choices.append(f'"{re.escape(choice)}"')
-
-        return f"({'|'.join(choices)})"
-
-    elif "$ref" in instance:
-        path = f"{instance['$ref']}"
-        instance = resolver.lookup(path).contents
-        return to_regex(resolver, instance)
-
-    # The type keyword may either be a string or an array:
-    # - If it's a string, it is the name of one of the basic types.
-    # - If it is an array, it must be an array of strings, where each string is
-    # the name of one of the basic types, and each element is unique. In this
-    # case, the JSON snippet is valid if it matches any of the given types.
-    elif "type" in instance:
-        instance_type = instance["type"]
-        if instance_type == "string":
-            if "maxLength" in instance or "minLength" in instance:
-                max_items = instance.get("maxLength", "")
-                min_items = instance.get("minLength", "")
-                try:
-                    if int(max_items) < int(min_items):
-                        raise ValueError(
-                            "maxLength must be greater than or equal to minLength"
-                        )
-                except ValueError:
-                    pass
-                return f'"{STRING_INNER}{{{min_items},{max_items}}}"'
-            elif "pattern" in instance:
-                pattern = instance["pattern"]
-                if pattern[0] == "^" and pattern[-1] == "$":
-                    return rf'(^"{pattern[1:-1]}"$)'
-                else:
-                    return rf'("{pattern}")'
+    def go(instance: Schema) -> str:
+        if isinstance(instance, bool):
+            if instance:
+                # True means any JSON object is valid
+                return JSON_VALUE
             else:
-                return type_to_regex["string"]
+                # False means no JSON object is valid
+                return r""
 
-        elif instance_type == "number":
-            return type_to_regex["number"]
+        if instance == {}:
+            # Empty object means any JSON object is valid
+            return JSON_VALUE
 
-        elif instance_type == "integer":
-            return type_to_regex["integer"]
+        if "properties" in instance:
+            regex = ""
+            regex += r"\{"
+            for i, (name, value) in enumerate(instance["properties"].items()):
+                regex += f'{WHITESPACE}"{name}"{WHITESPACE}:{WHITESPACE}'
+                regex += go(value)
 
-        elif instance_type == "array":
-            min_items = instance.get("minItems", "0")
-            max_items = instance.get("maxItems", "")
-            if min_items == max_items:
-                num_repeats = "{" + str(int(min_items) - 1) + "}"
-            else:
-                num_repeats = "*"
+                # No comma after the last key-value pair in JSON
+                if i < len(instance["properties"]) - 1:
+                    regex += f"{WHITESPACE},"
 
-            if "items" in instance:
-                items_regex = to_regex(resolver, instance["items"])
-                return rf"\[({items_regex})(,({items_regex})){num_repeats}\]"
-            else:
-                # Here we need to make the choice to exclude generating list of objects
-                # if the specification of the object is not given, even though a JSON
-                # object that contains an object here would be valid under the specification.
-                types = [
-                    {"type": "boolean"},
-                    {"type": "null"},
-                    {"type": "number"},
-                    {"type": "integer"},
-                    {"type": "string"},
-                ]
-                regexes = [to_regex(resolver, t) for t in types]
-                return (
-                    rf"\[({'|'.join(regexes)})(,({'|'.join(regexes)})){num_repeats}\]"
-                )
+            regex += f"{WHITESPACE}" + r"\}"
 
-        elif instance_type == "boolean":
-            return type_to_regex["boolean"]
+            return regex
 
-        elif instance_type == "null":
-            return type_to_regex["null"]
+        # To validate against allOf, the given data must be valid against all of the
+        # given subschemas.
+        elif "allOf" in instance:
+            subregexes = [go(t) for t in instance["allOf"]]
+            subregexes_str = [f"{subregex}" for subregex in subregexes]
+            return rf"({''.join(subregexes_str)})"
 
-        elif isinstance(instance_type, list):
-            # Here we need to make the choice to exclude generating an object
-            # if the specification of the object is not give, even though a JSON
-            # object that contains an object here would be valid under the specification.
-            regexes = [
-                to_regex(resolver, {"type": t}) for t in instance_type if t != "object"
+        # To validate against `anyOf`, the given data must be valid against
+        # any (one or more) of the given subschemas.
+        elif "anyOf" in instance:
+            subregexes = [go(t) for t in instance["anyOf"]]
+            combinations = [
+                "(" + "".join(c) + ")"
+                for r in range(1, len(subregexes) + 1)
+                for c in it.permutations(subregexes, r)
             ]
-            return rf"({'|'.join(regexes)})"
 
-    raise NotImplementedError(
-        f"""Could not translate the instance {instance} to a
-    regular expression. Make sure it is valid to the JSON Schema specification. If
-    it is, please open an issue on the Outlines repository"""
-    )
+            return rf"({'|'.join(combinations)})"
+
+        # To validate against oneOf, the given data must be valid against exactly
+        # one of the given subschemas.
+        elif "oneOf" in instance:
+            subregexes = [go(t) for t in instance["oneOf"]]
+
+            xor_patterns = []
+            # json schema validation ensured there is no overlapping schemas in oneOf
+            for subregex in subregexes:
+                other_subregexes = filter(lambda r: r != subregex, subregexes)
+                other_subregexes_str = "|".join([f"{s}" for s in other_subregexes])
+                negative_lookahead = f"(?!.*({other_subregexes_str}))"
+                xor_patterns.append(f"({subregex}){negative_lookahead}")
+
+            return rf"({'|'.join(xor_patterns)})"
+
+        # The enum keyword is used to restrict a value to a fixed set of values. It
+        # must be an array with at least one element, where each element is unique.
+        elif "enum" in instance:
+            choices = []
+            for choice in instance["enum"]:
+                if type(choice) in [int, float, bool, None]:
+                    choices.append(re.escape(str(choice)))
+                elif type(choice) == str:
+                    choices.append(f'"{re.escape(choice)}"')
+
+            return f"({'|'.join(choices)})"
+
+        elif "$ref" in instance:
+            path = f"{instance['$ref']}"
+            name = re.escape(path.replace("/", "_").replace("#", "").replace("$", "_"))
+            assert resolver is not None, "Cannot resolve references without a resolver"
+            if name not in definitions:
+                definitions[name] = go(resolver.lookup(path).contents)
+            return f"(?&{name})"
+
+        # The type keyword may either be a string or an array:
+        # - If it's a string, it is the name of one of the basic types.
+        # - If it is an array, it must be an array of strings, where each string is
+        # the name of one of the basic types, and each element is unique. In this
+        # case, the JSON snippet is valid if it matches any of the given types.
+        elif "type" in instance:
+            instance_type = instance["type"]
+            if instance_type == "string":
+                if "maxLength" in instance or "minLength" in instance:
+                    max_items = instance.get("maxLength", "")
+                    min_items = instance.get("minLength", "")
+                    try:
+                        if int(max_items) < int(min_items):
+                            raise ValueError(
+                                "maxLength must be greater than or equal to minLength"
+                            )
+                    except ValueError:
+                        pass
+                    return f'"{STRING_INNER}{{{min_items},{max_items}}}"'
+                elif "pattern" in instance:
+                    pattern = instance["pattern"]
+                    if pattern[0] == "^" and pattern[-1] == "$":
+                        return rf'(^"{pattern[1:-1]}"$)'
+                    else:
+                        return rf'("{pattern}")'
+                else:
+                    return type_to_regex["string"]
+
+            elif instance_type == "number":
+                return type_to_regex["number"]
+
+            elif instance_type == "integer":
+                return type_to_regex["integer"]
+
+            elif instance_type == "array":
+                min_items = instance.get("minItems", "0")
+                max_items = instance.get("maxItems", "")
+                if min_items == max_items:
+                    num_repeats = "{" + str(int(min_items) - 1) + "}"
+                else:
+                    num_repeats = "*"
+
+                if "items" in instance:
+                    items_regex = go(instance["items"])
+                    return rf"\[({items_regex})(,({items_regex})){num_repeats}\]"
+                else:
+                    # Here we need to make the choice to exclude generating list of objects
+                    # if the specification of the object is not given, even though a JSON
+                    # object that contains an object here would be valid under the specification.
+                    types = [
+                        {"type": "boolean"},
+                        {"type": "null"},
+                        {"type": "number"},
+                        {"type": "integer"},
+                        {"type": "string"},
+                    ]
+                    regexes = [go(t) for t in types]
+                    return rf"\[({'|'.join(regexes)})(,({'|'.join(regexes)})){num_repeats}\]"
+
+            elif instance_type == "boolean":
+                return type_to_regex["boolean"]
+
+            elif instance_type == "null":
+                return type_to_regex["null"]
+
+            elif isinstance(instance_type, list):
+                # Here we need to make the choice to exclude generating an object
+                # if the specification of the object is not give, even though a JSON
+                # object that contains an object here would be valid under the specification.
+                regexes = [go({"type": t}) for t in instance_type if t != "object"]
+                return rf"({'|'.join(regexes)})"
+
+        raise NotImplementedError(
+            f"""Could not translate the instance {instance} to a
+        regular expression. Make sure it is valid to the JSON Schema specification. If
+        it is, please open an issue on the Outlines repository"""
+        )
+
+    _regex = go(instance)
+    regex = r"(?:"
+    for name, value in definitions.items():
+        regex += rf"(?P<{name}>{value})"
+    regex += r"){0}"
+    regex += _regex
+
+    return regex
 
 
-def get_schema_from_signature(fn: Callable) -> str:
+def get_schema_from_signature(fn: Callable) -> dict[str, Any]:
     """Turn a function signature into a JSON schema.
 
     Every JSON object valid to the output JSON Schema can be passed

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -83,7 +83,7 @@ def build_regex_from_object(
     if isinstance(object, BaseModel):
         schema = object.model_json_schema()
     elif isinstance(object, type) and issubclass(object, BaseModel):
-        schema = object.model_json_schema()
+        schema = object.model_json_schema()  # type: ignore
     elif callable(object):
         schema = get_schema_from_signature(object)
     else:

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -2,7 +2,7 @@ import inspect
 import itertools as it
 import json
 import re
-from typing import Any, Callable, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from jsonschema.protocols import Validator
 from jsonschema.validators import validator_for
@@ -133,7 +133,7 @@ def to_regex(resolver: Optional[Resolver], instance: Schema) -> str:
     class Regex(str):
         pass
 
-    definitions: dict[str, Union[Path, Regex]] = {
+    definitions: Dict[str, Union[Path, Regex]] = {
         name: Regex(regex) for name, regex in DEFINITIONS.items()
     }
 
@@ -353,7 +353,7 @@ def to_regex(resolver: Optional[Resolver], instance: Schema) -> str:
     return regex
 
 
-def get_schema_from_signature(fn: Callable) -> dict[str, Any]:
+def get_schema_from_signature(fn: Callable) -> Dict[str, Any]:
     """Turn a function signature into a JSON schema.
 
     Every JSON object valid to the output JSON Schema can be passed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
     "beartype<0.16.0",
     "datasets",
     "responses",
+    "types-regex",
 ]
 serve = [
     "vllm==0.2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ test = [
     "beartype<0.16.0",
     "datasets",
     "responses",
-    "types-regex",
 ]
 serve = [
     "vllm==0.2.6",


### PR DESCRIPTION
The main contribution of this PR is an enhanced `to_regex` function, which addresses both empty and recursive JSON schemas. I utilize the capabilities of the `regex` library, which notably supports recursion. Here's how this is achieved:

#### Handling Empty JSON Schemas

We identify empty schemas (i.e., `{}` or `True`) as those that should accept any valid JSON. To achieve this, a specific regex pattern for JSON values is implemented. This pattern is designed to be universally accepting.

#### Addressing Recursive JSON Schemas

The core of handling recursion lies in the use of named capture groups within the regex patterns. These groups are critical for creating references within the regex that can call back to themselves or to other groups.

The `regex` library's support for recursion is fundamental to this approach. It allows for patterns that can reference themselves, enabling the definition and validation of recursive and self-referential schemas. This is particularly important for complex schemas where elements may be nested within themselves or have mutual references.
