### PR TITLE
Added a step to check early stop with llamacpp generate

### DIFF
--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -182,6 +182,10 @@ class LlamaCpp:
             **llama_cpp_params,
         )
         completion = self.model(prompts, **llama_cpp_params)
+        if completion["choices"][0]["finish_reason"] != "stop":
+            raise RuntimeError(
+                f"The generation stopped earlier than expected. The reason was: `{completion['choices'][0]['finish_reason']}`. The default `max_tokens` of LlamaCpp is 16. Consider pass a larger `max_tokens`."
+            )
         result = completion["choices"][0]["text"]
 
         self.model.reset()


### PR DESCRIPTION
Fix #837 
Added an error when the llm stopped generation earlier than expected. 

In llama-cpp-python [this line](https://github.com/abetlen/llama-cpp-python/blob/2138561fab5e60672c63b6c446b62a8bc26e17c4/llama_cpp/llama.py#L1431), the default number is 16 tokens. This prevents us to generate a complete json. 