### PR TITLE
Bump vLLM version to `0.3.0`

### DIFF
--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -4,12 +4,7 @@ Outlines can be deployed as an LLM service using the vLLM inference engine and a
 
 ```bash
 pip install outlines[serve]
-pip install "pydantic>=2.0"
 ```
-
-!!! Warning
-
-    Updating Pydantic to v2 after the installation is necessary.
 
 You can then start the server with:
 

--- a/outlines/serve/vllm.py
+++ b/outlines/serve/vllm.py
@@ -51,7 +51,7 @@ class RegexLogitsProcessor:
             An instance of `vllm.LLM`
 
         """
-        tokenizer = self.adapt_tokenizer(llm.tokenizer)
+        tokenizer = self.adapt_tokenizer(llm.tokenizer.tokenizer)
 
         fsm = RegexFSM(regex_string, tokenizer)
         self.fsm = fsm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
     "huggingface_hub"
 ]
 serve = [
-    "vllm>=0.2.6",
+    "vllm>=0.3.0",
     "ray==2.9.0",
     "uvicorn",
     "fastapi"


### PR DESCRIPTION
- [x] pin new version
- [x] Fix serving with vLLM, `LLMEngine.tokenizer` uses a new class now: `TokenizerGroup`
- [x] Update docs regarding `pydantic`

Fixes https://github.com/outlines-dev/outlines/issues/576

Fixes https://github.com/outlines-dev/outlines/issues/504

vLLM `main` is incompatible with outlines. Do not merge until `vllm==0.2.8` is released, leaving as draft until then.