### PR TITLE
Remove broken final state loop

### DIFF
--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -193,7 +193,7 @@ class RegexGuide(Guide):
         The new state of the guide.
 
         """
-        if token_id == self.eos_token_id:
+        if token_id == self.eos_token_id or state not in self.states_to_token_maps:
             return -1
 
         last_token_to_end_state = self.states_to_token_maps[state]

--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -195,10 +195,6 @@ class RegexGuide(Guide):
         """
         if token_id == self.eos_token_id:
             return -1
-        elif (
-            state in self.final_states
-        ):  # Necessary because we keep generating EOS tokens when finished
-            return state
 
         last_token_to_end_state = self.states_to_token_maps[state]
         next_state = last_token_to_end_state.get(token_id)

--- a/tests/fsm/test_fsm.py
+++ b/tests/fsm/test_fsm.py
@@ -82,9 +82,7 @@ def test_regex_final_state():
     assert fsm.is_final_state(state)
 
     state = fsm.next_state(state=5, token_id=103)
-    assert state == 5
-
-    assert fsm.is_final_state(-1)
+    assert fsm.is_final_state(state)
 
 
 def test_cfg():

--- a/tests/fsm/test_guide.py
+++ b/tests/fsm/test_guide.py
@@ -180,9 +180,7 @@ def test_regex_final_state():
     assert fsm.is_final_state(state)
 
     state = fsm.get_next_state(state=5, token_id=103)
-    assert state == 5
-
-    assert fsm.is_final_state(-1)
+    assert fsm.is_final_state(state)
 
 
 def test_cfg():


### PR DESCRIPTION
Fixes #856

The code this PR removes introduces an artificial and erroneous loop transition in every final state that is always traversed, regardless of the generation.

The comment doesn't make sense in my opinion, as the `if` above just handles exactly this case.

Removing this piece of code fixes the bug that surfaced in the upgrade of outlines in the vLLM integration.