### PR TITLE
Use a trie for scanning during index construction

### DIFF
--- a/tests/fsm/test_regex.py
+++ b/tests/fsm/test_regex.py
@@ -257,6 +257,11 @@ def test_create_fsm_index_end_to_end():
     vocabulary_nb.update(vocabulary)
 
     res = create_fsm_index_end_to_end(regex_fsm.fsm_info, vocabulary_nb)
+    res = {
+        state: set(tokens_id_end_state_list)
+        for state, tokens_id_end_state_list in enumerate(res)
+        if tokens_id_end_state_list
+    }
 
     assert res == {0: {(2, 2), (3, 1)}, 2: {(2, 2), (3, 2)}}
 


### PR DESCRIPTION
Update `state_scan_tokens` to use a trie. We are performing an expensive `_walk_fsm` for every token * every state, which is the current bottleneck. This reduces the calls to `_walk_fsm`.

# Performance

Author of interegular pushed my interegular `FSM.reduce()` optimization to pypi in version `0.3.3`.

(For simple regex, `interegular` `reduce()` doesn't take much time, so the difference between 0.3.3 and 0.3.2 is mostly variation in runtime of the rest of RegexFSM.)

- main (0.3.2): Performance of main on old interegular
- main (0.3.3): Performance with `interegular` change
- PR (wo/ trie): Performance with `interegular` change + PR's numbafication
- PR: Performance with `interegular` change + PR's numbafication + PR's token trie

Benchmarks indicate all RegexFSM constructions are faster than before. Worst sample is 20% faster, best sample is 700% faster.

Benchmarks
<details>

email: 
```
[a-z0-9!#$%&'*+/=?^_{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?
```
- main (0.3.2): 0.5830576419830322
- main (0.3.3): 0.58341383934021
- PR (wo/ trie): 0.34377002716064453
- PR: 0.47698211669921875 (*bad*)

complex_phone: 
```
\+?\d{1,4}?[-.\s]?\(?\d{1,3}?\)?[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,9}
```
- main (0.3.2): 1.5468947887420654
- main (0.3.3): 1.4503862857818604
- PR (wo/ trie): 1.1407146453857422
- PR: 0.32466745376586914 (*good*)

simple_phone: 
```
\+?[1-9][0-9]{7,14}
```
- main (0.3.2): 0.4189467430114746
- main (0.3.3): 0.4271810054779053
- PR (wo/ trie): 0.3233828544616699
- PR: 0.14258384704589844 (*good*)

date: 
```
([1-9]|0[1-9]|1[0-9]|2[0-9]|3[0-1])(\.|-|/)([1-9]|0[1-9]|1[0-2])(\.|-|/)([0-9][0-9]|19[0-9][0-9]|20[0-9][0-9])|([0-9][0-9]|19[0-9][0-9]|20[0-9][0-9])(\.|-|/)([1-9]|0[1-9]|1[0-2])(\.|-|/)([1-9]|0[1-9]|1[0-9]|2[0-9]|3[0-1])
```
- main (0.3.2): 0.8260455131530762
- main (0.3.3): 0.8374199867248535
- PR (wo/ trie): 0.6275467872619629
- PR: 0.12444806098937988 (*good*)

time: 
```
(0?[1-9]|1[0-2]):[0-5]\d\s?(am|pm)?
```
- main (0.3.2): 0.26282405853271484
- main (0.3.3): 0.28090667724609375
- PR (wo/ trie): 0.19170904159545898
- PR: 0.10238885879516602 (*good*)

ip: 
```
(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
```
- main (0.3.2): 0.5932526588439941
- main (0.3.3): 0.5779187679290771
- PR (wo/ trie): 0.4326210021972656
- PR: 0.11676287651062012 (*good*)

url: 
```
(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?
```
- main (0.3.2): 0.9047980308532715
- main (0.3.3): 0.7660520076751709
- PR (wo/ trie): 0.5781815052032471
- PR: 0.7124283313751221 (*bad*)

ssn: 
```
\d{3}-\d{2}-\d{4}
```
- main (0.3.2): 0.306537389755249
- main (0.3.3): 0.34891176223754883
- PR (wo/ trie): 0.22051334381103516
- PR: 0.10631608963012695 (*good*)

very_complex: 
- main (0.3.2): 24.344436407089233
- main (0.3.3): 11.929908275604248
- PR (wo/ trie): 8.78506064414978
- PR: 3.1125617027282715 (*good*)

json_schema: 
```
\{[\n ]*"name"[\n ]*:[\n ]*"(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.){,10}"[\n ]*,[\n ]*"age"[\n ]*:[\n ]*(0|[1-9][0-9]*)[\n ]*,[\n ]*"armor"[\n ]*:[\n ]*("leather"|"chainmail"|"plate")[\n ]*,[\n ]*"strength"[\n ]*:[\n ]*(0|[1-9][0-9]*)[\n ]*\}
```
- main (0.3.2): 4.285711050033569
- main (0.3.3): 4.1461546421051025
- PR (wo/ trie): 3.075744867324829
- PR: 2.2587642669677734 (*good*)

complex_json_schema: 
```
\{[\n ]*"id"[\n ]*:[\n ]*(-)?((0|[1-9][0-9]*))(\.[0-9]+)?([eE][+-][0-9]+)?[\n ]*,[\n ]*"work"[\n ]*:[\n ]*\{[\n ]*"id"[\n ]*:[\n ]*(-)?((0|[1-9][0-9]*))(\.[0-9]+)?([eE][+-][0-9]+)?[\n ]*,[\n ]*"name"[\n ]*:[\n ]*"(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"[\n ]*,[\n ]*"composer"[\n ]*:[\n ]*\{[\n ]*"id"[\n ]*:[\n ]*(-)?((0|[1-9][0-9]*))(\.[0-9]+)?([eE][+-][0-9]+)?[\n ]*,[\n ]*"name"[\n ]*:[\n ]*"(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"[\n ]*,[\n ]*"functions"[\n ]*:[\n ]*\[("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*")(,("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"))*\][\n ]*\}[\n ]*\}[\n ]*,[\n ]*"recording_artists"[\n ]*:[\n ]*\[(\{[\n ]*"id"[\n ]*:[\n ]*(-)?((0|[1-9][0-9]*))(\.[0-9]+)?([eE][+-][0-9]+)?[\n ]*,[\n ]*"name"[\n ]*:[\n ]*"(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"[\n ]*,[\n ]*"functions"[\n ]*:[\n ]*\[("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*")(,("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"))*\][\n ]*\})(,(\{[\n ]*"id"[\n ]*:[\n ]*(-)?((0|[1-9][0-9]*))(\.[0-9]+)?([eE][+-][0-9]+)?[\n ]*,[\n ]*"name"[\n ]*:[\n ]*"(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"[\n ]*,[\n ]*"functions"[\n ]*:[\n ]*\[("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*")(,("(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)*"))*\][\n ]*\}))*\][\n ]*\}
```
- main (0.3.2): 9.537730693817139
- main (0.3.3): 8.472238540649414
- PR (wo/ trie): 5.008383274078369
- PR: 2.342341661453247 (*good*)

</details>

Benchmark code:

<details>

```python
import cProfile
import pstats

import time
from outlines.models.transformers import TransformerTokenizer
from outlines.fsm.json_schema import build_regex_from_object

schema = """{
        "$defs": {
            "Armor": {
                "enum": ["leather", "chainmail", "plate"],
                "title": "Armor",
                "type": "string"
            }
        },
        "properties": {
            "name": {"maxLength": 10, "title": "Name", "type": "string"},
            "age": {"title": "Age", "type": "integer"},
            "armor": {"$ref": "#/$defs/Armor"},
            "strength": {"title": "Strength", "type": "integer"}\
        },
        "required": ["name", "age", "armor", "strength"],
        "title": "Character",
        "type": "object"
    }"""

complex_schema = """{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Schema for a recording",
  "type": "object",
  "definitions": {
    "artist": {
      "type": "object",
      "properties": {
        "id": {"type": "number"},
        "name": {"type": "string"},
        "functions": {
          "type": "array",
          "items": {"type": "string"}
        }
      },
      "required": ["id", "name", "functions"]
    }
  },
  "properties": {
    "id": {"type": "number"},
    "work": {
      "type": "object",
      "properties": {
        "id": {"type": "number"},
        "name": {"type": "string"},
        "composer": {"$ref": "#/definitions/artist"}
      }
    },
    "recording_artists": {
      "type": "array",
      "items": {"$ref": "#/definitions/artist"}
    }
  },
  "required": ["id", "work", "recording_artists"]
}"""

regex_samples = {
    "email": r"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
    "complex_phone": "\\+?\\d{1,4}?[-.\\s]?\\(?\\d{1,3}?\\)?[-.\\s]?\\d{1,4}[-.\\s]?\\d{1,4}[-.\\s]?\\d{1,9}",
    "simple_phone": "\\+?[1-9][0-9]{7,14}",
    "date": "([1-9]|0[1-9]|1[0-9]|2[0-9]|3[0-1])(\.|-|/)([1-9]|0[1-9]|1[0-2])(\.|-|/)([0-9][0-9]|19[0-9][0-9]|20[0-9][0-9])|([0-9][0-9]|19[0-9][0-9]|20[0-9][0-9])(\.|-|/)([1-9]|0[1-9]|1[0-2])(\.|-|/)([1-9]|0[1-9]|1[0-9]|2[0-9]|3[0-1])",
    "time": r"(0?[1-9]|1[0-2]):[0-5]\d\s?(am|pm)?",
    "ip": r"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
    "url": r"(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?",
    "ssn": r"\d{3}-\d{2}-\d{4}",
    "very_complex": <redacted>,
    "json_schema": build_regex_from_object(schema),
    "complex_json_schema": build_regex_from_object(complex_schema),
}

from outlines.fsm.fsm import RegexFSM

tokenizer = TransformerTokenizer("gpt2")


t = time.time()
RegexFSM(regex_string='ab', tokenizer=tokenizer)
print(time.time() - t, "seconds for a simple initial regex which compiles numba functions")




def create_rfsm(r):
    rfsm = RegexFSM(regex_string=r, tokenizer=tokenizer)


cProfile.run(f'create_rfsm(regex_samples["very_complex"])', 'profile_stats')


for name, r in regex_samples.items():
    print()
    print(f"{name}: `{r}`")
    print()
    start = time.time()
    create_rfsm(r)
    print("-", time.time() - start)


p = pstats.Stats('profile_stats')
p.sort_stats('cumtime').print_stats()
```
</details>