### PR TITLE
Exclude escape character in JSON string fields

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -9,7 +9,7 @@ from referencing import Registry, Resource
 from referencing._core import Resolver
 from referencing.jsonschema import DRAFT202012
 
-STRING_INNER = r'(?:[^"\\\x00-\x1f\x7f-\x9f]|\\.)'
+STRING_INNER = r'([^("\\\x00-\x1f\x7f-\x9f)]|\\\\)'
 STRING = f'"{STRING_INNER}*"'
 INTEGER = r"(-)?(0|[1-9][0-9]*)"
 NUMBER = rf"({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -116,7 +116,12 @@ def test_match_number(pattern, does_match):
         (
             {"title": "Foo", "type": "string"},
             STRING,
-            [("unquotedstring", False), ('"quoted_string"', True)],
+            [
+                ("unquotedstring", False),
+                ('"quoted_string"', True),
+                (r'"escape_\character"', False),
+                (r'"double_\\escape"', True),
+            ],
         ),
         # String with maximum length
         (


### PR DESCRIPTION
Closes #759.

Here we forbid the generation of an odd number of escape characters, which would lead to an invallid JSON string.