### PR TITLE
Pin transformers version to 4.36.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
    "referencing",
    "jsonschema",
    "requests",
+   "transformers==4.36.2",  # TODO: unpin when HF fixes release (4.37.0 is broken)
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Temporarily change to prevent failures described in https://github.com/outlines-dev/outlines/issues/568

Won't apply "fix" label because we don't know the root source of the issue (i.e. whether it's a result of incompatability or if it's a bad version of `transformers`)