### PR TITLE
Allow JSON Schema Constraining to a Single Whitespace

### DIFF
--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -26,12 +26,20 @@ class User(BaseModel):
     id: int
 
 
-model = models.transformers("mistralai/Mistral-7B")
+model = models.transformers("mistralai/Mistral-7B-v0.1")
 generator = text.generate.json(model, User)
 result = generator("Create a user profile with the fields name, last_name and id")
 print(result)
 # User(name="John", last_name="Doe", id=11)
 ```
+
+!!! warning "JSON and whitespaces"
+
+    By default Outlines lets model choose the number of linebreaks and white spaces used to structure the JSON. Small models tend to struggle with this, in which case we recommend to set the value of the parameter `whitespace_pattern` to the empty string:
+
+    ```python
+    generator = text.generate.json(model, User, whitespace_pattern="")
+    ```
 
 ## From a function's signature
 
@@ -44,7 +52,7 @@ from outlines import text
 def add(a: int, b: int):
     return a + b
 
-model = models.transformers("mistralai/Mistral-7B")
+model = models.transformers("mistralai/Mistral-7B-v0.1")
 generator = text.generate.json(model, add)
 result = generator("Return two integers named a and b respectively. a is odd and b even.")
 

--- a/outlines/generate/json.py
+++ b/outlines/generate/json.py
@@ -1,6 +1,6 @@
 import json as pyjson
 from functools import singledispatch
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 from pydantic import BaseModel
 
@@ -14,21 +14,49 @@ from .regex import regex
 
 @singledispatch
 def json(
-    model, schema_object: Union[str, object, Callable], sampler: Sampler = multinomial()
+    model,
+    schema_object: Union[str, object, Callable],
+    sampler: Sampler = multinomial(),
+    whitespace_pattern: Optional[str] = None,
 ) -> SequenceGenerator:
+    """
+    Generate structured JSON data with a `Transformer` model based on a specified JSON Schema.
+
+    Parameters
+    ----------
+    model:
+        An instance of `Transformer` that represents a model from the
+        `transformers` library.
+    schema_object:
+        The JSON Schema to generate data for. Can be a JSON string, a Pydantic model, or a callable
+        that returns a JSON schema.
+    max_tokens:
+        The maximum number of tokens to generate.
+    sampler:
+        The sampling algorithm to use to generate token ids from the logits
+        distribution.
+    whitespace_pattern
+        Pattern to use for JSON syntactic whitespace (doesn't impact string literals)
+        Example: allow only a single space or newline with `whitespace_pattern=r"[\n ]?"`
+
+    Returns
+    -------
+    A `SequenceGenerator` instance that generates text constrained by the schema_object and
+    transforms the result if BaseModel is used.
+    """
     if isinstance(schema_object, type(BaseModel)):
         schema = pyjson.dumps(schema_object.model_json_schema())
-        regex_str = build_regex_from_object(schema)
+        regex_str = build_regex_from_object(schema, whitespace_pattern)
         generator = regex(model, regex_str, sampler)
         generator.format_sequence = lambda x: schema_object.parse_raw(x)
     elif callable(schema_object):
         schema = pyjson.dumps(get_schema_from_signature(schema_object))
-        regex_str = build_regex_from_object(schema)
+        regex_str = build_regex_from_object(schema, whitespace_pattern)
         generator = regex(model, regex_str, sampler)
         generator.format_sequence = lambda x: pyjson.loads(x)
     elif isinstance(schema_object, str):
         schema = schema_object
-        regex_str = build_regex_from_object(schema)
+        regex_str = build_regex_from_object(schema, whitespace_pattern)
         generator = regex(model, regex_str, sampler)
         generator.format_sequence = lambda x: pyjson.loads(x)
     else:

--- a/outlines/serve/vllm.py
+++ b/outlines/serve/vllm.py
@@ -2,7 +2,7 @@
 import json
 import math
 from collections import defaultdict
-from typing import DefaultDict, List
+from typing import DefaultDict, List, Optional
 
 import torch
 
@@ -105,8 +105,8 @@ class RegexLogitsProcessor:
 
 
 class JSONLogitsProcessor(RegexLogitsProcessor):
-    def __init__(self, schema, llm):
-        """Compile the FSM that drives the JSON-structured generation.
+    def __init__(self, schema, llm, whitespace_pattern: Optional[str] = None):
+        """Compile the FSM that drives the JSON-guided generation.
 
         Parameters
         ----------
@@ -114,9 +114,11 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
             A JSON schema that encodes the structure we want the model to generate
         llm
             An instance of `vllm.LLM`
-
+        whitespace_pattern
+            Pattern to use for JSON syntactic whitespace (doesn't impact string literals)
+            Example: allow only a single space or newline with `whitespace_pattern=r"[\n ]?"`
         """
         if isinstance(schema, dict):
             schema = json.dumps(schema)
-        regex_string = build_regex_from_object(schema)
+        regex_string = build_regex_from_object(schema, whitespace_pattern)
         super().__init__(regex_string, llm)

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -540,3 +540,32 @@ def test_format(schema, regex, examples):
             assert match.span() == (0, len(string))
         else:
             assert match is None
+
+
+@pytest.mark.parametrize("whitespace_pattern", [None, r"[\n ]?", "abc"])
+def test_json_schema_custom_whitespace_pattern(whitespace_pattern):
+    """assert whitespace_pattern setting respected"""
+
+    class MockModel(BaseModel):
+        foo: int
+        bar: str
+
+    # assert any ws pattern can be used
+    if whitespace_pattern == "abc":
+        build_regex_from_object(MockModel, whitespace_pattern)
+        return
+
+    pattern = build_regex_from_object(MockModel, whitespace_pattern)
+
+    mock_result_mult_ws = (
+        """{     "foo"   :   4, \n\n\n   "bar": "baz    baz baz bar"\n\n}"""
+    )
+    mock_result_maybe_ws = """{"foo" : 4 ,"bar":"baz    baz baz bar"}"""
+
+    match_default_ws = re.fullmatch(pattern, mock_result_mult_ws)
+    if whitespace_pattern is None:
+        assert match_default_ws
+    else:
+        assert match_default_ws is None
+
+    assert re.fullmatch(pattern, mock_result_maybe_ws)


### PR DESCRIPTION
Allow disabling `multiple_ws` argument in JSON constrained generation. Results in a maximum of one consecutive syntactic whitespace (no impact on string literals).

Fixes https://github.com/outlines-dev/outlines/issues/624