### PR TITLE
Remove idx arg from FSM interface

### DIFF
--- a/examples/cfg.py
+++ b/examples/cfg.py
@@ -1,5 +1,3 @@
-from lark.exceptions import UnexpectedCharacters, UnexpectedToken
-
 import outlines.generate as generate
 import outlines.models as models
 
@@ -49,19 +47,13 @@ calc_grammar = """
 
 model = models.transformers("hf-internal-testing/tiny-random-gpt2")
 batch_size = 10
-max_tokens = 30
 for grammar in [nlamb_grammar, calc_grammar]:
     generator = generate.cfg(model, grammar)
-    sequences = generator([" "] * batch_size, max_tokens=max_tokens)
+    sequences = generator([" "] * batch_size)
     for seq in sequences:
         try:
             parse = generator.fsm.parser.parse(seq)
             assert parse is not None
             print("SUCCESS", seq)
-        except (UnexpectedCharacters, UnexpectedToken):
-            if generator.fsm.num_tokens_generated == max_tokens:
-                print("MAXTOKEN", seq)
-            else:
-                print("FAILURE", seq)
         except Exception:
             print("FAILURE", seq)

--- a/tests/fsm/test_fsm.py
+++ b/tests/fsm/test_fsm.py
@@ -81,27 +81,27 @@ def test_cfg():
 
     assert set(fsm.allowed_token_ids(state=0)) == {1, 3, 5}
     state = fsm.next_state(state=0, token_id=1)
-    assert fsm.generations[0] == "{"
+    assert fsm.generation == "{"
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {1, 2, 3}
     state = fsm.next_state(state=state, token_id=3)
-    assert fsm.generations[0] == "{["
+    assert fsm.generation == "{["
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {1, 3, 4}
     state = fsm.next_state(state=state, token_id=4)
-    assert fsm.generations[0] == "{[]"
+    assert fsm.generation == "{[]"
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {2}
     state = fsm.next_state(state=state, token_id=2)
-    assert fsm.generations[0] == "{[]}"
+    assert fsm.generation == "{[]}"
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {5}
     state = fsm.next_state(state=state, token_id=5)
-    assert fsm.generations[0] == "{[]}"
+    assert fsm.generation == "{[]}"
     assert fsm.is_final_state(0)
 
 
@@ -132,18 +132,18 @@ def test_cfg_early_termination():
 
     assert set(fsm.allowed_token_ids(state=0)) == {1}
     state = fsm.next_state(state=0, token_id=1)
-    assert fsm.generations[0] == "("
+    assert fsm.generation == "("
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {1, 2}
     state = fsm.next_state(state=state, token_id=2)
-    assert fsm.generations[0] == "()"
+    assert fsm.generation == "()"
     assert not fsm.is_final_state(0)
 
     # possible to continue or terminate
     assert set(fsm.allowed_token_ids(state=state)) == {1, 3}
     state = fsm.next_state(state=state, token_id=3)  # feed eos
-    assert fsm.generations[0] == "()"
+    assert fsm.generation == "()"
     assert fsm.is_final_state(0)
 
     # once eos generated, can only terminate
@@ -175,21 +175,21 @@ def test_cfg_multitoken_subexpr():
     fsm = CFGFSM(cfg_str, tokenizer)
 
     assert set(fsm.allowed_token_ids(state=0)) == {1, 2}
-    assert fsm.reset_state[0]  # starting new regex
+    assert fsm.reset_state  # starting new regex
     state = fsm.next_state(state=0, token_id=1)
-    assert fsm.generations[0] == "a"
+    assert fsm.generation == "a"
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {1}
-    assert not fsm.reset_state[0]  # continuing current regex
+    assert not fsm.reset_state  # continuing current regex
     state = fsm.next_state(state=state, token_id=1)
-    assert fsm.generations[0] == "aa"
+    assert fsm.generation == "aa"
     assert not fsm.is_final_state(0)
 
     assert set(fsm.allowed_token_ids(state=state)) == {3}
-    assert not fsm.reset_state[0]  # completing current regex
+    assert not fsm.reset_state  # completing current regex
     state = fsm.next_state(state=state, token_id=3)
-    assert fsm.generations[0] == "aa"
+    assert fsm.generation == "aa"
     assert fsm.is_final_state(0)
 
 
@@ -224,7 +224,7 @@ def test_cfg_overlapping_subexpr():
 
     assert set(fsm.allowed_token_ids(state=0)) == {1, 2}
     state = fsm.next_state(state=0, token_id=1)
-    assert fsm.generations[0] == "a"
+    assert fsm.generation == "a"
     assert not fsm.is_final_state(0)
 
     # INTENDED LOGIC
@@ -239,5 +239,5 @@ def test_cfg_overlapping_subexpr():
     # This implementation is sound, and always terminates, but is not complete
     assert set(fsm.allowed_token_ids(state=state)) == {3}
     state = fsm.next_state(state=state, token_id=3)
-    assert fsm.generations[0] == "a"
+    assert fsm.generation == "a"
     assert fsm.is_final_state(0)

--- a/tests/generate/test_generator.py
+++ b/tests/generate/test_generator.py
@@ -21,17 +21,17 @@ from outlines.generate.generator import (
 
 def test_sequence_generator_class():
     class MockFSM:
-        def next_state(self, state, next_token_ids, _):
+        def next_state(self, state, next_token_ids):
             return 4
 
         def allowed_token_ids(self, *_):
             return [4]
 
-        def is_final_state(self, _, idx=0):
+        def is_final_state(self, _):
             return True
 
-        def reset(self):
-            pass
+        def copy(self):
+            return self
 
     class MockTokenizer:
         def encode(self, _):
@@ -74,17 +74,14 @@ def test_sequence_generator_class():
 
 def test_init_sequence_generator():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return 0
 
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return []
 
-        def is_final_state(self, _, idx=0):
+        def is_final_state(self, _):
             return True
-
-        def reset(self):
-            pass
 
     class MockTokenizer:
         def encode(self, _):
@@ -112,17 +109,14 @@ def test_init_sequence_generator():
 
 def test_sequence_generator_1d_single_iteration():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return 0
 
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return [0, 1, 2, 3]
 
-        def is_final_state(self, _, idx=0):
+        def is_final_state(self, _):
             return True
-
-        def reset(self):
-            pass
 
     class MockTokenizer:
         def encode(self, _):
@@ -145,7 +139,7 @@ def test_sequence_generator_1d_single_iteration():
     init_fsm_states = [0]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, MockFSM(), init_state, init_fsm_states, torch.Generator()
+        generate, [MockFSM()], init_state, init_fsm_states, torch.Generator()
     )
     result = next(sequence)
 
@@ -158,20 +152,17 @@ def test_sequence_generator_1d_single_iteration():
 
 def test_sequence_generator_1d_several_iterations():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return FSMState(state + 1)
 
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return [0, 1, 2, 3]
 
-        def is_final_state(self, state, idx=0):
+        def is_final_state(self, state):
             if state < 2:
                 return False
             else:
                 return True
-
-        def reset(self):
-            pass
 
     class MockTokenizer:
         def encode(self, _):
@@ -194,7 +185,7 @@ def test_sequence_generator_1d_several_iterations():
     init_fsm_states = [0]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, MockFSM(), init_state, init_fsm_states, torch.Generator()
+        generate, [MockFSM()], init_state, init_fsm_states, torch.Generator()
     )
 
     result = next(sequence)
@@ -211,17 +202,14 @@ def test_sequence_generator_1d_several_iterations():
 
 def test_sequence_generator_2d_single_iteration():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return 0
 
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return [0, 1, 2, 3]
 
-        def is_final_state(self, _, idx=0):
+        def is_final_state(self, _):
             return True
-
-        def reset(self):
-            pass
 
     class MockTokenizer:
         def encode(self, _):
@@ -248,9 +236,10 @@ def test_sequence_generator_2d_single_iteration():
         None,
     )
     init_fsm_states = [0, 0]
+    fsms = [MockFSM(), MockFSM()]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, MockFSM(), init_state, init_fsm_states, torch.Generator()
+        generate, fsms, init_state, init_fsm_states, torch.Generator()
     )
 
     result = next(sequence)
@@ -267,20 +256,17 @@ def test_sequence_generator_2d_single_iteration():
 
 def test_sequence_generator_2d_several_iterations():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return FSMState(state + 1)
 
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return [0, 1, 2, 3]
 
-        def is_final_state(self, state, idx=0):
+        def is_final_state(self, state):
             if state < 2:
                 return False
             else:
                 return True
-
-        def reset(self):
-            pass
 
     class MockTokenizer:
         def encode(self, _):
@@ -307,9 +293,10 @@ def test_sequence_generator_2d_several_iterations():
         None,
     )
     init_fsm_states = [0, 0]
+    fsms = [MockFSM(), MockFSM()]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, MockFSM(), init_state, init_fsm_states, torch.Generator()
+        generate, fsms, init_state, init_fsm_states, torch.Generator()
     )
 
     result = next(sequence)
@@ -411,44 +398,48 @@ def test_generator_2d(logits_biases, expected_result, expected_biased_logits):
 
 def test_get_next_fsm_states():
     class MockFSM:
-        def next_state(self, state, next_token_ids, idx=0):
+        def next_state(self, state, next_token_ids):
             return 0
 
-    result = get_next_fsm_states(MockFSM(), [0], torch.tensor([[0]]))
+    result = get_next_fsm_states([MockFSM()], [0], torch.tensor([[0]]))
     assert result == [0]
 
-    result = get_next_fsm_states(MockFSM(), [0, 0], torch.tensor([[0], [0]]))
+    result = get_next_fsm_states(
+        [MockFSM(), MockFSM()], [0, 0], torch.tensor([[0], [0]])
+    )
     assert result == [0, 0]
 
 
 def test_get_allowed_token_idss():
     class MockFSM:
-        def allowed_token_ids(self, _, idx=0):
+        def allowed_token_ids(self, _):
             return [1, 2, 3, 4]
 
-    result = get_allowed_tokens(MockFSM(), [0])
+    result = get_allowed_tokens([MockFSM()], [0])
     assert result == [[1, 2, 3, 4]]
 
-    result = get_allowed_tokens(MockFSM(), [0, 1])
+    result = get_allowed_tokens([MockFSM(), MockFSM()], [0, 1])
     assert result == [[1, 2, 3, 4], [1, 2, 3, 4]]
 
 
 def test_is_generation_finished():
     class MockFSMFinished:
-        def is_final_state(self, _, idx=0):
+        def is_final_state(self, _):
             return True
 
-    result = is_generation_finished(MockFSMFinished(), [1, 1])
+    result = is_generation_finished([MockFSMFinished(), MockFSMFinished()], [1, 1])
     assert result is True
 
     class MockFSMNotFinished:
-        def is_final_state(self, state, idx=0):
+        def is_final_state(self, state):
             if state == 0:
                 return False
             else:
                 return True
 
-    result = is_generation_finished(MockFSMNotFinished(), [0, 1])
+    result = is_generation_finished(
+        [MockFSMNotFinished(), MockFSMNotFinished()], [0, 1]
+    )
     assert result is False
 
 


### PR DESCRIPTION
This is an updated version of https://github.com/outlines-dev/outlines/pull/449/ up-to-date with `main` and with `examples/cfg.py` updated to remove the branch that checks the FSM `num_tokens_generated` attribute, which has now been removed.