### PR TITLE
Fix Incorrect Finality Check in `RegexGuide.get_next_state()`

### DIFF
--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -195,9 +195,8 @@ class RegexGuide(Guide):
         """
         if token_id == self.eos_token_id:
             return -1
-        elif (
-            state in self.final_states
-        ):  # Necessary because we keep generating EOS tokens when finished
+        elif state not in self.states_to_token_maps:
+            # Necessary because we keep generating EOS tokens when finished
             return state
 
         last_token_to_end_state = self.states_to_token_maps[state]

--- a/tests/fsm/test_guide.py
+++ b/tests/fsm/test_guide.py
@@ -485,7 +485,6 @@ def test_cfg_allow_both_extend_and_shift_terminal():
     assert fsm.is_final_state(state)
 
 
-# TODO: parameterize
 @pytest.mark.parametrize(
     "generation_str, is_valid, should_break_early",
     [


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/856

The issue was caused by the fact that in `RegexGuide` `self.final_states` includes not just **necessarily** final states, but all **possibly final states, . 

In other words, in `main` if we get to a state which can legally complete (e.g. `127.0.0.1`), the current state will be returned for `get_next_state` for any non-EOS token. `127.0.0.11` is a legal continuation, but because no state transition occurred, we could continue with `127.0.0.123`, `127.0.0.1234`, `127.0.0.12345`, etc

The correct check to determine whether a state is **necessarily** final and must produce an EOS next is `state not in self.states_to_token_maps`.