### PR TITLE
Make `torch` and `transformers` imports optional

### DIFF
--- a/docs/reference/models/transformers.md
+++ b/docs/reference/models/transformers.md
@@ -3,7 +3,11 @@
 
 !!! Installation
 
-    You need to install the `transformer` and `datasets` libraries to be able to use these models in Outlines.
+    You need to install the `transformer`, `datasets` and `torch` libraries to be able to use these models in Outlines:
+
+    ```bash
+    pip install torch transformers datasets
+    ```
 
 
 Outlines provides an integration with the `torch` implementation of causal models in the [transformers][transformers] library. You can initialize the model by passing its name:

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -1,11 +1,12 @@
 import datetime
 from dataclasses import dataclass
-from typing import Iterator, List, Optional, Union
-
-import torch
+from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
 from outlines.generate.generator import sequence_generator
 from outlines.samplers import BeamSearchSampler, GreedySampler, MultinomialSampler
+
+if TYPE_CHECKING:
+    import torch
 
 FormattedOutput = Union[
     str, int, float, bool, datetime.date, datetime.time, datetime.datetime
@@ -29,9 +30,9 @@ class SequenceGenerator:
 
     def get_generated_token_ids(
         self,
-        prompt_token_ids: torch.Tensor,
-        token_ids: torch.Tensor,
-    ) -> List[torch.Tensor]:
+        prompt_token_ids: "torch.Tensor",
+        token_ids: "torch.Tensor",
+    ) -> List["torch.Tensor"]:
         """Get the tokens generated so far.
 
         Parameters
@@ -130,7 +131,7 @@ class SequenceGenerator:
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
-        rng: Optional[torch.Generator] = None,
+        rng: Optional["torch.Generator"] = None,
     ) -> Union[FormattedOutput, List[FormattedOutput], List[List[FormattedOutput]]]:
         """Generate the full text sequence.
 
@@ -157,6 +158,7 @@ class SequenceGenerator:
         -------
         The generation(s), potentially cast to another type.
         """
+        import torch
 
         if isinstance(prompts, str):
             prompts = [prompts]
@@ -247,7 +249,7 @@ class SequenceGenerator:
         prompts: Union[str, List[str]],
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
-        rng: Optional[torch.Generator] = None,
+        rng: Optional["torch.Generator"] = None,
     ) -> Iterator[Union[List[str], str, List[List[str]]]]:
         """Generate the text sequence one token at a time.
 
@@ -274,6 +276,7 @@ class SequenceGenerator:
         A string or list of strings that contain the generated text.
 
         """
+        import torch
 
         if isinstance(prompts, str):
             prompts = [prompts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,10 @@ dependencies = [
    "cloudpickle",
    "diskcache",
    "pydantic>=2.0",
-   "torch>=2.1.0",
    "numba",
    "referencing",
    "jsonschema",
    "requests",
-   "transformers",
 ]
 dynamic = ["version"]
 
@@ -47,7 +45,6 @@ test = [
     "pytest-benchmark",
     "pytest-cov",
     "pytest-mock",
-    "transformers",
     "coverage[toml]>=5.1",
     "diff-cover",
     "accelerate",
@@ -57,7 +54,9 @@ test = [
     "llama-cpp-python",
     "huggingface_hub",
     "openai>=1.0.0",
-    "vllm"
+    "vllm",
+    "torch",
+    "transformers",
 ]
 serve = [
     "vllm>=0.3.0",


### PR DESCRIPTION
The `torch` and `transformers` libraries are installed by default with Outlines. These two dependencies are heavy, and not needed for the users who want to use the `llama-cpp-python` or `vllm`  integration. We thus make them optional.