### PR TITLE
Dockerize and Add Release-Push Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Clean docker cache
-      run: docker buildx prune --all --force
+      run: docker system prune --all --force
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,28 @@ on:
 
 jobs:
   release-job:
-    name: Build and publish on PyPi
+    name: Build and publish on PyPi and Docker Hub
     runs-on: ubuntu-latest
+    environment: release
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: |
+          lapp0/outlines-serve:latest
+          lapp0/outlines-serve:${{ github.event.release.tag_name }}
+        build-args: |
+          BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Run Partial Release (Push to Docker Hub, Dont Push to PyPi)'
+        description: 'Docker Tag'
         required: false
         default: 'latest'
 
@@ -32,7 +32,7 @@ jobs:
         push: true
         tags: |
           outlinesdev/outlines:latest
-          outlinesdev/outlines:${{ github.event.release.tag_name }}
+          outlinesdev/outlines:${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Clean docker cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           lapp0/outlines-serve:${{ github.event.release.tag_name }}
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+    - name: Delete Docker Build Cache
+      run:
+        rm -rf /tmp/.buildx-cache
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,9 @@ jobs:
           lapp0/outlines-serve:${{ github.event.release.tag_name }}
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
-    - name: Delete Docker Build Cache
-      run:
-        rm -rf /tmp/.buildx-cache
+    - name: Clean docker cache
+      run: docker buildx prune -f
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Clean docker cache
-      run: docker buildx prune -f
+      run: docker buildx prune --all --force
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       with:
         push: true
         tags: |
-          lapp0/outlines-serve:latest
-          lapp0/outlines-serve:${{ github.event.release.tag_name }}
+          outlinesdev/outlines:latest
+          outlinesdev/outlines:${{ github.event.release.tag_name }}
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Clean docker cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Run Partial Release (Push to Docker Hub, Dont Push to PyPi)'
+        required: false
+        default: 'latest'
 
 jobs:
   release-job:
@@ -33,6 +39,7 @@ jobs:
       run: docker system prune --all --force
 
     - name: Set up Python
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
@@ -42,9 +49,11 @@ jobs:
         python -m pip install build
         python -m build
     - name: Check that the package version matches the Release name
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         grep -Rq "^Version: ${GITHUB_REF:10}$" outlines.egg-info/PKG-INFO
     - name: Check sdist install and imports
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         mkdir -p test-sdist
         cd test-sdist
@@ -52,6 +61,7 @@ jobs:
         venv-sdist/bin/python -m pip install ../dist/outlines-*.tar.gz
         venv-sdist/bin/python -c "import outlines"
     - name: Check wheel install and imports
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         mkdir -p test-wheel
         cd test-wheel
@@ -59,6 +69,7 @@ jobs:
         venv-wheel/bin/python -m pip install ../dist/outlines-*.whl
         venv-wheel/bin/python -c "import outlines"
     - name: Publish to PyPi
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,37 @@
+name: Release Docker
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release Tag (for manual dispatch)'
+        required: false
+        default: 'latest'
+jobs:
+  release-job:
+    name: Build and publish on Docker Hub
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: |
+          outlinesdev/outlines:latest
+          outlinesdev/outlines:${{ github.event.release.tag_name }}
+        build-args: |
+          BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+    - name: Clean docker cache
+      run: docker system prune --all --force

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -1,45 +1,15 @@
-name: Release
+name: Release PyPi
 
 on:
   release:
     types:
       - created
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Docker Tag'
-        required: false
-        default: 'latest'
-
 jobs:
   release-job:
-    name: Build and publish on PyPi and Docker Hub
+    name: Build and publish on PyPi
     runs-on: ubuntu-latest
-    environment: release
     steps:
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        push: true
-        tags: |
-          outlinesdev/outlines:latest
-          outlinesdev/outlines:${{ github.event.release.tag_name || github.event.inputs.release_tag }}
-        build-args: |
-          BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
-    - name: Clean docker cache
-      run: docker system prune --all --force
-
     - name: Set up Python
-      if: ${{ github.event_name == 'workflow_dispatch' }}
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
@@ -49,11 +19,9 @@ jobs:
         python -m pip install build
         python -m build
     - name: Check that the package version matches the Release name
-      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         grep -Rq "^Version: ${GITHUB_REF:10}$" outlines.egg-info/PKG-INFO
     - name: Check sdist install and imports
-      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         mkdir -p test-sdist
         cd test-sdist
@@ -61,7 +29,6 @@ jobs:
         venv-sdist/bin/python -m pip install ../dist/outlines-*.tar.gz
         venv-sdist/bin/python -c "import outlines"
     - name: Check wheel install and imports
-      if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         mkdir -p test-wheel
         cd test-wheel
@@ -69,7 +36,6 @@ jobs:
         venv-wheel/bin/python -m pip install ../dist/outlines-*.whl
         venv-wheel/bin/python -c "import outlines"
     - name: Publish to PyPi
-      if: ${{ github.event_name == 'workflow_dispatch' }}
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10
+
+WORKDIR /outlines
+
+RUN pip install --upgrade pip
+
+# Copy necessary build components
+COPY pyproject.toml .
+COPY outlines ./outlines
+
+# Install outlines and outlines[serve]
+# .git required by setuptools-scm
+RUN --mount=source=.git,target=.git,type=bind \
+    pip install --no-cache-dir .[serve]
+
+# https://outlines-dev.github.io/outlines/reference/vllm/
+ENTRYPOINT python3 -m outlines.serve.serve

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First time here? Go to our [setup guide](https://outlines-dev.github.io/outlines
 - [x] 💾 Caching of generations
 - [x] 🗂️ Batch inference
 - [x] 🎲 Sample with the greedy, multinomial and beam search algorithms (and more to come!)
-- [x] 🚀 [Serve with vLLM](https://outlines-dev.github.io/outlines/reference/vllm)
+- [x] 🚀 [Serve with vLLM](https://outlines-dev.github.io/outlines/reference/vllm), with official Docker image, [`lapp0/outlines-serve`](https://hub.docker.com/r/lapp0/outlines-serve)!
 
 
 Outlines 〰 has new releases and features coming every week. Make sure to ⭐ star and 👀 watch this repository, follow [@dottxtai][twitter] to stay up to date!

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First time here? Go to our [setup guide](https://outlines-dev.github.io/outlines
 - [x] 💾 Caching of generations
 - [x] 🗂️ Batch inference
 - [x] 🎲 Sample with the greedy, multinomial and beam search algorithms (and more to come!)
-- [x] 🚀 [Serve with vLLM](https://outlines-dev.github.io/outlines/reference/vllm), with official Docker image, [`lapp0/outlines-serve`](https://hub.docker.com/r/lapp0/outlines-serve)!
+- [x] 🚀 [Serve with vLLM](https://outlines-dev.github.io/outlines/reference/vllm), with official Docker image, [`outlinesdev/outlines`](https://hub.docker.com/r/outlinesdev/outlines)!
 
 
 Outlines 〰 has new releases and features coming every week. Make sure to ⭐ star and 👀 watch this repository, follow [@dottxtai][twitter] to stay up to date!

--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -42,6 +42,15 @@ pip install -e .[test]
 pre-commit install
 ```
 
+#### Developing Serve Endpoint Via Docker
+
+```bash
+docker build -t outlines-serve .
+docker run -p 8012:8000 outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+```
+
+This builds `outlines-serve` and runs on `localhost:8012` with the model `Mistral-7B-Instruct-v0.2`
+
 ### Before pushing your code
 
 Run the tests:

--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -46,10 +46,10 @@ pre-commit install
 
 ```bash
 docker build -t outlines-serve .
-docker run -p 8012:8000 outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+docker run -p 8000:8000 outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
-This builds `outlines-serve` and runs on `localhost:8012` with the model `Mistral-7B-Instruct-v0.2`
+This builds `outlines-serve` and runs on `localhost:8000` with the model `Mistral-7B-Instruct-v0.2`
 
 ### Before pushing your code
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -248,7 +248,7 @@ Or you can start the server with Outlines' official Docker image:
 docker run -p 8000:8000 outlinesdev/outlines --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
-This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though)  with the OPT-125M model. If you want to specify another model:
+This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though). Without the `--model` argument set, the OPT-125M model is used.
 
 
 You can then query the model in shell by passing a prompt and a [JSON Schema][jsonschema]{:target="_blank"} specification for the structure of the output:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -245,7 +245,7 @@ python -m outlines.serve.serve --model="mistralai/Mistral-7B-Instruct-v0.2"
 Or you can start the server with Outlines' official Docker image:
 
 ```bash
-docker run -p 8000:8000 lapp0/outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+docker run -p 8000:8000 outlinesdev/outlines --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
 This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though)  with the OPT-125M model. If you want to specify another model:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -239,14 +239,17 @@ Outlines can be deployed as a LLM service using [vLLM][vllm]{:target="_blank"} a
 First start the server:
 
 ```python
-python -m outlines.serve.serve
+python -m outlines.serve.serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+```
+
+Or you can start the server with Outlines' official Docker image:
+
+```bash
+docker run -p 8000:8000 lapp0/outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
 This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though)  with the OPT-125M model. If you want to specify another model:
 
-```python
-python -m outlines.serve.serve --model="mistralai/Mistral-7B-Instruct-v0.2"
-```
 
 You can then query the model in shell by passing a prompt and a [JSON Schema][jsonschema]{:target="_blank"} specification for the structure of the output:
 

--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -19,7 +19,7 @@ This will by default start a server at `http://127.0.0.1:8000` (check what the c
 You can install and run the server with Outlines' official Docker image using the command
 
 ```bash
-docker run -p 8000:8000 lapp0/outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+docker run -p 8000:8000 outlinesdev/outlines --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
 ## Querying Endpoint

--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -9,14 +9,20 @@ pip install outlines[serve]
 You can then start the server with:
 
 ```bash
-python -m outlines.serve.serve
-```
-
-This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though) with the OPT-125M model. If you want to specify another model (e.g. Mistral-7B-Instruct-v0.2), you can do so with the `--model` parameter:
-
-```bash
 python -m outlines.serve.serve --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
+
+This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though) with the OPT-125M model. If you want to specify another model (e.g. Mistral-7B-Instruct-v0.2), you can do so with the `--model` parameter.
+
+### Alternative Method: Via Docker
+
+You can install and run the server with Outlines' official Docker image using the command
+
+```bash
+docker run -p 8000:8000 lapp0/outlines-serve --model="mistralai/Mistral-7B-Instruct-v0.2"
+```
+
+## Querying Endpoint
 
 You can then query the model in shell by passing a prompt and either
 

--- a/docs/reference/vllm.md
+++ b/docs/reference/vllm.md
@@ -12,7 +12,7 @@ You can then start the server with:
 python -m outlines.serve.serve --model="mistralai/Mistral-7B-Instruct-v0.2"
 ```
 
-This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though) with the OPT-125M model. If you want to specify another model (e.g. Mistral-7B-Instruct-v0.2), you can do so with the `--model` parameter.
+This will by default start a server at `http://127.0.0.1:8000` (check what the console says, though). Without the `--model` argument set, the OPT-125M model is used. The `--model` argument allows you to specify any model of your choosing.
 
 ### Alternative Method: Via Docker
 


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/555

- Introduces dockerized `outlines.serve.serve`.
- Introduces automatic docker image push action to `release.yml`
  - Example: [lapp0/outlines build](https://github.com/lapp0/outlines/actions/runs/7972431838/job/21764184361), [resulting image on Docker Hub](https://hub.docker.com/r/lapp0/outlines-serve)

Need some setup on your end please @rlouf:
- Let me know the outlines official docker repo URL so I can update `release.yml` and docs
- Configure the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets on GitHub in an environment named "release".


TODO: 
- [x] I run out of space later in the build process if I build the image. Fix it.
  - Fixed, all steps (except publish PyPi) pass https://github.com/lapp0/outlines/actions/runs/7973090033/job/21766228377
- [x] substitute official repo link in