### PR TITLE
Update openai_compatible.py

### DIFF
--- a/outlines/models/openai_compatible.py
+++ b/outlines/models/openai_compatible.py
@@ -23,7 +23,7 @@ class OpenAICompatibleAPI(OpenAI):
         timeout: Optional[float] = None,
         system_prompt: Optional[str] = None,
         config: Optional[OpenAIConfig] = None,
-        encoding="gpt4",  # Default for tiktoken, should USUALLY work
+        encoding="gpt-4",  # Default for tiktoken, should USUALLY work
     ):
         """Create an `OpenAI` instance.
 


### PR DESCRIPTION
Fixing error

KeyError: 'Could not automatically map gpt4 to a tokeniser. Please use `tiktoken.get_encoding` to explicitly get the tokeniser you expect.'