### PR TITLE
Make json array generation more flexible

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -246,16 +246,22 @@ def to_regex(resolver: Resolver, instance: dict):
             return type_to_regex["integer"]
 
         elif instance_type == "array":
-            min_items = instance.get("minItems", "0")
-            max_items = instance.get("maxItems", "")
-            if min_items == max_items:
-                num_repeats = "{" + str(int(min_items) - 1) + "}"
+            min_items = int(instance.get("minItems", "0"))
+            max_items = instance.get("maxItems", None)
+            max_items = max_items if max_items is None else int(max_items)
+            
+            if max_items is None:
+                num_repeats = rf"{{{max(min_items - 1, 0)},}}"
             else:
-                num_repeats = "*"
+                if max_items < 1:
+                    return rf"\[{WHITESPACE}\]"
+                num_repeats = rf"{{{max(min_items - 1, 0)},{max_items - 1}}}"
+
+            allow_empty = "?" if min_items == 0 else ""
 
             if "items" in instance:
                 items_regex = to_regex(resolver, instance["items"])
-                return rf"\[({items_regex})(,({items_regex})){num_repeats}\]"
+                return rf"\[(({items_regex})(,{WHITESPACE}({items_regex})){num_repeats}){allow_empty}\]"
             else:
                 # Here we need to make the choice to exclude generating list of objects
                 # if the specification of the object is not given, even though a JSON
@@ -269,7 +275,7 @@ def to_regex(resolver: Resolver, instance: dict):
                 ]
                 regexes = [to_regex(resolver, t) for t in types]
                 return (
-                    rf"\[({'|'.join(regexes)})(,({'|'.join(regexes)})){num_repeats}\]"
+                    rf"\[({'|'.join(regexes)})(,{WHITESPACE}({'|'.join(regexes)})){num_repeats}){allow_empty}\]"
                 )
 
         elif instance_type == "boolean":

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -249,7 +249,7 @@ def to_regex(resolver: Resolver, instance: dict):
             min_items = int(instance.get("minItems", "0"))
             max_items = instance.get("maxItems", None)
             max_items = max_items if max_items is None else int(max_items)
-            
+
             if max_items is None:
                 num_repeats = rf"{{{max(min_items - 1, 0)},}}"
             else:
@@ -261,7 +261,7 @@ def to_regex(resolver: Resolver, instance: dict):
 
             if "items" in instance:
                 items_regex = to_regex(resolver, instance["items"])
-                return rf"\[(({items_regex})(,{WHITESPACE}({items_regex})){num_repeats}){allow_empty}\]"
+                return rf"\[{WHITESPACE}(({items_regex})(,{WHITESPACE}({items_regex})){num_repeats}){allow_empty}{WHITESPACE}\]"
             else:
                 # Here we need to make the choice to exclude generating list of objects
                 # if the specification of the object is not given, even though a JSON
@@ -274,9 +274,7 @@ def to_regex(resolver: Resolver, instance: dict):
                     {"type": "string"},
                 ]
                 regexes = [to_regex(resolver, t) for t in types]
-                return (
-                    rf"\[({'|'.join(regexes)})(,{WHITESPACE}({'|'.join(regexes)})){num_repeats}){allow_empty}\]"
-                )
+                return rf"\[{WHITESPACE}({'|'.join(regexes)})(,{WHITESPACE}({'|'.join(regexes)})){num_repeats}){allow_empty}{WHITESPACE}\]"
 
         elif instance_type == "boolean":
             return type_to_regex["boolean"]


### PR DESCRIPTION
Makes the regex generated for json arrays more valid and flexible.

1. Allows for empty lists when min_items == 0
2. Allows whitespace between array elements
3. Adds support for maxItems (before, having any maxItems != minItems would allow infinite repeats)

