### PR TITLE
vLLM request parameters `constraint_mode` and `constraint`

### DIFF
--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -33,7 +33,8 @@ For example, to generate a string that matches the schema `{"type": "string"}` (
 curl http://127.0.0.1:8000/generate \
     -d '{
         "prompt": "What is the capital of France?",
-        "schema": {"type": "string"}
+        "grammar_mode": "json_schema",
+        "grammar": {"type": "string"}
         }'
 ```
 
@@ -43,7 +44,8 @@ To generate a string that matches the regex `(-)?(0|[1-9][0-9]*)(\.[0-9]+)?([eE]
 curl http://127.0.0.1:8000/generate \
     -d '{
         "prompt": "What is Pi? Give me the first 15 digits: ",
-        "regex": "(-)?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-][0-9]+)?"
+        "grammar_mode": "regex",
+        "grammar": "(-)?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-][0-9]+)?"
         }'
 ```
 

--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -33,8 +33,8 @@ For example, to generate a string that matches the schema `{"type": "string"}` (
 curl http://127.0.0.1:8000/generate \
     -d '{
         "prompt": "What is the capital of France?",
-        "grammar_mode": "json_schema",
-        "grammar": {"type": "string"}
+        "constraint_mode": "json_schema",
+        "constraint": {"type": "string"}
         }'
 ```
 
@@ -44,8 +44,8 @@ To generate a string that matches the regex `(-)?(0|[1-9][0-9]*)(\.[0-9]+)?([eE]
 curl http://127.0.0.1:8000/generate \
     -d '{
         "prompt": "What is Pi? Give me the first 15 digits: ",
-        "grammar_mode": "regex",
-        "grammar": "(-)?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-][0-9]+)?"
+        "constraint_mode": "regex",
+        "constraint": "(-)?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-][0-9]+)?"
         }'
 ```
 

--- a/outlines/serve/serve.py
+++ b/outlines/serve/serve.py
@@ -83,11 +83,15 @@ async def generate(request: Request) -> Response:
         constraint = regex_string
 
     if constraint_mode is not None:
+        if constraint is None:
+            return Response(status_code=400, content=f'Please set constraint in addition to constraint_mode.')
         logits_processor_cls = LOGITS_PROCESSOR_CLASSES.get(constraint_mode)
         if logits_processor_cls is None:
             return Response(status_code=400, content=f'Invalid constraint_mode: {constraint_mode}')
         logits_processors = [logits_processor_cls(constraint, engine.engine)]
     else:
+        if constraint is not None:
+            return Response(status_code=400, content=f'Please set constraint_mode in addition to constraint.')
         logits_processors = []
 
     sampling_params = SamplingParams(


### PR DESCRIPTION
Introduced generic vLLM request parameters `constraint_mode` and `constraint` to replace `json_schema` and `regex`.

The main reason for the change is to allow for adding an arbitrary number of grammars types without having to add new parameters to the vLLM API every time. It also reduces the probability of a future collision with an original vLLM request parameter name. 

It also reduces confusion due to naming, like `cfg` meaning both "configuration" and "Context-Free Grammar", which was confusing at least to me. (This is for the upcoming PR to introduce full Lark grammar support to the vLLM API.)

Kept the old `json_schema` and `regex` parameters for backwards compatibility, but we should remove them soon.