### PR TITLE
Allow specifying own Hugging Face tokenizer instance

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -58,7 +58,9 @@ def get_llama_tokenizer_types():
 class TransformerTokenizer(Tokenizer):
     """Represents a tokenizer for models in the `transformers` library."""
 
-    def __init__(self, tokenizer_or_model_name: Union["PreTrainedTokenizerBase", str], **kwargs):
+    def __init__(
+        self, tokenizer_or_model_name: Union["PreTrainedTokenizerBase", str], **kwargs
+    ):
         if isinstance(tokenizer_or_model_name, str):
             from transformers import AutoTokenizer
 
@@ -66,10 +68,12 @@ class TransformerTokenizer(Tokenizer):
             self.model_name = tokenizer_or_model_name
             # TODO: Do something to make this hashable?
             self.kwargs = kwargs
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_or_model_name, **kwargs)
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer_or_model_name, **kwargs
+            )
         else:
             self.tokenizer = tokenizer_or_model_name
-        
+
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token
 
@@ -112,7 +116,9 @@ class TransformerTokenizer(Tokenizer):
     def __eq__(self, other):
         if isinstance(other, type(self)):
             if hasattr(self, "model_name") and hasattr(self, "kwargs"):
-                return other.model_name == self.model_name and other.kwargs == self.kwargs
+                return (
+                    other.model_name == self.model_name and other.kwargs == self.kwargs
+                )
             else:
                 return other.tokenizer == self.tokenizer
         return NotImplemented

--- a/tests/generate/test_integration_transformers.py
+++ b/tests/generate/test_integration_transformers.py
@@ -618,7 +618,7 @@ def test_custom_sampler():
 
 
 def test_transformers_use_existing_model_and_tokenizer():
-    from transformers import AutoTokenizer, AutoModelForCausalLM
+    from transformers import AutoModelForCausalLM, AutoTokenizer
 
     rng = torch.Generator()
     rng.manual_seed(10000)

--- a/tests/generate/test_integration_transformers.py
+++ b/tests/generate/test_integration_transformers.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, constr
 import outlines.generate as generate
 import outlines.models as models
 from outlines.fsm.regex import reduced_vocabulary
-from outlines.models.transformers import TransformerTokenizer
+from outlines.models.transformers import Transformer, TransformerTokenizer
 from outlines.samplers import beam_search, multinomial
 
 
@@ -615,3 +615,18 @@ def test_custom_sampler():
     )
 
     assert sequence == "c"
+
+
+def test_transformers_use_existing_model_and_tokenizer():
+    from transformers import AutoTokenizer, AutoModelForCausalLM
+
+    rng = torch.Generator()
+    rng.manual_seed(10000)
+
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
+    hf_model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = TransformerTokenizer(hf_tokenizer)
+    model = Transformer(hf_model, tokenizer)
+    sequence = generate.text(model)("Write a short sentence ", rng=rng)
+    assert isinstance(sequence, str)


### PR DESCRIPTION
This gives the option of specifying your own `PreTrainedTokenizer` instance rather than specifying a model name and having outlines construct the tokenizer for you. This might be convenient for situations where you are already using the LLM in other parts of your application and only need outlines for a specific use case.

Example of use:

```python
from transformers import AutoTokenizer, AutoModelForCausalLM
from outlines.models.transformers import TransformerTokenizer, Transformer

model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
hf_model = AutoModelForCausalLM.from_pretrained(model_name)
tokenizer = TransformerTokenizer(hf_tokenizer)
model = Transformer(hf_model, tokenizer)
```

As compared to before this change:

```python
from transformers import AutoTokenizer, AutoModelForCausalLM
from outlines.models.transformers import TransformerTokenizer, Transformer

model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
hf_model = AutoModelForCausalLM.from_pretrained(model_name)
tokenizer = TransformerTokenizer(model_name) # Can't make use of hf_tokenizer here, even if
                                             # you already instantiated it for other reasons!
model = Transformer(hf_model, tokenizer)
```

This also corrects a type annotation on the `outlines.models.transformers.Transformer` class which incorrectly stated that the `tokenizer` argument was of type `transformers.PreTrainedTokenizer` when actually it should be of type `outlines.models.transformers.TransformerTokenizer`. In order to fix the annotation, the classes also had to be rearranged so that the name of the other class would be defined at the right time.
