### PR TITLE
Add Particle Filter

### DIFF
--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -77,7 +77,7 @@ def sequence_generator(
         allowed_tokens = get_allowed_tokens(fsms, fsm_states)
         biased_logits = bias_logits(logits, allowed_tokens)
         next_token_ids, ancestors, sequence_weights = sampler(
-            biased_logits, sequence_weights, rng
+            logits, biased_logits, sequence_weights, rng
         )
 
         token_ids = update_token_ids(token_ids, next_token_ids, ancestors)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -7,11 +7,13 @@ from outlines.samplers import (
     BeamSearchSampler,
     GreedySampler,
     MultinomialSampler,
+    ParticleFilter,
     beam_search,
     greedy,
     keep_top_k_logits,
     keep_top_p_logits,
     multinomial,
+    multinomial_resampling,
     rescale_logits,
 )
 
@@ -30,7 +32,7 @@ def test_greedy():
     sampler = GreedySampler()
     logits = torch.tensor([[1.0, 2.0, 5.0]])
     weights = torch.tensor([0])
-    next_token_ids, ancestors, weights = sampler(logits, weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[2]]))
@@ -40,7 +42,7 @@ def test_greedy():
     sampler = GreedySampler()
     logits = torch.tensor([[10.0, 0.0, 3.0], [-math.inf, 2.0, 5.0]])
     weights = torch.tensor([0, 0])
-    next_token_ids, ancestors, weights = sampler(logits, weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[0], [2]]))
@@ -55,7 +57,7 @@ def test_multinomial():
     sampler = MultinomialSampler()
     logits = torch.tensor([[1.0, 4.0, 5.0]])
     weights = torch.tensor([0])
-    next_token_ids, ancestors, weights = sampler(logits, weights, rng)
+    next_token_ids, ancestors, weights = sampler(None, logits, weights, rng)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[2]]))
@@ -65,7 +67,7 @@ def test_multinomial():
     sampler = MultinomialSampler()
     logits = torch.tensor([[10.0, 0.0, 9.0], [-math.inf, 4.0, 5.0]])
     weights = torch.tensor([0, 0])
-    next_token_ids, ancestors, weights = sampler(logits, weights, rng)
+    next_token_ids, ancestors, weights = sampler(None, logits, weights, rng)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[0], [2]]))
@@ -202,7 +204,7 @@ def test_beam_search():
     sampler = BeamSearchSampler(2)
     logits = torch.tensor([[0.0, 1.0], [2.0, 0.0]])
     init_weights = torch.tensor([0, 1.0])
-    next_token_ids, ancestors, weights = sampler(logits, init_weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, init_weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[0], [1]]))
@@ -215,7 +217,7 @@ def test_beam_search():
     sampler = BeamSearchSampler(2)
     logits = torch.tensor([[0.0, 1.0], [0.0, 1.0]])
     init_weights = torch.tensor([0, 0])
-    next_token_ids, ancestors, weights = sampler(logits, init_weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, init_weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[1], [0]]))
@@ -226,7 +228,7 @@ def test_beam_search():
     sampler = BeamSearchSampler(1)
     logits = torch.tensor([[0.0, 1.0], [2.0, 0.0]])
     weights = torch.tensor([0, 0])
-    next_token_ids, ancestors, weights = sampler(logits, weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[1], [0]]))
@@ -237,7 +239,7 @@ def test_beam_search():
     sampler = BeamSearchSampler(2)
     logits = torch.tensor([[0.0, 1.0], [2.0, 0.0], [3.0, 2.0], [0.0, 1.0]])
     init_weights = torch.tensor([0, 0, 2.0, 0])
-    next_token_ids, ancestors, weights = sampler(logits, init_weights, None)
+    next_token_ids, ancestors, weights = sampler(None, logits, init_weights, None)
 
     logprobs = compute_logprobs(logits)
     assert next_token_ids.equal(torch.tensor([[0], [1], [0], [1]]))
@@ -252,3 +254,80 @@ def test_beam_search():
             ]
         )
     )
+
+
+def test_multinomial_resampling():
+    rng = torch.Generator()
+    rng.manual_seed(239)
+
+    weights = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    num_samples = 2
+    weights, indices = multinomial_resampling(rng, weights, num_samples)
+    assert indices.equal(torch.tensor([[2, 0], [2, 1]]))
+    assert weights.equal(torch.tensor([[3.0, 1.0], [6.0, 5.0]]))
+
+    weights = torch.tensor([[-math.inf, 1.0]])
+    num_samples = 1
+    weights, indices = multinomial_resampling(rng, weights, num_samples)
+    assert indices.equal(torch.tensor([[1]]))
+    assert indices.equal(torch.tensor([[1.0]]))
+
+
+def test_particle_filter():
+    # If masked_logits = logits then equal probability
+    rng = torch.Generator()
+    rng.manual_seed(239)
+
+    sampler = ParticleFilter(2)
+    logits = torch.tensor([[0.0, 1.0], [2.0, 0.0]])
+    biased_logits = logits
+    init_weights = None
+    next_token_ids, ancestors, weights = sampler(
+        logits, biased_logits, init_weights, rng
+    )
+    assert next_token_ids.equal(torch.tensor([[0], [1]]))
+    assert ancestors.equal(torch.tensor([0, 1]))
+    assert weights.equal(torch.tensor([0, 0]))
+
+    rng = torch.Generator()
+    rng.manual_seed(239)
+
+    sampler = ParticleFilter(1)
+    logits = torch.tensor([[0.0, 1.0], [2.0, 0.0]])
+    biased_logits = logits
+    init_weights = None
+    next_token_ids, ancestors, weights = sampler(
+        logits, biased_logits, init_weights, rng
+    )
+    assert next_token_ids.equal(torch.tensor([[0], [1]]))
+    assert ancestors.equal(torch.tensor([0, 1]))
+    assert weights.equal(torch.tensor([0, 0]))
+
+    rng = torch.Generator()
+    rng.manual_seed(239)
+
+    sampler = ParticleFilter(2)
+    logits = torch.tensor([[0.0, 1.0], [2.0, 0.0], [3.0, 2.0], [0.0, 1.0]])
+    biased_logits = torch.tensor([[0.0, 1.0], [2.0, 0.0], [3.0, 2.0], [0.0, 1.0]])
+    init_weights = None
+    next_token_ids, ancestors, weights = sampler(
+        logits, biased_logits, init_weights, rng
+    )
+
+    assert next_token_ids.equal(torch.tensor([[0], [1], [1], [0]]))
+    assert ancestors.equal(torch.tensor([0, 1, 2, 3]))
+
+    # If probability of masked logits is really low for one sequence, then only
+    # the other one should be resampled.
+    rng = torch.Generator()
+    rng.manual_seed(239)
+
+    sampler = ParticleFilter(2)
+    logits = torch.tensor([[1.0, 10.0, 10.0], [10.0, 1.0, 1.0]])
+    biased_logits = torch.tensor([[-math.inf, 1.0, 1.0], [-math.inf, 1.0, 1.0]])
+    init_weights = None
+    next_token_ids, ancestors, weights = sampler(
+        logits, biased_logits, init_weights, rng
+    )
+    assert next_token_ids.equal(torch.tensor([[1], [2]]))
+    assert ancestors.equal(torch.tensor([0, 0]))


### PR DESCRIPTION
See Nicolas Chopin's [book](https://link.springer.com/book/10.1007/978-3-030-47845-2) for a really nice introduction to the topic. The algorithms consists in carrying $N$ particles for each sequence in the batch, and at each step to:

1. Sample a new token for each particle using the next-token logits.
2. Resample the particles.

We use the multinomial resampling function in this first PR, although it is known to have very large variance. To make the implementation easier we combine (1) and (2) in a single step, similarly to what we do with beam search.

Note that there is a subtlety when doing structured generation. We can think of the simple following scheme to sample from the distribution of sequences that follow the structure:

1. Move particles by one step using the *unbiased* next-token logits;
2. Set the weight of each invalid particle to $-\infty$
3. Resample

But this can be very inefficient. Instead, we move particles using a specific proposal: using the *biased* next-token logits. Since this is not exactly sampling from the original distribution we need to resample the particles using the factor $P_i  / \tilde{P}_i$ as a weight where $P_i$ is the unbiased probability of token $i$ and $P_i$ the biased probability of token $i$ (importance sampling).

**Note:** I am wondering if we should correct the Beam Search algorithm as well.

