### PR TITLE
disable cache for all tests except `test_cache.py` and benchmark tests

### DIFF
--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -7,7 +7,10 @@ from typing import Callable, Optional
 import cloudpickle
 from diskcache import Cache
 
-_caching_enabled = True
+if os.environ.get("OUTLINES_DISABLE_CACHE", "") in ("", "0"):
+    _caching_enabled = True
+else:
+    _caching_enabled = False
 
 
 @functools.lru_cache(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_env():
+    os.environ["OUTLINES_DISABLE_CACHE"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,15 @@ import os
 
 import pytest
 
+ENABLE_CACHE_TEST_PREFIXES = ["tests.test_cache", "tests.benchmark"]
 
-@pytest.fixture(scope="session", autouse=True)
-def set_env():
+
+@pytest.fixture(scope="module", autouse=True)
+def disable_cache(request):
+    for prefix in ENABLE_CACHE_TEST_PREFIXES:
+        if request.module.__name__.startswith(prefix):
+            return
+
     os.environ["OUTLINES_DISABLE_CACHE"] = "1"
     import outlines.caching
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 import pytest
@@ -6,3 +7,6 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def set_env():
     os.environ["OUTLINES_DISABLE_CACHE"] = "1"
+    import outlines.caching
+
+    importlib.reload(outlines.caching)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,8 +33,6 @@ def test_cache(refresh_environment):
     Initialize a temporary cache and delete it after the test has run.
     Enable cache (unique to these tests, other tests have cache disabled by default)
     """
-    os.environ["OUTLINES_DISABLE_CACHE"] = ""
-
     with tempfile.TemporaryDirectory() as tempdir:
         os.environ["OUTLINES_CACHE_DIR"] = tempdir
         import outlines

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import tempfile
 
@@ -28,7 +29,12 @@ def refresh_environment():
 
 @pytest.fixture
 def test_cache(refresh_environment):
-    """Initialize a temporary cache and delete it after the test has run."""
+    """
+    Initialize a temporary cache and delete it after the test has run.
+    Enable cache (unique to these tests, other tests have cache disabled by default)
+    """
+    os.environ["OUTLINES_DISABLE_CACHE"] = ""
+
     with tempfile.TemporaryDirectory() as tempdir:
         os.environ["OUTLINES_CACHE_DIR"] = tempdir
         import outlines
@@ -157,3 +163,19 @@ def test_version_upgrade_cache_invalidate(test_cache, mocker):
 
     # assert with version upgrade, old cache is invalidated and new cache is used
     a, b = foo()
+
+
+def test_outlines_cache_disabled_env_var():
+    os.environ["OUTLINES_DISABLE_CACHE"] = "1"
+    import outlines.caching
+
+    importlib.reload(outlines.caching)
+    assert not outlines.caching._caching_enabled
+
+
+def test_outlines_cache_enabled_env_var():
+    os.environ["OUTLINES_DISABLE_CACHE"] = ""
+    import outlines.caching
+
+    importlib.reload(outlines.caching)
+    assert outlines.caching._caching_enabled

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -29,10 +29,7 @@ def refresh_environment():
 
 @pytest.fixture
 def test_cache(refresh_environment):
-    """
-    Initialize a temporary cache and delete it after the test has run.
-    Enable cache (unique to these tests, other tests have cache disabled by default)
-    """
+    """Initialize a temporary cache and delete it after the test has run."""
     with tempfile.TemporaryDirectory() as tempdir:
         os.environ["OUTLINES_CACHE_DIR"] = tempdir
         import outlines


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/853


