### PR TITLE
[Draft] Add option to ignore fields order

### DIFF
--- a/outlines/serve/vllm.py
+++ b/outlines/serve/vllm.py
@@ -114,7 +114,13 @@ class RegexLogitsProcessor:
 
 
 class JSONLogitsProcessor(RegexLogitsProcessor):
-    def __init__(self, schema: Dict, llm, whitespace_pattern: Optional[str] = None):
+    def __init__(
+        self,
+        schema: Dict,
+        llm,
+        whitespace_pattern: Optional[str] = None,
+        ignore_fields_order: bool = False,
+    ):
         """Compile the FSM that drives the JSON-guided generation.
 
         Parameters
@@ -126,6 +132,9 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
         whitespace_pattern
             Pattern to use for JSON syntactic whitespace (doesn't impact string literals)
             Example: allow only a single space or newline with `whitespace_pattern=r"[\n ]?"`
+        ignore_fields_order
+            If True, the generated JSON will not be constrained by the order of the fields
+            in the schema.
         """
         if isinstance(schema, type(BaseModel)):
             schema_str = json.dumps(schema.model_json_schema())
@@ -139,5 +148,7 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
                 + "a Pydantic object, a dictionary or a string that contains the JSON "
                 + "Schema specification"
             )
-        regex_string = build_regex_from_schema(schema_str, whitespace_pattern)
+        regex_string = build_regex_from_schema(
+            schema_str, whitespace_pattern, ignore_fields_order
+        )
         super().__init__(regex_string, llm)


### PR DESCRIPTION
# Description

Predibase recently published [an article](https://predibase.com/blog/lorax-outlines-better-json-extraction-with-structured-generation-and-lora) wherein they discussed an issue with the fact that Outlines imposes an ordering constraint on object fields. See below:
![image](https://github.com/outlines-dev/outlines/assets/14250344/a71e42f0-75a9-495a-a853-0e58b3205fb0)

This PR just adds an option to turn this constraint off. This does not change the default API interface at all.

There are probably a lot of smarter ways to do this, but this is good enough of a hack.

TODOs:
- [ ] Add tests
- [ ] Add docs



