### PR TITLE
Use actual function name in `get_schema_from_signature`

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -375,6 +375,10 @@ def get_schema_from_signature(fn: Callable) -> str:
         else:
             arguments[name] = (arg.annotation, ...)
 
-    model = create_model("Arguments", **arguments)
+    try:
+        fn_name = fn.__name__
+    except Exception:
+        fn_name = "Arguments"
+    model = create_model(fn_name, **arguments)
 
     return model.model_json_schema()


### PR DESCRIPTION
As discussed with @eitanturok in https://github.com/outlines-dev/outlines/pull/863

---

Currently, `get_schema_from_signature` converts the following function:
```python
def test_add(a: int, b: int | None = None):
    if b is None:
        return a
    return a + b
```
to the schema:
```python
{
    "properties": {
        "a": {"title": "A", "type": "integer"},
        "b": {"title": "B", "type": "integer"},
    },
    "required": ["a"],
    "title": "Arguments",
    "type": "object",
}
```
The issue is that the title of the schema is always "Arguments", regardless of the name of the function. And in some cases, this breaks the performance of the model as discussed by @eitanturok 