### PR TITLE
Fix generation of multi-token unicode characters

### DIFF
--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -6,7 +6,11 @@ from lark import Lark
 
 from outlines import grammars
 from outlines.caching import cache
-from outlines.fsm.regex import create_fsm_index_tokenizer, make_deterministic_fsm
+from outlines.fsm.regex import (
+    create_fsm_index_tokenizer,
+    make_byte_level_fsm,
+    make_deterministic_fsm,
+)
 
 if TYPE_CHECKING:
     from outlines.models.tokenizer import Tokenizer
@@ -111,7 +115,10 @@ class RegexGuide(Guide):
             The parameters of the function are used for caching purpose
             """
             regex_pattern = interegular.parse_pattern(regex_string)
-            regex_fsm, _ = make_deterministic_fsm(regex_pattern.to_fsm().reduce())
+            byte_fsm = make_byte_level_fsm(
+                regex_pattern.to_fsm().reduce(), keep_utf8=True
+            )
+            regex_fsm, _ = make_deterministic_fsm(byte_fsm)
             states_to_token_maps, empty_token_ids = create_fsm_index_tokenizer(
                 regex_fsm, tokenizer
             )
@@ -211,7 +218,8 @@ class RegexGuide(Guide):
             """Create the variables related to the mapping between states and tokens
             The parameters of the function are used for caching purpose
             """
-            regex_fsm, _ = make_deterministic_fsm(fsm.reduce())
+            byte_fsm = make_byte_level_fsm(fsm.reduce(), keep_utf8=True)
+            regex_fsm, _ = make_deterministic_fsm(byte_fsm)
             states_to_token_maps, empty_token_ids = create_fsm_index_tokenizer(
                 regex_fsm, tokenizer
             )

--- a/outlines/fsm/regex.py
+++ b/outlines/fsm/regex.py
@@ -1,10 +1,29 @@
 from collections import namedtuple
 from functools import lru_cache
-from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    FrozenSet,
+    Generator,
+    List,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numba
 import numpy as np
-from interegular.fsm import FSM, Alphabet, OblivionError, anything_else
+from interegular.fsm import (
+    FSM,
+    Alphabet,
+    OblivionError,
+    State,
+    TransitionKey,
+    _AnythingElseCls,
+    anything_else,
+)
 from numba.typed.typedobjectutils import _nonoptional
 
 if TYPE_CHECKING:
@@ -146,6 +165,173 @@ FSMInfo = namedtuple(
         "alphabet_symbol_mapping",
     ],
 )
+
+
+TransitionTrie = Dict[TransitionKey, "Union[TransitionTrie, State, None]"]
+
+
+def add_to_transition_trie(
+    trie: TransitionTrie,
+    key_seq: Sequence[TransitionKey],
+    value: Union[State, None],
+):
+    for key in key_seq[:-1]:
+        trie = cast(TransitionTrie, trie.setdefault(key, {}))
+        assert isinstance(trie, dict), "key sequence of incompatible length"
+    trie[key_seq[-1]] = value
+
+
+# merge default_trie into the trie, only updating entries not present in the trie
+def transition_trie_setdefault(
+    trie: TransitionTrie,
+    default_trie: TransitionTrie,
+):
+    for key, default_value in default_trie.items():
+        dest_value = trie.get(key)
+        if isinstance(dest_value, dict) and isinstance(default_value, dict):
+            transition_trie_setdefault(dest_value, default_value)
+        elif key not in trie:
+            trie[key] = default_value
+
+
+def byte_symbol(byte: int) -> str:
+    return f"{byte:02X}"
+
+
+def make_byte_level_fsm(fsm: FSM, keep_utf8=False) -> FSM:
+    """Convert an FSM to a byte-level FSM, expanding multi-byte characters as
+    sequences of single-byte transitions. If keep_utf8 is set, the original
+    utf-8 characters are kept in the alphabet.
+    NOTE: we're representing bytes as strings to keep it type-compatible.
+    """
+
+    anything_else_key = fsm.alphabet[anything_else]
+    symbol_mapping: Dict[Union[str, _AnythingElseCls], TransitionKey] = {}
+    map: Dict[State, Dict[TransitionKey, State]] = {}
+    states: List[State] = list(fsm.states)
+
+    # identify all multi-byte characters in the alphabet and build a mapping
+    # from the original transition keys to sequences of new keys for each byte
+    key_to_key_seqs: Dict[TransitionKey, Set[Tuple[TransitionKey, ...]]] = {}
+    all_key_seqs: Set[Tuple[TransitionKey, ...]] = set()
+    all_bytes: Set[int] = set()
+    max_key = max(fsm.alphabet.values())
+    for symbol, transition_key in fsm.alphabet.items():
+        assert symbol == anything_else or len(symbol) == 1
+        if symbol == anything_else or ord(symbol) < 0x80:
+            symbol_mapping[symbol] = transition_key
+        else:
+            if keep_utf8:
+                symbol_mapping[symbol] = transition_key
+            key_list: List[TransitionKey] = []
+            for byte in symbol.encode("utf-8"):
+                symbol = byte_symbol(byte)
+                if symbol not in symbol_mapping:
+                    symbol_mapping[symbol] = max_key = TransitionKey(max_key + 1)
+                    all_bytes.add(byte)
+                key_list.append(symbol_mapping[symbol])
+            key_seq = tuple(key_list)
+            key_to_key_seqs.setdefault(transition_key, set()).add(key_seq)
+            all_key_seqs.add(key_seq)
+
+    # add all remaining multi-byte utf-8 bytes to the alphabet
+    # (this is required to represent `anything_else`)
+    utf8_ranges = {
+        1: (0x80, 0xC0),  # continuation bytes
+        2: (0xC0, 0xE0),  # 2-byte sequences
+        3: (0xE0, 0xF0),  # 3-byte sequences
+        4: (0xF0, 0xF8),  # 4-byte sequences
+    }
+    utf8_all_keys: Dict[int, Set[TransitionKey]] = {
+        n: set() for n in utf8_ranges.keys()
+    }
+    for n, (start, end) in utf8_ranges.items():
+        range_key = max_key = TransitionKey(max_key + 1)
+        for byte in range(start, end):
+            byte_key = symbol_mapping.setdefault(byte_symbol(byte), range_key)
+            utf8_all_keys[n].add(byte_key)
+
+    # cache of intermediate transition states by transitions from that state
+    state_cache: Dict[FrozenSet[Tuple[TransitionKey, State]], State] = {}
+
+    # helper function to create multi-step transitions between states
+    max_state = max(fsm.states)
+
+    def create_seq_transitions(
+        seq_transitions_trie: TransitionTrie,
+    ) -> Dict[TransitionKey, State]:
+        nonlocal max_state
+        result: Dict[TransitionKey, State] = {}
+
+        for next_key, next_trie in seq_transitions_trie.items():
+            if isinstance(next_trie, dict):
+                next_transitions = create_seq_transitions(next_trie)
+                if not next_transitions:
+                    continue
+                cache_key = frozenset(next_transitions.items())
+                next_state = state_cache.get(cache_key)
+                if next_state is None:
+                    next_state = max_state = State(max_state + 1)
+                    map[next_state] = next_transitions
+                    state_cache[cache_key] = next_state
+                    states.append(next_state)
+                result[next_key] = next_state
+            elif next_trie is not None:
+                result[next_key] = next_trie
+
+        return result
+
+    # create new states and transitions
+    for state, transitions in fsm.map.items():
+        seq_transitions_trie: TransitionTrie = {}
+        state_map: Dict[TransitionKey, State] = {}
+
+        for transition_key, to_state in transitions.items():
+            if transition_key in key_to_key_seqs:
+                if keep_utf8:
+                    state_map[transition_key] = to_state
+                for key_seq in key_to_key_seqs[transition_key]:
+                    add_to_transition_trie(seq_transitions_trie, key_seq, to_state)
+            else:  # keep single-byte transitions as is
+                state_map[transition_key] = to_state
+
+        # handle multi-byte anything_else sequences
+        if anything_else_key in transitions:
+            for key_seq in all_key_seqs:
+                add_to_transition_trie(seq_transitions_trie, key_seq, None)
+
+            anything_else_trie: TransitionTrie = {}
+            cont_trie: Union[TransitionTrie, State] = transitions[anything_else_key]
+            for n in range(2, 5):
+                cont_trie = {key: cont_trie for key in utf8_all_keys[1]}
+                for key in utf8_all_keys[n]:
+                    anything_else_trie[key] = cont_trie
+
+            transition_trie_setdefault(seq_transitions_trie, anything_else_trie)
+
+        # create new states and transitions
+        next_transitions = create_seq_transitions(seq_transitions_trie)
+        state_map.update(next_transitions)
+        map[state] = state_map
+
+    return FSM(
+        alphabet=Alphabet(symbol_mapping),
+        states=states,
+        initial=fsm.initial,
+        finals=fsm.finals,
+        map=map,
+    )
+
+
+def make_byte_level_better_fsm(fsm: BetterFSM, keep_utf8=False) -> BetterFSM:
+    new_fsm = make_byte_level_fsm(fsm, keep_utf8)
+    return BetterFSM(
+        alphabet=BetterAlphabet(new_fsm.alphabet._symbol_mapping),
+        states=new_fsm.states,
+        initial=new_fsm.initial,
+        finals=new_fsm.finals,
+        map=new_fsm.map,
+    )
 
 
 def make_deterministic_fsm(fsm: FSM) -> Tuple[BetterFSM, Dict[int, int]]:


### PR DESCRIPTION
This PR fixes generation of unicode strings that can only be represented by sequences of multiple tokens (closes #725).

Currently, outlines will prevent any such characters from being generated at all, even with `'.*'` regex. This creates a major problem when generating text in non-latin languages, or generating special characters like emojis.

This PR addresses this problem by converting character-level regex FSMs to byte-level FSMs. More precisely, it augments the FSM by adding byte-by-byte transitions that can be triggered by sub-character tokens generated by the LLM. The full-character transitions are kept as-is, so the performance of generation for normal tokens isn't impacted.

I considered other design choices, including keeping the logic of dealing with such tokens in the `RegexGuide` class. I don't think it can work at least for GPT2-like tokenizers (which includes gpt2, phi, qwen and other models). Such tokenizers have tokens that combine full utf8 characters followed by parts of the next character (for example, `b'\x20\xf0'`), and deciding whether to accept such tokens requires walking the FSM.