### PR TITLE
Reset `lark` package in `test_parsing.py`

### DIFF
--- a/tests/fsm/test_parsing.py
+++ b/tests/fsm/test_parsing.py
@@ -1,5 +1,7 @@
+import importlib
 from copy import copy
 
+import lark.lark
 import pytest
 from lark.indenter import DedentError
 from lark.lexer import UnexpectedCharacters, UnexpectedToken
@@ -134,6 +136,9 @@ def test_partial_parsing():
     assert len(parser_state.state_stack) == 4
     assert parser_state.value_stack[-1].type == "LPAR"
 
+    # Clean up lark.lark.LarkOptions._defaults
+    importlib.reload(lark.lark)
+
 
 def test_sequential_parse_example():
     input_tokens = [
@@ -195,3 +200,6 @@ def test_sequential_parse_example():
 
         if i + 1 == len(input_tokens):
             assert all(tk in next_vocab for tk in ["\n", "\nde", "  ", " + 1"])
+
+    # Clean up lark.lark.LarkOptions._defaults
+    importlib.reload(lark.lark)


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/595

`test_grammars.py` fails if `test_parsing.py` is run first. This results in tests failing in https://github.com/outlines-dev/outlines/pull/539

This changeset ensures that `test_parsing.py` is isolated and doesn't impact other tests. 

Previously running the tests would impact `lark.lark.LarkOptions._defaults` (A class variable, not an instance variable), now the impact is erased via `importlib.reload(lark.lark)`