### PR TITLE
Bugfix:  Fixes dtype issue described in #583

### DIFF
--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -282,7 +282,7 @@ def bias_logits(logits: torch.Tensor, allowed_token_ids: List) -> torch.Tensor:
     A view of the original logits tensor where some values are masked.
 
     """
-    biased_logits = torch.full(logits.shape, -math.inf, device=logits.device)
+    biased_logits = torch.full_like(logits, -math.inf, device=logits.device)
     for i, ids in enumerate(allowed_token_ids):
-        biased_logits[i, ids] = logits[i, ids].to(biased_logits.dtype)
+        biased_logits[i, ids] = logits[i, ids]
     return biased_logits

--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -284,5 +284,5 @@ def bias_logits(logits: torch.Tensor, allowed_token_ids: List) -> torch.Tensor:
     """
     biased_logits = torch.full(logits.shape, -math.inf, device=logits.device)
     for i, ids in enumerate(allowed_token_ids):
-        biased_logits[i, ids] = logits[i, ids]
+        biased_logits[i, ids] = logits[i, ids].to(biased_logits.dtype)
     return biased_logits


### PR DESCRIPTION
Exllama generates logits in torch Half-dtype, but Outlines requires the Float-dtype. 

This small change converts the logits to the required dtype (whatever that might be), solving issue #583.

Tested with Exllama on the example code on the github front page, and #583 is resolved.