### PR TITLE
Allow to generate several samples for each prompt

### DIFF
--- a/docs/api/samplers.md
+++ b/docs/api/samplers.md
@@ -1,1 +1,1 @@
-::: outlines.generate.samplers
+::: outlines.samplers

--- a/docs/reference/samplers.md
+++ b/docs/reference/samplers.md
@@ -1,0 +1,73 @@
+# Samplers
+
+## Multinomial sampling
+
+Outlines defaults to the multinomial sampler without top-p or top-k sampling, and temperature equal to 1. Not specifying a sampler is equivalent to:
+
+```python
+from outlines import models, generate, samplers
+
+
+model = models.transformers("mistralai/Mistral-7B-0.1")
+sampler = samplers.multinomial()
+
+generator = generate.text(model, sampler)
+answer = generator("What is 2+2?")
+
+print(answer)
+# 4
+```
+
+You can ask the generator to take multiple samples by passing the number of samples when initializing the sampler:
+
+```python
+from outlines import models, generate, samplers
+
+
+model = models.transformers("mistralai/Mistral-7B-0.1")
+sampler = samplers.multinomial(3)
+
+generator = generate.text(model, sampler)
+answer = generator("What is 2+2?")
+
+print(answer)
+# [4, 4, 4]
+```
+
+If you ask multiple samples for a batch of prompt the returned array will be of shape `(num_samples, num_batches)`:
+
+```python
+from outlines import models, generate, samplers
+
+
+model = models.transformers("mistralai/Mistral-7B-0.1")
+sampler = samplers.multinomial(3)
+
+generator = generate.text(model, sampler)
+answer = generator(["What is 2+2?", "What is 3+3?"])
+
+print(answer)
+# [[4, 4, 4], [6, 6, 6]]
+```
+
+
+## Greedy sampler
+
+You can also use the greedy sampler. For this you need to initialize the generator with the sampler:
+
+
+```python
+from outlines import models, generate, samplers
+
+
+model = models.transformers("mistralai/Mistral-7B-0.1")
+sampler = samplers.greedy()
+
+generator = generate.text(model, sampler)
+answer = generator("What is 2+2?")
+
+print(answer)
+# 4
+```
+
+You cannot ask for multiple samples with the greedy sampler since it does not clear what the result should be.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
         - Grammar: reference/cfg.md
         - Regex: reference/regex.md
         - Types: reference/types.md
+        - Samplers: reference/samplers.md
     - Utilities:
         - Serve with vLLM: reference/vllm.md
         - Prompt templating: reference/prompting.md

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -20,7 +20,6 @@ class SequenceGenerator:
         sampler,
         device,
         *,
-        num_samples: int = 1,
         max_tokens=None,
         stop_at=None,
     ):
@@ -29,7 +28,7 @@ class SequenceGenerator:
         self.tokenizer = model.tokenizer
         self.device = device
         self.max_tokens = max_tokens
-        self.num_samples = num_samples
+        self.num_particles = sampler.particles
 
         if isinstance(stop_at, str):
             stop_at = [stop_at]
@@ -167,7 +166,6 @@ class SequenceGenerator:
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
-        num_samples: int = 1,
         rng: Optional[torch.Generator] = None,
         kv_cache: Optional[torch.tensor] = None,
     ) -> Union[str, List[str], List[List[str]]]:
@@ -210,6 +208,11 @@ class SequenceGenerator:
 
         stop_sequences = stop_at or self.stop_sequences
         max_tokens = max_tokens or self.max_tokens
+<<<<<<< HEAD
+=======
+        num_samples = self.num_particles
+        num_sequences = len(prompts)
+>>>>>>> c8bf540 (Pass number of samples via sampler)
         fsms = [self.fsm.copy() for _ in prompts]
 
         if rng is None:
@@ -276,7 +279,6 @@ class SequenceGenerator:
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
-        num_samples: int = 1,
         rng: Optional[torch.Generator] = None,
         kv_cache: Optional[torch.tensor] = None,
     ) -> Iterator[Union[List[str], List[List[str]], str]]:
@@ -318,6 +320,11 @@ class SequenceGenerator:
 
         stop_sequences = stop_at or self.stop_sequences
         max_tokens = max_tokens or self.max_tokens
+<<<<<<< HEAD
+=======
+        num_samples = self.num_particles
+        num_sequences = len(prompts)
+>>>>>>> c8bf540 (Pass number of samples via sampler)
         fsms = [self.fsm.copy() for _ in prompts]
 
         if rng is None:

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -226,15 +226,7 @@ class SequenceGenerator:
             self.strip_stop_sequences(sequence, stop_sequences)
             for sequence in generated
         ]
-        try:
-            formatted = [self.format_sequence(sequence) for sequence in stripped]
-        except pyjson.decoder.JSONDecodeError:
-            raise TypeError(
-                "Could not format the output of the model into a dictionary or a Pydantic model."
-                + " The model has likely exceeded its context length. Please try again using `constr` (for Pydantic)"
-                + " and `maxLength` (for JSON Schema) to limit the length of the string fields. If this exception"
-                + " is raised nevertheless please open an issue: https://github.com/outlines-dev/outlines/issues"
-            )
+        formatted = [self.format_sequence(sequence) for sequence in stripped]
 
         return formatted if len(formatted) > 1 else formatted[0]
 

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -13,12 +13,23 @@ from outlines.generate.generator import (
 
 
 class SequenceGenerator:
-    def __init__(self, fsm, model, sampler, device, max_tokens=None, stop_at=None):
+    def __init__(
+        self,
+        fsm,
+        model,
+        sampler,
+        device,
+        *,
+        num_samples: int = 1,
+        max_tokens=None,
+        stop_at=None,
+    ):
         self.generate_token = token_generator(model, sampler)
         self.fsm = fsm
         self.tokenizer = model.tokenizer
         self.device = device
         self.max_tokens = max_tokens
+        self.num_samples = num_samples
 
         if isinstance(stop_at, str):
             stop_at = [stop_at]
@@ -44,6 +55,7 @@ class SequenceGenerator:
         init_state: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         prompts: List[str],
         last_state: GenerationState,
+        num_samples: int,
     ) -> List[torch.Tensor]:
         """Get the tokens generated so far.
 
@@ -55,6 +67,8 @@ class SequenceGenerator:
             The prompts passed to the generator.
         last_state
             The current state of the generation
+        num_samples
+            The number of samples taken for each sequence
 
         Returns
         -------
@@ -62,11 +76,19 @@ class SequenceGenerator:
 
         """
         prompt_token_ids = init_state[0]
-        prompt_lengths = [len(prompt_token_ids[i]) for i in range(len(prompts))]
+        prompt_lengths = [
+            len(prompt_token_ids[i])
+            for _ in range(num_samples)
+            for i in range(len(prompts))
+        ]
+
+        # We flatten the obtained token_ids since the tokenizer's decoder
+        # only accepts tensor with two dimensions
+        token_ids = last_state.token_ids.reshape((-1, last_state.token_ids.shape[-1]))
 
         token_ids = [
             cur_token_ids[length:]
-            for cur_token_ids, length in zip(last_state.token_ids, prompt_lengths)
+            for cur_token_ids, length in zip(token_ids, prompt_lengths)
         ]
 
         return token_ids
@@ -145,9 +167,10 @@ class SequenceGenerator:
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
+        num_samples: int = 1,
         rng: Optional[torch.Generator] = None,
         kv_cache: Optional[torch.tensor] = None,
-    ) -> Union[str, List[str]]:
+    ) -> Union[str, List[str], List[List[str]]]:
         """Generate the full text sequence.
 
         Since `SequenceGenerator.stream` calls the tokenizer at every step this
@@ -199,7 +222,12 @@ class SequenceGenerator:
         init_fsm_states = [self.fsm.first_state for _ in prompts]
 
         states = sequence_generator(
-            self.generate_token, fsms, init_state, init_fsm_states, rng
+            self.generate_token,
+            fsms,
+            init_state,
+            init_fsm_states,
+            rng=rng,
+            num_samples=num_samples,
         )
 
         while True:
@@ -207,7 +235,7 @@ class SequenceGenerator:
                 last_state = next(states)
                 if max_tokens or stop_sequences:
                     generated_token_ids = self.get_generated_token_ids(
-                        init_state, prompts, last_state
+                        init_state, prompts, last_state, num_samples
                     )
                     if max_tokens and len(generated_token_ids[0]) >= max_tokens:
                         break
@@ -219,8 +247,9 @@ class SequenceGenerator:
                 break
 
         generated_token_ids = self.get_generated_token_ids(
-            init_state, prompts, last_state
+            init_state, prompts, last_state, num_samples
         )
+
         generated = self.tokenizer.decode(generated_token_ids)
         stripped = [
             self.strip_stop_sequences(sequence, stop_sequences)
@@ -228,16 +257,29 @@ class SequenceGenerator:
         ]
         formatted = [self.format_sequence(sequence) for sequence in stripped]
 
-        return formatted if len(formatted) > 1 else formatted[0]
+        # We reshape the output to (sample_size, batch_size)
+        output = []
+        step = len(prompts)
+        for i in range(0, len(formatted), step):
+            output.append(formatted[i : i + step])
+
+        # We remove leading dimensions for the output
+        if len(prompts) == 1 and num_samples == 1:
+            return output[0][0]
+        elif num_samples == 1:
+            return output[0]
+        else:
+            return output
 
     def stream(
         self,
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
+        num_samples: int = 1,
         rng: Optional[torch.Generator] = None,
         kv_cache: Optional[torch.tensor] = None,
-    ) -> Iterator[Union[List[str], str]]:
+    ) -> Iterator[Union[List[str], List[List[str]], str]]:
         """Generate the text sequence one token at a time.
 
         Since `Tokenizer.decode` strips the whitespaces from the tokens we have no
@@ -288,13 +330,20 @@ class SequenceGenerator:
         init_fsm_states = [self.fsm.first_state for _ in prompts]
 
         states = sequence_generator(
-            self.generate_token, fsms, init_state, init_fsm_states, rng
+            self.generate_token,
+            fsms,
+            init_state,
+            init_fsm_states,
+            num_samples=num_samples,
+            rng=rng,
         )
 
-        def token_generator() -> Iterator[Union[List[str], str]]:
-            previously_generated_sequences = ["" for _ in prompts]
+        def token_generator() -> Iterator[Union[List[str], str, List[List[str]]]]:
+            previously_generated_sequences = [
+                "" for _ in range(num_sequences)
+            ] * num_samples
             num_generated = 0
-            is_stop_at_reached = [False for _ in prompts]
+            is_stop_at_reached = [False for _ in range(num_sequences)] * num_samples
             while True:
                 if (max_tokens and num_generated >= max_tokens) or all(
                     is_stop_at_reached
@@ -305,7 +354,10 @@ class SequenceGenerator:
                     num_generated += 1
                 except StopIteration:
                     return
-                generated_token_ids = sequence.token_ids[:, -num_generated:]
+                generated_token_ids = sequence.token_ids[:, :, -num_generated:]
+                generated_token_ids = generated_token_ids.reshape(
+                    -1, generated_token_ids.shape[-1]
+                )
                 generated_sequences = self.tokenizer.decode(generated_token_ids)
                 next_tokens = [
                     token[len(sequence) :] if not stop else ""
@@ -326,6 +378,18 @@ class SequenceGenerator:
                             generated_sequences, is_stop_at_reached
                         )
                     ]
-                yield next_tokens
+                # We reshape the output to (sample_size, batch_size)
+                output = []
+                step = len(prompts)
+                for i in range(0, len(next_tokens), step):
+                    output.append(next_tokens[i : i + step])
+
+                # We remove leading dimensions for the output
+                if len(prompts) == 1 and num_samples == 1:
+                    yield output[0][0]
+                elif num_samples == 1:
+                    yield output[0]
+                else:
+                    yield output
 
         return token_generator()

--- a/outlines/generate/cfg.py
+++ b/outlines/generate/cfg.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Union
 
 from outlines.fsm.fsm import CFGFSM
 from outlines.generate.api import SequenceGenerator
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
@@ -13,7 +13,7 @@ def cfg(
     cfg_str: str,
     max_tokens: Optional[int] = None,
     stop_at: Optional[Union[str, List[str]]] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     fsm = CFGFSM(cfg_str, model.tokenizer)
 
@@ -31,7 +31,7 @@ def cfg_openai(
     cfg_str: str,
     max_tokens: Optional[int] = None,
     stop_at: Optional[Union[str, List[str]]] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     raise NotImplementedError(
         "Cannot use grammar-structured generation with an OpenAI model"

--- a/outlines/generate/choice.py
+++ b/outlines/generate/choice.py
@@ -1,8 +1,8 @@
 from functools import singledispatch
 from typing import Callable, List, Optional
 
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 from .regex import regex
 
@@ -12,7 +12,7 @@ def choice(
     model,
     choices: List[str],
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     regex_str = r"(" + r"|".join(choices) + r")"
     return regex(model, regex_str, max_tokens, sampler)
@@ -23,9 +23,9 @@ def choice_openai(
     model: OpenAI,
     choices: List[str],
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ) -> Callable:
-    if not sampler == multinomial:
+    if not isinstance(sampler, multinomial):
         raise NotImplementedError(
             r"The OpenAI API does not support any other sampling algorithm "
             + "that the multinomial sampler."

--- a/outlines/generate/format.py
+++ b/outlines/generate/format.py
@@ -2,15 +2,18 @@ from functools import singledispatch
 from typing import Optional
 
 from outlines.fsm.types import python_types_to_regex
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 from .regex import regex
 
 
 @singledispatch
 def format(
-    model, python_type, max_tokens: Optional[int] = None, sampler: Sampler = multinomial
+    model,
+    python_type,
+    max_tokens: Optional[int] = None,
+    sampler: Sampler = multinomial(),
 ):
     regex_str = python_types_to_regex(python_type)
     return regex(model, regex_str, max_tokens, sampler)
@@ -18,7 +21,10 @@ def format(
 
 @format.register(OpenAI)
 def format_openai(
-    model, python_type, max_tokens: Optional[int] = None, sampler: Sampler = multinomial
+    model,
+    python_type,
+    max_tokens: Optional[int] = None,
+    sampler: Sampler = multinomial(),
 ):
     raise NotImplementedError(
         "Cannot use Python type-structured generation with an OpenAI model"

--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -165,7 +165,7 @@ def token_generator(model, sampler: "Sampler") -> Callable:
             )
 
         biased_logits = bias_logits(logits, allowed_tokens)
-        next_token_ids = sampler(biased_logits, 1, rng)
+        next_token_ids = sampler(biased_logits, rng)
 
         return next_token_ids, new_kv_cache, logits, biased_logits
 

--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -8,8 +8,8 @@ from outlines.fsm.fsm import FSMState
 
 if TYPE_CHECKING:
     from outlines.fsm.fsm import FSM
-    from outlines.generate.samplers import Sampler
     from outlines.models.tokenizer import Tokenizer
+    from outlines.samplers import Sampler
 
 
 @dataclasses.dataclass(frozen=True)

--- a/outlines/generate/json.py
+++ b/outlines/generate/json.py
@@ -5,8 +5,8 @@ from typing import Callable, Optional, Union
 from pydantic import BaseModel
 
 from outlines.fsm.json_schema import build_regex_from_object, get_schema_from_signature
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 from .regex import regex
 
@@ -16,7 +16,7 @@ def json(
     model,
     schema_object: Union[str, object, Callable],
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     if isinstance(schema_object, type(BaseModel)):
         schema = pyjson.dumps(schema_object.model_json_schema())
@@ -48,7 +48,7 @@ def json_openai(
     model,
     schema_object: Union[str, object, Callable],
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     raise NotImplementedError(
         "Cannot use JSON Schema-structure generation with an OpenAI model "

--- a/outlines/generate/regex.py
+++ b/outlines/generate/regex.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from outlines.fsm.fsm import RegexFSM
 from outlines.generate.api import SequenceGenerator
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
@@ -12,7 +12,7 @@ def regex(
     model,
     regex_str: str,
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     fsm = RegexFSM(regex_str, model.tokenizer)
 
@@ -27,7 +27,7 @@ def regex_openai(
     model,
     regex_str: str,
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ):
     raise NotImplementedError(
         "Cannot use regex-structured generation with an OpenAI model"

--- a/outlines/generate/samplers.py
+++ b/outlines/generate/samplers.py
@@ -4,68 +4,98 @@ import torch
 
 
 class Sampler(Protocol):
+    particles: int
+
     def __call__(
-        self, logits: torch.DoubleTensor, samples: int, rng: torch.Generator
+        self, logits: torch.DoubleTensor, rng: torch.Generator
     ) -> torch.DoubleTensor:
         ...
 
 
-def greedy(logits: torch.DoubleTensor, samples: int, *_) -> torch.DoubleTensor:
+class GreedySampler:
     """Greedy Sampling algorithm.
 
     Greedy sampling consists in choosing the token with the largest
     likelihood at every step.
 
-    Parameters
+    Attributes
     ----------
-    logits
-        A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
-        probability distribution of the next token over the vocabulary.
-    samples
-        The number of sequences to produce.  In this case, the top-`samples`
-        logit values are returned.
-    rng
-        A random number generator.
-
-    Returns
-    -------
-    The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+    particles
+        The number of samples taken for each input sequence.
 
     """
-    if samples == 1:
-        next_token_ids = torch.argmax(logits, dim=-1, keepdim=True)
-    else:
-        next_token_ids = torch.topk(
-            logits, samples, dim=-1, largest=True, sorted=True
-        ).indices.T
 
-    return next_token_ids
+    def __init__(self, samples: int = 1):
+        self.particles = samples
+
+    def __call__(self, logits: torch.DoubleTensor, *_) -> torch.DoubleTensor:
+        """Call the greedy sampler.
+
+        Parameters
+        ----------
+        logits
+            A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
+            probability distribution of the next token over the vocabulary.
+        rng
+            A random number generator.
+
+        Returns
+        -------
+        The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+
+        """
+        if self.particles == 1:
+            next_token_ids = torch.argmax(logits, dim=-1, keepdim=True)
+        else:
+            next_token_ids = torch.topk(
+                logits, self.particles, dim=-1, largest=True, sorted=True
+            ).indices.T
+
+        return next_token_ids
 
 
-def multinomial(
-    logits: torch.DoubleTensor, samples: int, rng: torch.Generator
-) -> torch.DoubleTensor:
+greedy = GreedySampler
+
+
+class MultinomialSampler:
     """Multinomial sampling algorithm.
 
     Multinomial sampling consists in randomly sampling the next token assuming
     its distribution is a Categorical distribution parametrized by the
     next-token logits.
 
-    Parameters
-    ----------
-    logits
-        A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
-        probability distribution of the next token over the vocabulary.
-    samples
-        The number of sequences to sample.
-    rng
-        A random number generator.
 
-    Returns
-    -------
-    The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+    Attributes
+    ----------
+    particles
+        The number of samples taken for each input sequence.
 
     """
-    probs = torch.nn.functional.softmax(logits, dim=-1)
-    next_token_ids = torch.multinomial(probs, num_samples=samples, generator=rng)
-    return next_token_ids
+
+    def __init__(self, samples: int = 1):
+        self.particles = samples
+
+    def __call__(
+        self, logits: torch.DoubleTensor, rng: torch.Generator
+    ) -> torch.DoubleTensor:
+        """Call the multinomial sampler.
+
+        Parameters
+        ----------
+        logits
+            A tensor of shape ``(n_seqs, vocab_size,)`` that represents the
+            probability distribution of the next token over the vocabulary.
+        rng
+            A random number generator.
+
+        Returns
+        -------
+        The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+
+        """
+        probs = torch.nn.functional.softmax(logits, dim=-1)
+        next_token_ids = torch.multinomial(probs, num_samples=1, generator=rng)
+        return next_token_ids
+
+
+multinomial = MultinomialSampler

--- a/outlines/generate/text.py
+++ b/outlines/generate/text.py
@@ -4,8 +4,8 @@ from typing import List, Optional, Union
 
 from outlines.fsm.fsm import StopAtEosFSM
 from outlines.generate import SequenceGenerator
-from outlines.generate.samplers import Sampler, multinomial
 from outlines.models import OpenAI
+from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
@@ -15,7 +15,7 @@ def text(
     stop_at: Optional[Union[str, List[str]]] = None,
     *,
     samples: int = 1,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ) -> SequenceGenerator:
     """Generate text with a `Transformer` model.
 
@@ -64,9 +64,9 @@ def text_openai(
     max_tokens: Optional[int] = None,
     stop_at: Optional[Union[List[str], str]] = None,
     *,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = multinomial(),
 ) -> OpenAI:
-    if not sampler == multinomial:
+    if not isinstance(sampler, multinomial):
         raise NotImplementedError(
             r"The OpenAI API does not support any other sampling algorithm "
             + "that the multinomial sampler."

--- a/outlines/samplers.py
+++ b/outlines/samplers.py
@@ -18,15 +18,12 @@ class GreedySampler:
     Greedy sampling consists in choosing the token with the largest
     likelihood at every step.
 
-    Attributes
-    ----------
-    particles
-        The number of samples taken for each input sequence.
+    We don't allow more than one sample as this does not really make sense.
 
     """
 
-    def __init__(self, samples: int = 1):
-        self.particles = samples
+    def __init__(self):
+        self.particles = 1
 
     def __call__(self, logits: torch.DoubleTensor, *_) -> torch.DoubleTensor:
         """Call the greedy sampler.
@@ -41,15 +38,10 @@ class GreedySampler:
 
         Returns
         -------
-        The ids of the sampled tokens having shape ``(samples, n_seqs)``.
+        The ids of the sampled tokens, of shape ``(n_seqs, 1)``
 
         """
-        if self.particles == 1:
-            next_token_ids = torch.argmax(logits, dim=-1, keepdim=True)
-        else:
-            next_token_ids = torch.topk(
-                logits, self.particles, dim=-1, largest=True, sorted=True
-            ).indices.T
+        next_token_ids = torch.argmax(logits, dim=-1, keepdim=True)
 
         return next_token_ids
 

--- a/outlines/text/generate/api.py
+++ b/outlines/text/generate/api.py
@@ -2,7 +2,7 @@ import warnings
 from typing import Callable, List, Optional, Union
 
 import outlines
-from outlines.generate.samplers import MultinomialSampler, Sampler
+from outlines.samplers import MultinomialSampler, Sampler
 
 
 def json(

--- a/outlines/text/generate/api.py
+++ b/outlines/text/generate/api.py
@@ -2,7 +2,7 @@ import warnings
 from typing import Callable, List, Optional, Union
 
 import outlines
-from outlines.generate.samplers import Sampler, multinomial
+from outlines.generate.samplers import MultinomialSampler, Sampler
 
 
 def json(
@@ -10,7 +10,7 @@ def json(
     schema_object: Union[str, object, Callable],
     max_tokens: Optional[int] = None,
     *,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = MultinomialSampler(),
 ):
     warnings.warn(
         "`outlines.text.generate.json` is deprecated, please use `outlines.generate.json` instead. "
@@ -25,7 +25,7 @@ def regex(
     regex_str: str,
     max_tokens: Optional[int] = None,
     *,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = MultinomialSampler(),
 ):
     warnings.warn(
         "`outlines.text.generate.regex` is deprecated, please use `outlines.generate.regex` instead. "
@@ -39,7 +39,7 @@ def format(
     model,
     python_type,
     max_tokens: Optional[int] = None,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = MultinomialSampler(),
 ):
     warnings.warn(
         "`outlines.text.generate.format` is deprecated, please use `outlines.generate.format` instead. "
@@ -54,7 +54,7 @@ def continuation(
     max_tokens: Optional[int] = None,
     stop_at: Optional[Union[str, List[str]]] = None,
     *,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = MultinomialSampler(),
 ):
     warnings.warn(
         "`outlines.text.generate.continuation` is deprecated, please use `outlines.generate.text` instead. "
@@ -70,7 +70,7 @@ def choice(
     choices: List[str],
     max_tokens: Optional[int] = None,
     *,
-    sampler: Sampler = multinomial,
+    sampler: Sampler = MultinomialSampler(),
 ):
     warnings.warn(
         "`outlines.text.generate.choice` is deprecated, please use `outlines.generate.choice` instead. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ serve = [
     "vllm>=0.3.0",
     "ray==2.9.0",
     "uvicorn",
-    "fastapi"
+    "fastapi",
+    "pydantic>=2.0",
 ]
 
 [project.urls]

--- a/tests/generate/test_generator.py
+++ b/tests/generate/test_generator.py
@@ -11,7 +11,6 @@ from outlines.generate.generator import (
     expand_attention_masks,
     get_allowed_tokens,
     get_next_fsm_states,
-    init_generator_state,
     is_generation_finished,
     sequence_generator,
     token_generator,
@@ -78,41 +77,6 @@ def test_sequence_generator_class():
     assert result == "x"
 
 
-def test_init_sequence_generator():
-    class MockFSM:
-        def next_state(self, state, next_token_ids):
-            return 0
-
-        def allowed_token_ids(self, _):
-            return []
-
-        def is_final_state(self, _):
-            return True
-
-    class MockTokenizer:
-        def encode(self, _):
-            return torch.tensor([[0, 1, 2, 3]]), torch.tensor([[1, 1, 1, 1]])
-
-        def decode(self, _):
-            return "x"
-
-    class MockModel:
-        def __init__(self):
-            self.tokenizer = MockTokenizer()
-
-        def __call__(*_):
-            return torch.tensor([[0, 1, 2, 3]], dtype=torch.float), None
-
-    def sampler(biased_logits, *_):
-        return torch.argmax(biased_logits, keepdims=True)
-
-    result = init_generator_state(MockTokenizer(), "cpu", "")
-    token_ids, attention_masks, kv_cache = result
-    assert torch.equal(token_ids, torch.tensor([[0, 1, 2, 3]]))
-    assert torch.equal(attention_masks, torch.tensor([[1, 1, 1, 1]]))
-    assert kv_cache is None
-
-
 def test_sequence_generator_1d_single_iteration():
     class MockFSM:
         def next_state(self, state, next_token_ids):
@@ -144,15 +108,23 @@ def test_sequence_generator_1d_single_iteration():
     def sampler(biased_logits, *_):
         return torch.argmax(biased_logits, keepdims=True)
 
-    init_state = (torch.tensor([[0, 1, 2, 3]]), torch.tensor([[1, 1, 1, 1]]), None)
+    token_ids, attention_mask = (
+        torch.tensor([[0, 1, 2, 3]]),
+        torch.tensor([[1, 1, 1, 1]]),
+    )
     init_fsm_states = [0]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, [MockFSM()], init_state, init_fsm_states, rng=torch.Generator()
+        generate,
+        [MockFSM()],
+        token_ids,
+        attention_mask,
+        init_fsm_states,
+        rng=torch.Generator(),
     )
     result = next(sequence)
 
-    assert torch.equal(result.token_ids, torch.tensor([[[0, 1, 2, 3, 3]]]))
+    assert torch.equal(result.token_ids, torch.tensor([[0, 1, 2, 3, 3]]))
     assert torch.equal(result.logits, torch.tensor([[0, 1, 2, 3]]))
 
     with pytest.raises(StopIteration):
@@ -193,19 +165,27 @@ def test_sequence_generator_1d_several_iterations():
     def sampler(biased_logits, *_):
         return torch.argmax(biased_logits, keepdims=True)
 
-    init_state = (torch.tensor([[0, 1, 2, 3]]), torch.tensor([[1, 1, 1, 1]]), None)
+    token_ids, attention_mask = (
+        torch.tensor([[0, 1, 2, 3]]),
+        torch.tensor([[1, 1, 1, 1]]),
+    )
     init_fsm_states = [0]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, [MockFSM()], init_state, init_fsm_states, rng=torch.Generator()
+        generate,
+        [MockFSM()],
+        token_ids,
+        attention_mask,
+        init_fsm_states,
+        rng=torch.Generator(),
     )
 
     result = next(sequence)
-    assert torch.equal(result.token_ids, torch.tensor([[[0, 1, 2, 3, 3]]]))
+    assert torch.equal(result.token_ids, torch.tensor([[0, 1, 2, 3, 3]]))
     assert torch.equal(result.logits, torch.tensor([[0, 1, 2, 3]]))
 
     result = next(sequence)
-    assert torch.equal(result.token_ids, torch.tensor([[[0, 1, 2, 3, 3, 3]]]))
+    assert torch.equal(result.token_ids, torch.tensor([[0, 1, 2, 3, 3, 3]]))
     assert torch.equal(result.logits, torch.tensor([[0, 1, 2, 3]]))
 
     with pytest.raises(StopIteration):
@@ -245,73 +225,9 @@ def test_sequence_generator_2d_single_iteration():
     def sampler(biased_logits, *_):
         return torch.argmax(biased_logits, keepdims=True, dim=-1)
 
-    init_state = (
+    token_ids, attention_mask = (
         torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]),
         torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]]),
-        None,
-    )
-    init_fsm_states = [0, 0]
-    fsms = [MockFSM(), MockFSM()]
-    generate = token_generator(MockModel(), sampler)
-    sequence = sequence_generator(
-        generate, fsms, init_state, init_fsm_states, rng=torch.Generator()
-    )
-
-    result = next(sequence)
-    assert torch.equal(
-        result.token_ids, torch.tensor([[[0, 1, 2, 3, 3], [4, 5, 6, 7, 2]]])
-    )
-    assert torch.equal(
-        result.logits, torch.tensor([[0, 1, 2, 3], [4, 5, 7, 6]], dtype=torch.float)
-    )
-
-    with pytest.raises(StopIteration):
-        next(sequence)
-
-
-def test_sequence_generator_2d_single_iteration_several_samples():
-    class MockFSM:
-        def next_state(self, state, next_token_ids):
-            return 0
-
-        def allowed_token_ids(self, _):
-            return [0, 1, 2, 3]
-
-        def is_final_state(self, _):
-            return True
-
-        def copy(self):
-            return self
-
-    class MockTokenizer:
-        def encode(self, _):
-            return torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]), torch.tensor(
-                [[1, 1, 1, 1], [1, 1, 1, 1]]
-            )
-
-        def decode(self, x):
-            return x
-
-    class MockModel:
-        def __init__(self):
-            self.tokenizer = MockTokenizer()
-
-        def __call__(*_):
-            return (
-                torch.tensor(
-                    [[0, 1, 2, 3], [4, 5, 7, 6], [0, 1, 2, 3], [1, 5, 3, 4]],
-                    dtype=torch.float,
-                ),
-                None,
-            )
-
-    def sampler(biased_logits, *_):
-        return torch.argmax(biased_logits, keepdims=True, dim=-1)
-
-    init_state = (
-        torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]),
-        torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]]),
-        None,
     )
     init_fsm_states = [0, 0]
     fsms = [MockFSM(), MockFSM()]
@@ -319,25 +235,19 @@ def test_sequence_generator_2d_single_iteration_several_samples():
     sequence = sequence_generator(
         generate,
         fsms,
-        init_state,
+        token_ids,
+        attention_mask,
         init_fsm_states,
-        num_samples=2,
         rng=torch.Generator(),
     )
 
     result = next(sequence)
-    expected_token_ids = torch.tensor(
-        [
-            [[0, 1, 2, 3, 3], [0, 1, 2, 3, 2]],
-            [[4, 5, 6, 7, 3], [4, 5, 6, 7, 1]],
-        ]
+    assert torch.equal(
+        result.token_ids, torch.tensor([[0, 1, 2, 3, 3], [4, 5, 6, 7, 2]])
     )
-    assert torch.equal(result.token_ids, expected_token_ids)
-
-    expected_logits = torch.tensor(
-        [[0, 1, 2, 3], [4, 5, 7, 6], [0, 1, 2, 3], [1, 5, 3, 4]], dtype=torch.float
+    assert torch.equal(
+        result.logits, torch.tensor([[0, 1, 2, 3], [4, 5, 7, 6]], dtype=torch.float)
     )
-    assert torch.equal(result.logits, expected_logits)
 
     with pytest.raises(StopIteration):
         next(sequence)
@@ -379,21 +289,25 @@ def test_sequence_generator_2d_several_iterations():
     def sampler(biased_logits, *_):
         return torch.argmax(biased_logits, keepdims=True, dim=-1)
 
-    init_state = (
+    token_ids, attention_mask = (
         torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]),
         torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]]),
-        None,
     )
     init_fsm_states = [0, 0]
     fsms = [MockFSM(), MockFSM()]
     generate = token_generator(MockModel(), sampler)
     sequence = sequence_generator(
-        generate, fsms, init_state, init_fsm_states, rng=torch.Generator()
+        generate,
+        fsms,
+        token_ids,
+        attention_mask,
+        init_fsm_states,
+        rng=torch.Generator(),
     )
 
     result = next(sequence)
     assert torch.equal(
-        result.token_ids, torch.tensor([[[0, 1, 2, 3, 3], [4, 5, 6, 7, 2]]])
+        result.token_ids, torch.tensor([[0, 1, 2, 3, 3], [4, 5, 6, 7, 2]])
     )
     assert torch.equal(
         result.logits, torch.tensor([[0, 1, 2, 3], [4, 5, 7, 6]], dtype=torch.float)
@@ -401,7 +315,7 @@ def test_sequence_generator_2d_several_iterations():
 
     result = next(sequence)
     assert torch.equal(
-        result.token_ids, torch.tensor([[[0, 1, 2, 3, 3, 3], [4, 5, 6, 7, 2, 2]]])
+        result.token_ids, torch.tensor([[0, 1, 2, 3, 3, 3], [4, 5, 6, 7, 2, 2]])
     )
     assert torch.equal(
         result.logits, torch.tensor([[0, 1, 2, 3], [4, 5, 7, 6]], dtype=torch.float)

--- a/tests/generate/test_generator.py
+++ b/tests/generate/test_generator.py
@@ -50,11 +50,15 @@ def test_sequence_generator_class():
         def __call__(*_):
             return torch.tensor([[0, 1, 2, 3, 4]], dtype=torch.float), None
 
-    def sampler(biased_logits, *_):
-        return torch.argmax(biased_logits, keepdims=True)
+    class sampler:
+        def __init__(self):
+            self.particles = 1
+
+        def __call__(self, biased_logits, *_):
+            return torch.argmax(biased_logits, keepdims=True)
 
     # Stream
-    generator = SequenceGenerator(MockFSM(), MockModel(), sampler, "cpu")
+    generator = SequenceGenerator(MockFSM(), MockModel(), sampler(), "cpu")
     assert generator.device == "cpu"
     assert isinstance(generator.tokenizer, MockTokenizer)
     assert isinstance(generator.fsm, MockFSM)
@@ -69,7 +73,7 @@ def test_sequence_generator_class():
         next(sequence)
 
     # Call
-    generator = SequenceGenerator(MockFSM(), MockModel(), sampler, "cpu")
+    generator = SequenceGenerator(MockFSM(), MockModel(), sampler(), "cpu")
     result = generator("test")
     assert result == "x"
 

--- a/tests/generate/test_integration_transfomers.py
+++ b/tests/generate/test_integration_transfomers.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel, constr
 import outlines.generate as generate
 import outlines.models as models
 from outlines.fsm.regex import reduced_vocabulary
-from outlines.generate.samplers import multinomial
 from outlines.models.transformers import TransformerTokenizer
+from outlines.samplers import multinomial
 
 
 def test_deprecation():

--- a/tests/generate/test_samplers.py
+++ b/tests/generate/test_samplers.py
@@ -29,12 +29,7 @@ def test_multinomial():
     next_token_ids = multinomial(logits, 1, rng)
     assert next_token_ids.equal(torch.tensor([[2]]))
 
-    next_token_ids = multinomial(logits, 2, rng)
-    assert next_token_ids.equal(torch.tensor([[2, 1]]))
-
+    sampler = MultinomialSampler()
     logits = torch.tensor([[10.0, 0.0, 9.0], [-math.inf, 4.0, 5.0]])
-    next_token_ids = multinomial(logits, 1, rng)
-    assert next_token_ids.equal(torch.tensor([[0], [1]]))
-
-    next_token_ids = multinomial(logits, 2, rng)
-    assert next_token_ids.equal(torch.tensor([[2, 0], [2, 1]]))
+    next_token_ids = sampler(logits, rng)
+    assert next_token_ids.equal(torch.tensor([[0], [2]]))

--- a/tests/generate/test_samplers.py
+++ b/tests/generate/test_samplers.py
@@ -2,22 +2,36 @@ import math
 
 import torch
 
-from outlines.generate.samplers import greedy, multinomial
+from outlines.generate.samplers import (
+    GreedySampler,
+    MultinomialSampler,
+    greedy,
+    multinomial,
+)
+
+
+def test_aliases():
+    assert greedy == GreedySampler
+    assert multinomial == MultinomialSampler
 
 
 def test_greedy():
+    sampler = GreedySampler()
     logits = torch.tensor([[1.0, 2.0, 5.0]])
-    next_token_ids = greedy(logits, samples=1)
+    next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[2]]))
 
-    next_token_ids = greedy(logits, samples=2)
+    sampler = GreedySampler(2)
+    next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[2], [1]]))
 
+    sampler = GreedySampler()
     logits = torch.tensor([[10.0, 0.0, 3.0], [-math.inf, 2.0, 5.0]])
-    next_token_ids = greedy(logits, samples=1)
+    next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[0], [2]]))
 
-    next_token_ids = greedy(logits, samples=2)
+    sampler = GreedySampler(2)
+    next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[0, 2], [2, 1]]))
 
 
@@ -25,8 +39,9 @@ def test_multinomial():
     rng = torch.Generator()
     rng.manual_seed(239)
 
+    sampler = MultinomialSampler()
     logits = torch.tensor([[1.0, 4.0, 5.0]])
-    next_token_ids = multinomial(logits, 1, rng)
+    next_token_ids = sampler(logits, rng)
     assert next_token_ids.equal(torch.tensor([[2]]))
 
     sampler = MultinomialSampler()

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -2,12 +2,7 @@ import math
 
 import torch
 
-from outlines.generate.samplers import (
-    GreedySampler,
-    MultinomialSampler,
-    greedy,
-    multinomial,
-)
+from outlines.samplers import GreedySampler, MultinomialSampler, greedy, multinomial
 
 
 def test_aliases():
@@ -21,18 +16,10 @@ def test_greedy():
     next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[2]]))
 
-    sampler = GreedySampler(2)
-    next_token_ids = sampler(logits)
-    assert next_token_ids.equal(torch.tensor([[2], [1]]))
-
     sampler = GreedySampler()
     logits = torch.tensor([[10.0, 0.0, 3.0], [-math.inf, 2.0, 5.0]])
     next_token_ids = sampler(logits)
     assert next_token_ids.equal(torch.tensor([[0], [2]]))
-
-    sampler = GreedySampler(2)
-    next_token_ids = sampler(logits)
-    assert next_token_ids.equal(torch.tensor([[0, 2], [2, 1]]))
 
 
 def test_multinomial():


### PR DESCRIPTION
Closes #416 

### TODO

- [x] Use `torch.repeat_interleave` so samples of the same sequence in a batch are contiguous (easier for beam search)
- [x] Make sure the FSMs are corrrectly duplicated

### Questions

- Do we make the sequence generator return arrays of shape `(num_samples * batch_size, num_tokens)`, and reshape in `SequenceGenerator`? Reshaping in the generator makes the latter much more complex. We could also not reshape at all, and let the user do it manually, which will simplify chained calls in the future.