### PR TITLE
Fix format in the BentoML doc

### DIFF
--- a/docs/cookbook/deploy-using-bentoml.md
+++ b/docs/cookbook/deploy-using-bentoml.md
@@ -50,12 +50,13 @@ $ bentoml models list
 
 Tag                                          Module  Size        Creation Time
 mistralai--mistral-7b-v0.1:m7lmf5ac2cmubnnz          13.49 GiB   2024-04-25 06:52:39
+```
+
 ## Define a BentoML Service
 
 As the model is ready, we can define a [BentoML Service](https://docs.bentoml.com/en/latest/guides/services.html) to wrap the capabilities of the model.
 
 We will run the JSON-structured generation example [in the README](https://github.com/outlines-dev/outlines?tab=readme-ov-file#efficient-json-generation-following-a-json-schema), with the following schema:
-
 
 ```python
 DEFAULT_SCHEMA = """{
@@ -206,6 +207,8 @@ Expected output:
   "weapon": "sword",
   "strength": 20
 }
+```
+
 ## Deploy to BentoCloud
 
 After the Service is ready, you can deploy it to [BentoCloud](https://docs.bentoml.com/en/latest/bentocloud/get-started.html) for better management and scalability. [Sign up](https://cloud.bentoml.com/signup) if you haven't got a BentoCloud account.


### PR DESCRIPTION
Fix format issues as some text is embedded in code blocks.

![Screenshot 2024-05-06 at 10 35 18](https://github.com/outlines-dev/outlines/assets/65327072/75f1104a-73f7-4435-b539-bc135302bf56)
