### PR TITLE
Log Logits

### DIFF
--- a/docs/reference/debug.md
+++ b/docs/reference/debug.md
@@ -1,0 +1,92 @@
+---
+title: Debugging
+---
+
+# Debugging
+
+Language models are a new and complex area of research. Adding constrained generation to them can bring up unexpected issues. We have some debugging methods documented here to help determine the source(s) of problems.
+
+## Understanding Generation Quality Issues
+
+Language models determine the probability of every possible next-token based on the full sequence of preceding tokens. In Outlines, we can either choose the highest probability next token ("Greedy") or select randomly weighted by token probability ("Multinomial").
+
+If the output quality is lacking, the model (or prompt) might not be well-suited for your particular use case. Logging next-token-probabilities, based on the model's "logits" can help with troubleshooting. This can be accomplished via `outlines.logging.enable_logits_logging()`.
+
+_(Note: `enable_logits_logging()` will slow down generation and shouldn't be used in production.)_
+
+### Example:
+
+In this debug example we attempt to extract sentiment from a restaurant review, but at first the model is struggling.
+
+```python
+import outlines.logging
+outlines.logging.enable_logits_logging()
+
+import outlines
+
+model = outlines.models.transformers("mistralai/Mistral-7B-Instruct-v0.2")
+
+prompt = """You are a sentiment-labelling assistant.
+Is the following review positive or negative?
+
+Review: This restaurant is just awesome!
+"""
+
+generator = outlines.generate.choice(model, ["Positive", "Negative"])
+answer = generator(prompt)
+```
+
+#### Output (click to expand)
+
+<details>
+
+```
+Selected: 'N' for batch_item=0
+	Top Raw Tokens: 'The': 0.560, '\n': 0.212, 'I': 0.106, 'Great': 0.017, 'From': 0.017, 'We': 0.013, 'F': 0.011, 'They': 0.006, EOS: 0.006
+	Top Guided Tokens: 'P': 0.456, 'N': 0.330, 'Pos': 0.173, 'Ne': 0.018, 'Neg': 0.016, 'Po': 0.007, 'P': 0.000, 'N': 0.000, EOS: -0.000
+Selected: 'ega' for batch_item=0
+	Top Raw Tokens: 'ice': 0.964, 'ut': 0.006, 'at': 0.006, 'ood': 0.004, 'ic': 0.003, 'ick': 0.002, 'ear': 0.002, 'umer': 0.002, EOS: 0.002
+	Top Guided Tokens: 'eg': 0.514, 'ega': 0.419, 'e': 0.065, 'e': 0.001, '\x00': 0.000, '\x04': 0.000, '': 0.000, '\x01': 0.000, EOS: -0.000
+Selected: 't' for batch_item=0
+	Top Raw Tokens: 'ive': 0.442, 'ative': 0.381, 'тив': 0.054, ':': 0.030, 'iv': 0.006, 'itive': 0.006, 'Review': 0.005, 'ativ': 0.003, EOS: 0.003
+	Top Guided Tokens: 't': 0.903, 'ti': 0.097, 't': 0.000, '\x04': 0.000, '\x00': 0.000, '': 0.000, '\x01': 0.000, '\x02': 0.000, EOS: -0.000
+Selected: 'ive' for batch_item=0
+	Top Raw Tokens: 'ive': 0.993, 'ion': 0.005, 'iv': 0.002, 've': 0.000, 'ivity': 0.000, 'ively': 0.000, 'ives': 0.000, 'if': 0.000, EOS: 0.000
+	Top Guided Tokens: 'ive': 0.998, 'iv': 0.002, 'i': 0.000, 'i': 0.000, '\x00': 0.000, '\x04': 0.000, '': 0.000, '\x01': 0.000, EOS: -0.000
+Selected: '' for batch_item=0
+	Top Raw Tokens: ':': 0.625, '\n': 0.227, 'or': 0.073, ',': 0.022, '/': 0.016, '.': 0.008, '?': 0.007, '-': 0.003, EOS: 0.003
+	Top Guided Tokens: EOS: 1.000, '': 0.000, '\x04': 0.000, '\x01': 0.000, '\x00': 0.000, '': 0.000, '\x02': 0.000, '\x03': 0.000
+```
+
+</details>
+
+#### Analysis
+
+The model incorrectly classified the review as "Negative".
+
+We can observe in the "Raw Tokens" section that prior to constraining generation to "Positive" / "Negative" the most likely next token was `The`, and tokens allowing for legal generations had very low probabilities:
+
+```
+	Top Raw Tokens: 'The': 0.560, '\n': 0.212, 'I': 0.106, 'Great': 0.017, 'From': 0.017, 'We': 0.013, 'F': 0.011, 'They': 0.006, EOS: 0.006
+	Top Guided Tokens: 'P': 0.456, 'N': 0.330, 'Pos': 0.173, 'Ne': 0.018, 'Neg': 0.016, 'Po': 0.007, 'P': 0.000, 'N': 0.000, EOS: -0.000
+```
+
+Ideally the Raw Tokens are closely aligned to Guided Tokens. To accomplish this, we update the prompt as follows
+
+```python
+prompt = """You are a sentiment-labelling assistant.
+Is the following review positive or negative?
+
+Review: This restaurant is just awesome!
+
+Review label:
+"""
+```
+
+This change results in substantially better "Raw Tokens" and an accurate label being applied, the model assigns a 100% probability to "Positive", whereas previously the chance of "Positive" was ~64%:
+
+```
+Selected: 'Pos' for batch_item=0
+	Top Raw Tokens: 'Pos': 0.858, 'POS': 0.060, '\n': 0.031, 'pos': 0.022, '+': 0.007, '**': 0.007, 'The': 0.004, 'Pos': 0.002, EOS: 0.002
+	Top Guided Tokens: 'Pos': 1.000, 'P': 0.000, 'Po': 0.000, 'Neg': 0.000, 'Ne': 0.000, 'N': 0.000, 'P': 0.000, 'N': 0.000, EOS: -0.000
+```

--- a/docs/reference/debug.md
+++ b/docs/reference/debug.md
@@ -36,9 +36,7 @@ generator = outlines.generate.choice(model, ["Positive", "Negative"])
 answer = generator(prompt)
 ```
 
-#### Output (click to expand)
-
-<details>
+#### Output
 
 ```
 Selected: 'N' for batch_item=0
@@ -58,8 +56,6 @@ Selected: '' for batch_item=0
 	Top Guided Tokens: EOS: 1.000, '': 0.000, '\x04': 0.000, '\x01': 0.000, '\x00': 0.000, '': 0.000, '\x02': 0.000, '\x03': 0.000
 ```
 
-</details>
-
 #### Analysis
 
 The model incorrectly classified the review as "Negative".
@@ -71,7 +67,9 @@ We can observe in the "Raw Tokens" section that prior to constraining generation
 	Top Guided Tokens: 'P': 0.456, 'N': 0.330, 'Pos': 0.173, 'Ne': 0.018, 'Neg': 0.016, 'Po': 0.007, 'P': 0.000, 'N': 0.000, EOS: -0.000
 ```
 
-Ideally the Raw Tokens are closely aligned to Guided Tokens. To accomplish this, we update the prompt as follows
+#### Fix
+
+Ideally the Raw Tokens are closely aligned to Guided Tokens. To accomplish this, we update the prompt by appending a statement which we would expect to immediately precede "Positive" or "Negative" - "Review label:"
 
 ```python
 prompt = """You are a sentiment-labelling assistant.

--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -82,7 +82,7 @@ def sequence_generator(
             biased_logits, sequence_weights, rng
         )
 
-        log_logits(model.tokenizer, token_ids, biased_logits, next_token_ids)
+        log_logits(model.tokenizer, token_ids, logits, biased_logits, next_token_ids)
 
         token_ids = update_token_ids(token_ids, next_token_ids, ancestors)
         attention_masks = update_attention_masks(attention_masks, ancestors)

--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Tuple
 import torch
 
 from outlines.fsm.fsm import FSMState
+from outlines.logging import log_logits
+from outlines.models.model import OutlinesModel
 
 if TYPE_CHECKING:
     from outlines.fsm.fsm import FSM
@@ -24,7 +26,7 @@ class GenerationState:
 
 
 def sequence_generator(
-    model: Callable,
+    model: OutlinesModel,
     sampler: Callable,
     fsms: List["FSM"],
     token_ids: torch.Tensor,
@@ -79,6 +81,8 @@ def sequence_generator(
         next_token_ids, ancestors, sequence_weights = sampler(
             biased_logits, sequence_weights, rng
         )
+
+        log_logits(model.tokenizer, token_ids, biased_logits, next_token_ids)
 
         token_ids = update_token_ids(token_ids, next_token_ids, ancestors)
         attention_masks = update_attention_masks(attention_masks, ancestors)

--- a/outlines/logging.py
+++ b/outlines/logging.py
@@ -92,7 +92,7 @@ def log_logits(
         next_token_id = next_token_ids[b]
         token_ids = token_ids_group[b]
 
-        generation = only(tokenizer.decode(token_ids))
+        generation = tokenizer.decode(token_ids)
         next_token = only(tokenizer.decode(next_token_id))
 
         # Log the information for the current batch

--- a/outlines/logging.py
+++ b/outlines/logging.py
@@ -52,6 +52,8 @@ def log_logits(
         top_probs, top_indices = torch.topk(probs, top_n)
 
         # ensure EOS is included
+        if top_indices.device != tokenizer.eos_token_id.device:
+            top_indices = top_indices.to(tokenizer.eos_token_id.device)
         if tokenizer.eos_token_id not in top_indices:
             top_indices = torch.cat(
                 (top_indices, torch.tensor([tokenizer.eos_token_id]))

--- a/outlines/logging.py
+++ b/outlines/logging.py
@@ -30,9 +30,9 @@ def log_logits(
 
     Disabled unless you call enable_logits_logging()
 
-    Simple wrapper which logs
+    Simple utility function which logs
     - selected next token string
-    - probabilities for the EOS token, and the top n tokens
+    - probabilities for the EOS token, and the top n tokens for biased and unbiased logits
     """
     # this function is expensive, skip it if logging isn't enabled
     if logits_logger.getEffectiveLevel() >= LOG_LEVEL_OFF:

--- a/outlines/logging.py
+++ b/outlines/logging.py
@@ -52,13 +52,15 @@ def log_logits(
         top_probs, top_indices = torch.topk(probs, top_n)
 
         # ensure EOS is included
-        if top_indices.device != tokenizer.eos_token_id.device:
-            top_indices = top_indices.to(tokenizer.eos_token_id.device)
         if tokenizer.eos_token_id not in top_indices:
-            top_indices = torch.cat(
-                (top_indices, torch.tensor([tokenizer.eos_token_id]))
+            eos_token_id_tensor = torch.tensor(
+                [tokenizer.eos_token_id], device=top_indices.device
             )
-            top_probs = torch.cat((top_probs, torch.tensor([min(top_probs) - 1e-6])))
+            eos_prob_tensor = torch.tensor(
+                [min(top_probs) - 1e-12], device=top_probs.device
+            )
+            top_indices = torch.cat((top_indices, eos_token_id_tensor))
+            top_probs = torch.cat((top_probs, eos_prob_tensor))
 
         top_token_reprs = [
             "EOS"

--- a/outlines/logging.py
+++ b/outlines/logging.py
@@ -1,0 +1,68 @@
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from outlines.models.tokenizer import Tokenizer
+
+
+LOG_LEVEL_OFF = logging.CRITICAL + 100
+logits_logger = logging.getLogger("logits_logger")
+logits_logger.setLevel(LOG_LEVEL_OFF)
+logits_logger.addHandler(logging.StreamHandler(sys.stderr))
+
+
+def enable_logits_logging():
+    logits_logger.setLevel(logging.DEBUG)
+
+
+def log_logits(
+    tokenizer: "Tokenizer",
+    logits: torch.Tensor,
+    next_token_ids: torch.Tensor,
+    top_n: int = 8,
+):
+    """ """
+
+    def only(l):
+        assert len(list(l)) == 1
+        return l[0]
+
+    # this function is expensive, skip it if logging isn't enabled
+    if logits_logger.getEffectiveLevel() >= LOG_LEVEL_OFF:
+        return
+
+    if logits.dim() == 1:
+        logits = logits.unsqueeze(0)
+        next_token_ids = next_token_ids.unsqueeze(0)
+
+    batch_size = logits.size(0)
+
+    for b in range(batch_size):
+        current_logits = logits[b]
+        next_token_id = next_token_ids[b]
+
+        # all token probs for the current batch
+        probs = torch.nn.functional.softmax(current_logits, dim=-1)
+
+        # top candidate tokens probs
+        top_probs, top_indices = torch.topk(probs, top_n)
+        top_tokens_detail_str = ", ".join(
+            [
+                f"{repr(only(tokenizer.decode([idx])))}: {prob.item():.3f}"
+                for prob, idx in zip(top_probs, top_indices)
+            ]
+        )
+
+        # tokens from current_next_token_ids
+        next_token = only(tokenizer.decode(next_token_id))
+
+        # Log the information for the current batch
+        logits_logger.info(f"Selected: {repr(next_token)} for batch_item={b}")
+        logits_logger.info(
+            f"\tEOS Prob: {probs[tokenizer.eos_token_id].item()}"
+            + f"(logit = {current_logits[tokenizer.eos_token_id].item()})"
+        )
+        logits_logger.info(f"\tTop {top_n} Tokens: {top_tokens_detail_str}")

--- a/outlines/models/exllamav2.py
+++ b/outlines/models/exllamav2.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from outlines.models.model import OutlinesModel
+
 from .transformers import TransformerTokenizer
 
 if TYPE_CHECKING:
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer
 
 
-class ExLlamaV2Model:
+class ExLlamaV2Model(OutlinesModel):
     """Represents a `exl2` model."""
 
     def __init__(

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -5,10 +5,11 @@ import numpy as np
 import torch
 from numpy.typing import NDArray
 
+from outlines.models.model import OutlinesModel
 from outlines.models.tokenizer import Tokenizer
 
 
-class LlamaCpp:
+class LlamaCpp(OutlinesModel):
     """Represents a `llama_cpp` model."""
 
     def __init__(

--- a/outlines/models/mamba.py
+++ b/outlines/models/mamba.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from outlines.models.model import OutlinesModel
+
 from .transformers import TransformerTokenizer
 
 if TYPE_CHECKING:
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
 TOKENIZER_MODEL = "EleutherAI/gpt-neox-20b"
 
 
-class Mamba:
+class Mamba(OutlinesModel):
     """Represent a `mamba` model."""
 
     def __init__(

--- a/outlines/models/model.py
+++ b/outlines/models/model.py
@@ -1,0 +1,16 @@
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Protocol, Union
+
+from numpy.typing import NDArray
+from torch import FloatTensor
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
+
+
+class OutlinesModel(Protocol):
+    tokenizer: "PreTrainedTokenizer"
+
+    @abstractmethod
+    def __call__(self, *args: Any, **kwargs: Any) -> Union[FloatTensor, NDArray]:
+        ...

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from outlines.base import vectorize
 from outlines.caching import cache
+from outlines.models.model import OutlinesModel
 
 __all__ = ["OpenAI", "openai"]
 
@@ -71,7 +72,7 @@ class OpenAIConfig:
     user: str = field(default_factory=str)
 
 
-class OpenAI:
+class OpenAI(OutlinesModel):
     """An object that represents the OpenAI API."""
 
     def __init__(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
 
+from outlines.models.model import OutlinesModel
 from outlines.models.tokenizer import Tokenizer
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ def get_llama_tokenizer_types():
     )
 
 
-class Transformer:
+class Transformer(OutlinesModel):
     """Represents a `transformers` model."""
 
     def __init__(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,64 @@
+import importlib
+
+import pytest
+import torch
+
+import outlines.logging
+from outlines.generate.generator import sequence_generator, token_generator
+
+
+@pytest.mark.parametrize("enable_logger", [True, False])
+def test_token_generator_logger_call(enable_logger, mocker):
+    """log_logits() is expensive, assert only called when explicitly enabled"""
+
+    class MockFSM:
+        def next_state(self, state, next_token_ids):
+            return 0
+
+        def allowed_token_ids(self, _):
+            return []
+
+        def is_final_state(self, _):
+            return True
+
+    class MockTokenizer:
+        eos_token_id = 2
+
+        def decode(self, _):
+            return "x"
+
+    class MockModel:
+        def __init__(self):
+            self.tokenizer = MockTokenizer()
+
+        def __call__(*_):
+            return torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.float), None
+
+    def sampler(biased_logits, *_):
+        return torch.argmax(biased_logits, keepdims=True)
+
+    importlib.reload(outlines.logging)
+    if enable_logger:
+        outlines.logging.enable_logits_logging()
+
+    mock_logits_logger_info = mocker.patch("outlines.logging.logits_logger.info")
+
+    init_state = (
+        torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]]),
+        torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]]),
+        None,
+    )
+    init_fsm_states = [0]
+    generate = token_generator(MockModel(), sampler)
+    sequence = sequence_generator(
+        generate, [MockFSM()], init_state, init_fsm_states, torch.Generator()
+    )
+    next(sequence)
+
+    if enable_logger:
+        mock_logits_logger_info.assert_called()
+    else:
+        mock_logits_logger_info.assert_not_called()
+
+    # ensure enable_logits_logging() doesn't bleed into other tests
+    importlib.reload(outlines.logging)


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/614

- Documents debugging via `enable_logits_logging()``
- adds logging call to `sequence_generator`
- defines `OutlinesModel` to allow type checking guarantee that models have `__call__` method and a `tokenizer` attribute

Enable via 

```
import outlines.logging
outlines.logging.enable_logits_logging()
```

Example of use: https://github.com/outlines-dev/outlines/issues/612#issuecomment-1928748749


TODO:
- [x] implement
- [x] document ([Rendered](https://github.com/lapp0/outlines/blob/log-logits/docs/reference/debug.md))
- [x] tests to ensure expensive debug log code isn't run unless explicitly enabled