### PR TITLE
Clear cache upon version upgrade

### DIFF
--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -22,7 +22,7 @@ def get_cache():
     environment variable.
 
     """
-    from outlines._version import __version__ as outlines_version
+    from outlines._version import __version__ as outlines_version  # type: ignore
 
     home_dir = os.path.expanduser("~")
     cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")

--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import hashlib
 import os
 from typing import Callable, Optional
@@ -6,10 +7,30 @@ from typing import Callable, Optional
 import cloudpickle
 from diskcache import Cache
 
-home_dir = os.path.expanduser("~")
-cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
-memory = Cache(cache_dir, eviction_policy="none", cull_limit=0)
 _caching_enabled = True
+
+
+@functools.lru_cache(1)
+def get_cache():
+    """Get the context object that contains previously-computed return values.
+
+    The cache is used to avoid unnecessary computations and API calls, which can
+    be long and expensive for large models.
+
+    The cache directory defaults to `HOMEDIR/.cache/outlines`, but this choice
+    can be overridden by the user by setting the value of the `OUTLINES_CACHE_DIR`
+    environment variable.
+
+    """
+    from outlines._version import __version__ as outlines_version
+
+    home_dir = os.path.expanduser("~")
+    cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
+    memory = Cache(cache_dir, eviction_policy="none", cull_limit=0)
+    if outlines_version != memory.get("__version__"):
+        memory.clear()
+    memory["__version__"] = outlines_version
+    return memory
 
 
 def hash_arguments(*args, **kwargs) -> str:
@@ -35,6 +56,8 @@ def cache(key_function: Optional[Callable] = None):
     """
 
     def decorator(cached_function: Callable):
+        memory = get_cache()
+
         def wrapper(*args, **kwargs):
             if not _caching_enabled:
                 return cached_function(*args, **kwargs)
@@ -71,20 +94,6 @@ def cache(key_function: Optional[Callable] = None):
     return decorator
 
 
-def get_cache():
-    """Get the context object that contains previously-computed return values.
-
-    The cache is used to avoid unnecessary computations and API calls, which can
-    be long and expensive for large models.
-
-    The cache directory defaults to `HOMEDIR/.cache/outlines`, but this choice
-    can be overridden by the user by setting the value of the `OUTLINES_CACHE_DIR`
-    environment variable.
-
-    """
-    return memory
-
-
 def disable_cache():
     """Disable the cache for this session.
 
@@ -111,5 +120,5 @@ def disable_cache():
 
 def clear_cache():
     """Erase the cache completely."""
-    global memory
+    memory = get_cache()
     memory.clear()

--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -27,9 +27,12 @@ def get_cache():
     home_dir = os.path.expanduser("~")
     cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
     memory = Cache(cache_dir, eviction_policy="none", cull_limit=0)
+
+    # ensure if version upgrade occurs, old cache is pruned
     if outlines_version != memory.get("__version__"):
         memory.clear()
     memory["__version__"] = outlines_version
+
     return memory
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-mocker",
+    "pytest-mock",
     "transformers",
     "coverage[toml]>=5.1",
     "diff-cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-mocker",
     "transformers",
     "coverage[toml]>=5.1",
     "diff-cover",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -117,14 +117,15 @@ def test_clear_cache(test_cache):
 def test_version_upgrade_cache_invalidate(test_cache, mocker):
     """Ensure we can change the signature of a cached function if we upgrade the version"""
 
+    import outlines.caching
+
     def simulate_restart_outlines():
         # clearing in-memory lru_cache which returns the diskcache in
         # order to simulate a reload, we're not clearing the diskcache itself
         outlines.caching.get_cache.cache_clear()
 
-    import outlines.caching
-
     mocker.patch("outlines._version.__version__", new="0.0.0")
+    simulate_restart_outlines()
 
     # initialize cache with signature of Tuple-of-3
     @test_cache


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/561

Smoke test:

```
[nix-shell:~/p/outlines]$ git branch --show-current
clear-cache-upon-version-upgrade


[nix-shell:~/p/outlines]$ python3 -c "from outlines.fsm.fsm import RegexFSM; from outlines.models.transformers import TransformerTokenizer; RegexFSM('a', TransformerTokenizer('gpt2'))" && echo "success"
success


[nix-shell:~/p/outlines]$ git checkout benl/fsm-enhancements
[nix-shell:~/p/outlines]$ pip install . -q
[nix-shell:~/p/outlines]$ python3 -c "from outlines.fsm.fsm import RegexFSM; from outlines.models.transformers import TransformerTokenizer; RegexFSM('a', TransformerTokenizer('gpt2'))" && echo "success"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/andrew/p/outlines/outlines/fsm/fsm.py", line 120, in __init__
    self.states_to_token_maps, self.empty_token_ids = create_states_mapping(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)


[nix-shell:~/p/outlines]$ git merge clear-cache-upon-version-upgrade
Merge made by the 'ort' strategy.

[nix-shell:~/p/outlines]$ pip install . -q
[nix-shell:~/p/outlines]$ python3 -c "from outlines.fsm.fsm import RegexFSM; from outlines.models.transformers import TransformerTokenizer; RegexFSM('a', TransformerTokenizer('gpt2'))" && echo "success"
success

```