### PR TITLE
Extract function name in `get_schema_from_signature`

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import re
+import warnings
 from typing import Callable, Optional
 
 from jsonschema.protocols import Validator
@@ -375,6 +376,14 @@ def get_schema_from_signature(fn: Callable) -> str:
         else:
             arguments[name] = (arg.annotation, ...)
 
-    model = create_model("Arguments", **arguments)
+    try:
+        fn_name = fn.__name__
+    except Exception as e:
+        fn_name = "Arguments"
+        warnings.warn(
+            f"The function name could not be determined. Using default name 'Arguments' instead. For debugging, here is exact error:\n{e}",
+            category=UserWarning,
+        )
+    model = create_model(fn_name, **arguments)
 
     return model.model_json_schema()


### PR DESCRIPTION
Currently, `get_schema_from_signature` creates a json where `"title": "Arguments"`. This PR changes this so that the `"title"` will instead be mapped to the function's name.

Here is an example. I have this code snippet:
```python
from outlines.fsm.json_schema import get_schema_from_signature

def test_add(a: int, b: int | None = None):
    if b is None:
        return a
    return a + b

schema = get_schema_from_signature(test_add)
print(schema)
```
Before this PR, this outputted
```python
{'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'B'}}, 'required': ['a', 'b'], 'title': 'Arguments', 'type': 'object'}
```
and after this PR, this outputted
```python
{'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'B'}}, 'required': ['a', 'b'], 'title': 'test_add', 'type': 'object'}
```
(Scroll to see the `'title'` key.)