### PR TITLE
Ignore errors caused by import warnings from `huggingface_hub` & `pyairports`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,9 @@ filterwarnings = [
     "ignore::numba.core.errors.NumbaPendingDeprecationWarning",
     "ignore::pydantic.warnings.PydanticDeprecatedSince20",
     "ignore::FutureWarning:transformers.*",
+    "ignore::FutureWarning:huggingface_hub.*",
     "ignore::UserWarning",
+    "ignore::DeprecationWarning:pyairports.*",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
`pytest` seems to be pretty strict with these warnings.

This PR ignores errors caused by import warnings from `huggingface_hub` & `pyairports`