### PR TITLE
fix actions

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-
     - name: Checkout
       uses: actions/checkout@v4
     - name: Log in to Docker Hub
@@ -30,7 +29,7 @@ jobs:
         push: true
         tags: |
           outlinesdev/outlines:latest
-          outlinesdev/outlines:${{ github.event.release.tag_name }}
+          outlinesdev/outlines:${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         build-args: |
           BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Clean docker cache

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -9,6 +9,8 @@ jobs:
     name: Build and publish on PyPi
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Release Docker dispatch: https://github.com/lapp0/outlines/actions/runs/7994419887
- "Fails successfully": Got to the point where it only auth errors. `Error: buildx failed with: ERROR: denied: requested access to the resource is denied`

Not testing fetch PyPi. Changes are minimal between this version and the previous *working* main.

```
git diff e99d92d024dbf6f6bff10a9c3954f326cf4a0cd3 -- .github/workflows/release_pypi.yaml .github/workflows/release.yml | cat
diff --git a/.github/workflows/release.yml b/.github/workflows/release_pypi.yaml
similarity index 92%
rename from .github/workflows/release.yml
rename to .github/workflows/release_pypi.yaml
index e6bf1b1..597ebb7 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release_pypi.yaml
@@ -1,16 +1,17 @@
-name: Release
+name: Release PyPi
 
 on:
   release:
     types:
       - created
-
 jobs:
   release-job:
     name: Build and publish on PyPi
     runs-on: ubuntu-latest
+    environment: release
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
```