### PR TITLE
Add azure_openai to models __init__.py

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -10,7 +10,7 @@ from typing import Union
 from .exllamav2 import ExLlamaV2Model, exl2
 from .llamacpp import LlamaCpp, llamacpp
 from .mamba import Mamba, mamba
-from .openai import OpenAI, openai
+from .openai import OpenAI, openai, azure_openai
 from .transformers import Transformers, transformers
 from .vllm import VLLM, vllm
 

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -10,7 +10,7 @@ from typing import Union
 from .exllamav2 import ExLlamaV2Model, exl2
 from .llamacpp import LlamaCpp, llamacpp
 from .mamba import Mamba, mamba
-from .openai import OpenAI, openai, azure_openai
+from .openai import OpenAI, azure_openai, openai
 from .transformers import Transformers, transformers
 from .vllm import VLLM, vllm
 


### PR DESCRIPTION
Currently, importing azure_openai as documented in https://outlines-dev.github.io/outlines/reference/models/openai/ does not work. Importing azure_openai as documented results in "AttributeError: module 'outlines.models' has no attribute 'azure_openai'"

Adding azure_openai to __init__.py fixes that behaviour. Currently, only way to import azure_openai is with `from outlines.models.openai import azure_openai`