### PR TITLE
Patch nest_asyncio in notebooks only

### DIFF
--- a/outlines/base.py
+++ b/outlines/base.py
@@ -1,9 +1,9 @@
 import asyncio
+import builtins
 import functools
 import inspect
 from typing import Callable, Optional
 
-import nest_asyncio
 import numpy as np
 from numpy.lib.function_base import (
     _calculate_shapes,
@@ -12,11 +12,17 @@ from numpy.lib.function_base import (
     _update_dim_sizes,
 )
 
-# Allow nested loops, useful to run in notebooks
-try:
-    nest_asyncio.apply()
-except ValueError as e:
-    print("Could not apply nest_asyncio:", e)
+# Allow nested loops for running in notebook. We don't enable it globally as it
+# may interfere with other libraries that use asyncio.
+if hasattr(builtins, "__IPYTHON__"):
+    try:
+        import nest_asyncio
+
+        nest_asyncio.apply()
+    except ImportError:
+        print(
+            "Couldn't patch nest_asyncio because it's not installed. Running in the notebook might be have issues"
+        )
 
 
 class vectorize:


### PR DESCRIPTION
The logic to call `nest_asyncio` was added in https://github.com/outlines-dev/outlines/commit/587f9ac139651ff2e4af860fbd6e155f38eca675 presumably to make notebook interactions easier.

However, it's a bad practice to unconditionally call global python patches from library code.

It caused some issues with vLLM integration and was patched in https://github.com/outlines-dev/outlines/pull/481

We ran into different issues when using Outlines in our codebase. The unittests started hanging on shutdown because of stray asyncio threads.

I propose to make the patch happen only when running inside IPython. According to https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook it's an ok detention method for notebooks. Other proposed methods are too narrow and e.g. don't capture Colab.

However, even better fix might be to remove this patch all together and instead include it explicitly in the notebooks of choice. @rlouf - do you have more context on what was the original issue?