### PR TITLE
Updates chess cookbook example with Phi-2 and adds omitted code. 

### DIFF
--- a/docs/cookbook/models_playing_chess.md
+++ b/docs/cookbook/models_playing_chess.md
@@ -7,7 +7,7 @@ In this example we will make a Phi-2 model play chess against itself. On its own
 The game will be played on a standard checkboard. We will use the `chess` [library](https://github.com/niklasf/python-chess) to track the opponents' moves, and check that the moves are valid.
 
 ```python
-%pip install outlines -q 
+%pip install outlines -q
 %pip install chess -q
 %pip install transformers accelerate einops -q
 
@@ -60,7 +60,7 @@ We update the prompt at each step so it reflects the state of the board after th
 ```python
 from outlines import generate
 
-board_state = " " 
+board_state = " "
 turn_number = 0
 while not board.is_game_over():
     regex_pattern = legal_moves_regex(board)
@@ -82,7 +82,7 @@ while not board.is_game_over():
 Interestingly enough, Phi-2 hates capturing.
 
 ```pgn
- e4 e5 1.Nf3 Ne7 3.b4 Nf5 5.Nc3 Ne7 7.Bb5 a6 9.Na4 b6 11.c3 Nec6 13.c4 a5 15.d4 Qg5 17.Nd2 Bb7 19.dxe5 
+ e4 e5 1.Nf3 Ne7 3.b4 Nf5 5.Nc3 Ne7 7.Bb5 a6 9.Na4 b6 11.c3 Nec6 13.c4 a5 15.d4 Qg5 17.Nd2 Bb7 19.dxe5
 ```
 
 *This example was originally authored by [@903124S](https://x.com/903124S) in [this gist](https://gist.github.com/903124/cfbefa24da95e2316e0d5e8ef8ed360d).*


### PR DESCRIPTION
Hello, 

This was a fun example in the cookbook, but there were some elements missing, e.g., `model` was referenced in the code, but not defined anywhere, `board_state` was set to be the model, etc. 

I updated the example to use the smaller Phi-2 (which actually plays terrible, but otherwise longer chess) and added the code needed so [that the example can run.](https://colab.research.google.com/drive/1-f9CC64HGgaZhxZTvJkZPfenySkb0Yt7?usp=sharing)



