### PR TITLE
Use a  trie to speed up index construction

### DIFF
--- a/benchmarks/bench_regex_fsm.py
+++ b/benchmarks/bench_regex_fsm.py
@@ -1,0 +1,56 @@
+import random
+
+from outlines.caching import cache_disabled
+from outlines.fsm.regex import reduced_vocabulary
+from outlines.models.tokenizer import Tokenizer
+
+from .common import ensure_numba_compiled
+
+
+class MockTokenizer(Tokenizer):
+    def __init__(self, token_strs):
+        self.eos_token = "<eos>"
+        self.eos_token_id = 0
+        self.pad_token_id = 1
+        self.special_tokens = {0, 1}
+
+        self.vocabulary = {"<eos>": 0, "<pad>": 1}
+
+        for i, tok in enumerate(token_strs):
+            self.vocabulary[tok] = i + 2
+
+    @classmethod
+    def from_random_tokens(cls, n_tokens, max_token_length=8, seed=42):
+        random.seed(seed)
+        tokens = [
+            "".join(
+                chr(random.randint(0, 4096))
+                for __ in range(random.randint(0, max_token_length))
+            )
+            for _ in range(n_tokens)
+        ]
+        return cls(tokens)
+
+    def convert_token_to_string(self, token):
+        return token
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.vocabulary.items())))
+
+
+def reduced_vocabulary_uncached(*args, **kwargs):
+    return reduced_vocabulary.__wrapped__(*args, **kwargs)
+
+
+class RegexReducedVocabularyBenchmark:
+    params = [10000, 100000, 1000000]
+    param_names = ["vocab_size"]
+
+    def setup(self, vocab_size):
+        ensure_numba_compiled(MockTokenizer([chr(i) for i in range(128)]))
+
+        self.tokenizer = MockTokenizer.from_random_tokens(vocab_size)
+
+    @cache_disabled()
+    def time_reduced_vocabulary(self, _):
+        reduced_vocabulary_uncached(self.tokenizer)

--- a/outlines/fsm/vocab_trie.py
+++ b/outlines/fsm/vocab_trie.py
@@ -1,0 +1,244 @@
+import operator
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+from numba import njit, typed, types
+from numba.cpython.hashing import (
+    _Py_uhash_t,
+    _PyHASH_XXPRIME_1,
+    _PyHASH_XXPRIME_2,
+    _PyHASH_XXPRIME_5,
+    _PyHASH_XXROTATE,
+    process_return,
+)
+from numba.experimental import jitclass, structref
+from numba.extending import overload
+from numba.typed import Dict
+
+###########################
+# Dict With Int[:] Key Impl
+###########################
+
+
+# Register type
+@structref.register
+class IntArrayDictType(types.StructRef):
+    """
+    Represents a dictionary using int64[:] as keys,
+    intended for byte-level FSM representation with int64[:] transition.
+    """
+
+    def preprocess_fields(self, fields):
+        return tuple(
+            (name, typ.dtype if isinstance(typ, types.TypeRef) else typ)
+            for name, typ in fields
+        )
+
+
+class IntArrayDict(structref.StructRefProxy):
+    """Python proxy"""
+
+    @property
+    def wrapped_dict(self):
+        return IntArrayDict_get_wrapped_dict(self)  # noqa: F821
+
+
+structref.define_proxy(IntArrayDict, IntArrayDictType, ["wrapped_dict"])
+
+
+@njit
+def hash_key(key):
+    """
+    XXH64 Hash for int64[:] keys
+    adapted from https://github.com/numba/numba/blob/556545/numba/cpython/hashing.py
+    """
+    acc = _PyHASH_XXPRIME_5
+    for i in range(key.shape[0]):
+        x = key[i]
+        lane = hash(x)
+        if lane == _Py_uhash_t(-1):
+            return -1
+        acc += lane * _PyHASH_XXPRIME_2
+        acc = _PyHASH_XXROTATE(acc)
+        acc *= _PyHASH_XXPRIME_1
+
+    acc += key.shape[0] ^ (_PyHASH_XXPRIME_5 ^ _Py_uhash_t(3527539))
+
+    if acc == _Py_uhash_t(-1):
+        return process_return(1546275796)
+
+    return process_return(acc)
+
+
+@overload(IntArrayDict)
+def custom_int_array_dict_constructor(value_type):
+    if isinstance(value_type, types.Type):
+
+        def impl(value_type):
+            wrapped_dictionary = Dict.empty(types.intp, value_type)
+            return IntArrayDict(wrapped_dictionary)
+
+        return impl
+
+
+@overload(operator.getitem)
+def ol_int_array_dict_getitem(inst, key):
+    if isinstance(inst, IntArrayDictType):
+
+        def impl(inst, key):
+            return inst.wrapped_dict[hash_key(key)]
+
+        return impl
+
+
+@overload(operator.setitem)
+def ol_int_array_dict_setitem(inst, key, value):
+    if isinstance(inst, IntArrayDictType):
+
+        def impl(inst, key, value):
+            inst.wrapped_dict[hash_key(key)] = value
+
+        return impl
+
+
+@overload(operator.contains)
+def ol_int_array_dict_contains(inst, key):
+    if isinstance(inst, IntArrayDictType):
+
+        def impl(inst, key):
+            return hash_key(key) in inst.wrapped_dict
+
+        return impl
+
+
+#################
+# Vocab Trie Impl
+#################
+
+nb_int64_array_type = types.int64[:]
+
+# use intp keys as that is the hash type,
+# but the true key type is nb_int64_array_type
+IntArrayToIntType = IntArrayDictType(
+    (("wrapped_dict", types.DictType(types.intp, types.int64)),)
+)
+IntArrayToIntArrayType = IntArrayDictType(
+    (("wrapped_dict", types.DictType(types.intp, nb_int64_array_type)),)
+)
+
+
+@jitclass(
+    [
+        ("token_to_token_key", IntArrayToIntType),
+        ("token_key_to_token", types.DictType(types.int64, nb_int64_array_type)),
+        (
+            "token_key_to_child_token_keys",
+            types.DictType(types.int64, nb_int64_array_type),
+        ),
+        ("token_to_token_ids", IntArrayToIntArrayType),
+    ]
+)
+class VocabTrie:
+    """
+    VocabTrie: Class for efficient traversal of the vocabulary
+
+    Bidirectional mapping between trie node ID and nb_int64_array_type token
+    - token_to_token_key: Dict[nb_int64_array_type, int]
+    - token_key_to_token: Dict[int, nb_int64_array_type]
+
+    Allow retrieval of children in trie
+    - token_key_to_child_token_keys: Dict[int, int64[:]]
+
+    Allow retrieval of token_ids for a given token
+    - token_to_token_ids: Dict[nb_int64_array_type, int64[:]]
+
+    Trie structure:
+        Only members of the vocabulary are included as nodes, no intermediates.
+        Structured to guarantee that recursive calls to get_children()
+        will return every token once, only once.
+
+        Given a vocabulary of ["a", "ab", "abc", "ac", "ace", "apple"],
+        the children of "a" are "ab", "ac", "apple".
+        "abc" and "ace" are excluded because they have intermediate parents in the vocabulary.
+    """
+
+    def __init__(
+        self,
+        all_token_transitions: List[Sequence[int]],
+        vocabulary: List[Tuple[str, Sequence[int]]],
+    ):
+        self.token_to_token_key = IntArrayDict(
+            typed.Dict.empty(types.intp, types.int64)
+        )
+        self.token_key_to_token = typed.Dict.empty(
+            key_type=types.int64, value_type=nb_int64_array_type
+        )
+        self.token_key_to_child_token_keys = typed.Dict.empty(
+            key_type=types.int64, value_type=nb_int64_array_type
+        )
+        self.token_to_token_ids = IntArrayDict(
+            typed.Dict.empty(types.intp, nb_int64_array_type)
+        )
+
+        self._insert(all_token_transitions, vocabulary)
+
+    def _insert(
+        self,
+        all_token_transitions: List[Sequence[int]],
+        vocabulary: List[Tuple[str, Sequence[int]]],
+    ) -> None:
+        # Initialize an empty array for the root token key to store child token keys
+        self.token_key_to_child_token_keys[-1] = np.empty((0,), types.int64)
+
+        # It's necessary to insert shorter transition sequences (prefixes) first
+        sorted_idx_transition_seq = sorted(
+            enumerate(all_token_transitions), key=lambda x: len(x[1])
+        )
+
+        for idx, token_transitions in sorted_idx_transition_seq:
+            token_ids = vocabulary[idx][1]
+            if token_transitions not in self.token_to_token_key:
+                # create bimapping between token and token_key (tokens trie node key)
+                self.token_to_token_key[token_transitions] = idx
+                self.token_key_to_token[idx] = token_transitions
+
+                # find parent token key
+                parent_token_key = -1  # root token
+                for i in range(len(token_transitions) - 1, -1, -1):
+                    prefix_token = token_transitions[:i]
+                    if prefix_token in self.token_to_token_key:
+                        parent_token_key = self.token_to_token_key[prefix_token]
+                        break
+                # map parent token to current token
+                self.token_key_to_child_token_keys[parent_token_key] = np.append(
+                    self.token_key_to_child_token_keys[parent_token_key],
+                    np.array([idx]),
+                )
+                # map current token to empty list of children
+                self.token_key_to_child_token_keys[idx] = np.empty((0,), types.int64)
+
+                # set current tokens token ids
+                self.token_to_token_ids[token_transitions] = token_ids
+
+            else:
+                # if exists, append to current tokens token ids
+                self.token_to_token_ids[token_transitions] = np.append(
+                    self.token_to_token_ids[token_transitions], token_ids
+                )
+
+    def get_children(self, token_transitions: Optional[Sequence[int]] = None):
+        """
+        Get the token_ids of all children for the given token_id.
+        If token_id is None, get the root children.
+        """
+        if token_transitions is None:
+            token_key = -1
+        else:
+            token_key = self.token_to_token_key[token_transitions]
+
+        child_token_keys = self.token_key_to_child_token_keys[token_key]
+
+        return [self.token_key_to_token[token_key] for token_key in child_token_keys]
+
+    def get_token_ids(self, token):
+        return self.token_to_token_ids[token]


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/795

Awaiting https://github.com/outlines-dev/outlines/pull/1070 

## Problem

In `regex.py` Outlines compiles an index of legal tokens for each state of the FSM (`state_scan_tokens`)

On the `main` branch we use a naive approach:
- for each (`state`, `token`) belonging to (`FSM`, `vocabulary`), simulate FSM traversal character-by-character, saving (`state`, `token`) pairs which can successfully walk the FSM.

Calling walking the FSM `num_tokens * num_states` times is inefficient  and the current bottleneck in index construction.

## Solution

We can improve this by using a Trie. 

We know for a fact that if the token `foo` is illegal at a state, the token `foobar` is also illegal. Therefore we construct a trie, and if only if `foo` is legal, we check `foobar`, and only if `foobar` is legal, we check `foobarbaz`. 

This prevents unnecessary work from being performed and reduces runtime on average.

#### Result

Some overhead is introduced, resulting in a slight degradation in performance for simple patterns, but a great performance increase for complex patterns.
- Worst case (`ssn`): `352ms` -> `374ms`
- Best case (`complex_schema`): `3.09s` ->`1.30s`


#### Analysis
This analysis reviews the profiling details of multiple runs using `complex_schema`.

This PR is primarily an optimization of `state_scan_tokens`. Runtime of this function reduces from an average of 6.52s to 1.77 for `complex_schema`

New result profiling breakdown (performance varies by pattern):
- **`RegexGuide()`**: 4.55s
  - `create_states_mapping()`: 4.15s
    - `Pattern.to_fsm().reduce()`: 0.961s
    - `create_fsm_index_tokenizer()`: 3.34s
      - (overhead): 0.14s
      - `reduced_vocabulary()`: 0.55s
      - `create_fsm_index_end_to_end()`: 2.29s
        - `state_scan_tokens(...)`: 1.77s (359 calls)
        - (overhead): 0.47s

#### Benchmarks


(Benchmarks are relative to https://github.com/outlines-dev/outlines/pull/1070)

Benchmarks that have improved:
```
| Change   | Before [65ae1585]    | After [a8075e9c]    |   Ratio | Benchmark (Parameter)                                                                                     |
|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------------------------------------------|
| -        | 3.09±0.02s           | 1.30±0.01s          |    0.42 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('complex_schema')                           |
| -        | 1.58±0s              | 837±4ms             |    0.53 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('simple_schema')                            |
| -        | 662±7ms              | 407±6ms             |    0.61 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_phone')                                |
| -        | 4.23±0s              | 2.06±0s             |    0.49 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_span_constrained_relation_extraction') |
| -        | 504±2ms              | 391±6ms             |    0.78 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('date')                                         |
| -        | 472±1ms              | 407±3ms             |    0.86 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('email')                                        |
| -        | 423±1ms              | 377±4ms             |    0.89 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ip')                                           |
| -        | 571±4ms              | 475±5ms             |    0.83 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('url')                                          |
```

Benchmarks that have stayed the same:

<details>

```
| Change   | Before [65ae1585]    | After [a8075e9c]    |   Ratio | Benchmark (Parameter)                                                                                              |
|----------|----------------------|---------------------|---------|--------------------------------------------------------------------------------------------------------------------|
|          | 92.3±0.5μs           | 91.7±1μs            |    0.99 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('complex_schema')                                  |
|          | 50.5±0.9μs           | 50.0±0.5μs          |    0.99 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('simple_schema')                                   |
|          | 3.78±0.01s           | 4.11±0.01s          |    1.09 | bench_numba_compile.NumbaCompileBenchmark.time_compile_numba                                                       |
|          | 183±0.2μs            | 183±0.9μs           |    1    | bench_processors.LogitsProcessorPassthroughBenchmark.time_passthrough('numpy')                                     |
|          | 181±0.4μs            | 181±3μs             |    1    | bench_processors.LogitsProcessorPassthroughBenchmark.time_passthrough('torch')                                     |
|          | 247±4μs              | 247±3μs             |    1    | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('numpy', 'Z*')                      |
|          | 1.04±0.01ms          | 1.06±0.02ms         |    1.02 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('numpy', '[^Z]*')                   |
|          | 230±0.8μs            | 224±5μs             |    0.97 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('torch', 'Z*')                      |
|          | 1.03±0.01ms          | 1.04±0.01ms         |    1    | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('torch', '[^Z]*')                   |
|          | 17.0±0.06ms          | 17.6±0.4ms          |    1.04 | bench_regex_fsm.RegexReducedVocabularyBenchmark.time_reduced_vocabulary(10000)                                     |
|          | 178±2ms              | 175±0.7ms           |    0.98 | bench_regex_fsm.RegexReducedVocabularyBenchmark.time_reduced_vocabulary(100000)                                    |
|          | 1.87±0.02s           | 1.85±0.01s          |    0.99 | bench_regex_fsm.RegexReducedVocabularyBenchmark.time_reduced_vocabulary(1000000)                                   |
|          | 640M                 | 671M                |    1.05 | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('complex_span_constrained_relation_extraction') |
|          | 542M                 | 586M                |    1.08 | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('simple_phone')                                 |
|          | 389±0.9ms            | 384±3ms             |    0.99 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('simple_phone')                                          |
|          | 352±1ms              | 374±4ms             |    1.06 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ssn')                                                   |
|          | 346±3ms              | 338±2ms             |    0.98 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('time')                                                  |
```

</details>

#### Profile

<details>

by `tottime`

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      359    1.414    0.004    1.414    0.004 /home/andrew/p/outlines/outlines/fsm/regex.py:662(state_scan_tokens)
        1    1.381    1.381    4.081    4.081 /home/andrew/p/outlines/outlines/caching.py:114(wrapper)
        1    0.358    0.358    1.761    1.761 /home/andrew/p/outlines/outlines/fsm/regex.py:783(create_fsm_index_end_to_end)
    67256    0.267    0.000    0.267    0.000 {method 'index' of 'list' objects}
        1    0.231    0.231    0.231    0.231 <string>:2(ctor)
  1665873    0.205    0.000    0.205    0.000 {method 'add' of 'set' objects}
        1    0.136    0.136    1.897    1.897 /home/andrew/p/outlines/outlines/fsm/regex.py:1016(create_fsm_index_tokenizer)
      523    0.134    0.000    0.724    0.001 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:969(crawl)
        1    0.113    0.113    0.113    0.113 /home/andrew/p/outlines/outlines/fsm/regex.py:960(vocab_dict_to_inverted_vocab_list)
      359    0.109    0.000    0.109    0.000 {built-in method torch.tensor}
        8    0.105    0.013    0.105    0.013 {method '__reduce_ex__' of 'object' objects}
  1126880    0.101    0.000    0.101    0.000 {method 'setdefault' of 'dict' objects}
   198170    0.095    0.000    0.107    0.000 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:347(follow)
   114135    0.082    0.000    0.082    0.000 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:925(follow)
        1    0.082    0.082    0.082    0.082 /home/andrew/p/outlines/outlines/fsm/regex.py:739(get_vocabulary_transition_keys)
   128256    0.074    0.000    0.074    0.000 {method 'decode' of 'tokenizers.decoders.Decoder' objects}
   128256    0.054    0.000    0.177    0.000 /home/andrew/p/outlines/outlines/models/transformers.py:96(convert_token_to_string)
   128420    0.050    0.000    0.196    0.000 /nix/store/yd3jmjzhalskwdbcn5c6sxnsyql9a21w-python3.12-numba-0.60.0/lib/python3.12/site-packages/numba/core/typing/typeof.py:27(typeof)
```

by `cumtime`


```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    5.395    5.395 {built-in method builtins.exec}
        1    0.000    0.000    5.395    5.395 <string>:1(<module>)
        1    0.000    0.000    5.395    5.395 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/contextlib.py:78(inner)
        1    0.029    0.029    5.394    5.394 /home/andrew/p/outlines/profile_regex_index.py:37(construct_regex_index)
        1    0.000    0.000    5.365    5.365 /home/andrew/p/outlines/outlines/fsm/guide.py:179(__init__)
        1    0.001    0.001    5.197    5.197 /home/andrew/p/outlines/outlines/caching.py:114(wrapper)
        1    0.000    0.000    5.197    5.197 /home/andrew/p/outlines/outlines/fsm/guide.py:119(create_states_mapping)
        1    0.158    0.158    4.141    4.141 /home/andrew/p/outlines/outlines/fsm/regex.py:1016(create_fsm_index_tokenizer)
        1    0.543    0.543    3.082    3.082 /home/andrew/p/outlines/outlines/fsm/regex.py:783(create_fsm_index_end_to_end)
      359    1.765    0.005    1.766    0.005 /home/andrew/p/outlines/outlines/fsm/regex.py:662(state_scan_tokens)
      523    0.178    0.000    0.957    0.002 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:969(crawl)
     10/1    0.001    0.000    0.911    0.911 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/patterns.py:447(to_fsm)
    128/2    0.001    0.000    0.777    0.388 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/patterns.py:453(<genexpr>)
    118/1    0.002    0.000    0.777    0.777 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/patterns.py:370(to_fsm)
        1    0.002    0.002    0.734    0.734 /home/andrew/p/outlines/outlines/fsm/regex.py:999(reduced_vocabulary)
     13/1    0.000    0.000    0.691    0.691 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/patterns.py:280(to_fsm)
      131    0.001    0.000    0.405    0.003 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:310(concatenate)
    67256    0.354    0.000    0.354    0.000 {method 'index' of 'list' objects}
       10    0.000    0.000    0.315    0.032 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:451(union)
       10    0.000    0.000    0.315    0.031 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:913(parallel)
        1    0.053    0.053    0.312    0.312 /home/andrew/p/outlines/outlines/fsm/regex.py:903(get_normalized_vocab)
        1    0.038    0.038    0.278    0.278 /home/andrew/p/outlines/outlines/fsm/regex.py:938(to_numba_dict)
        1    0.000    0.000    0.267    0.267 /nix/store/yd3jmjzhalskwdbcn5c6sxnsyql9a21w-python3.12-numba-0.60.0/lib/python3.12/site-packages/numba/experimental/jitclass/base.py:119(__call__)
        1    0.267    0.267    0.267    0.267 <string>:2(ctor)
  1665867    0.256    0.000    0.256    0.000 {method 'add' of 'set' objects}
   128256    0.077    0.000    0.251    0.000 /home/andrew/p/outlines/outlines/models/transformers.py:96(convert_token_to_string)
   128420    0.063    0.000    0.247    0.000 /nix/store/yd3jmjzhalskwdbcn5c6sxnsyql9a21w-python3.12-numba-0.60.0/lib/python3.12/site-packages/numba/core/typing/typeof.py:27(typeof)
   128256    0.059    0.000    0.174    0.000 /nix/store/dvqgbyv0i8bh4ddqay6cpsv9i48xi3ic-python3.12-transformers-4.43.3/lib/python3.12/site-packages/transformers/tokenization_utils_fast.py:637(convert_tokens_to_string)
        1    0.015    0.015    0.168    0.168 /home/andrew/p/outlines/outlines/fsm/guide.py:285(_cache_state_to_token_tensor)
        1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/outlines/models/transformers.py:118(__hash__)
        1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/fingerprint.py:226(hash)
        1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/utils/_dill.py:106(dumps)
        1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/utils/_dill.py:101(dump)
        1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/dill/_dill.py:418(dump)
        1    0.000    0.000    0.156    0.156 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/pickle.py:470(dump)
    179/1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/utils/_dill.py:31(save)
    179/1    0.000    0.000    0.156    0.156 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/dill/_dill.py:367(save)
    179/1    0.000    0.000    0.155    0.155 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/pickle.py:529(save)
        1    0.000    0.000    0.155    0.155 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/utils/_dill.py:202(_save_transformersPreTrainedTokenizerBase)
      9/1    0.000    0.000    0.155    0.155 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/pickle.py:615(save_reduce)
      9/1    0.000    0.000    0.155    0.155 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/dill/_dill.py:1195(save_module_dict)
      9/1    0.000    0.000    0.155    0.155 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/pickle.py:959(save_dict)
      9/1    0.000    0.000    0.155    0.155 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/datasets/utils/_dill.py:72(_batch_setitems)
      9/1    0.000    0.000    0.155    0.155 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/pickle.py:970(_batch_setitems)
      359    0.153    0.000    0.153    0.000 {built-in method torch.tensor}
        8    0.153    0.019    0.153    0.019 {method '__reduce_ex__' of 'object' objects}
       13    0.000    0.000    0.145    0.011 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:364(__add__)
128744/128420    0.054    0.000    0.143    0.000 /nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4/lib/python3.12/functools.py:904(wrapper)
   198170    0.125    0.000    0.139    0.000 /home/andrew/p/outlines/.myenv2/lib/python3.12/site-packages/interegular/fsm.py:347(follow)
        1    0.139    0.139    0.139    0.139 /home/andrew/p/outlines/outlines/fsm/regex.py:960(vocab_dict_to_inverted_vocab_list)
```

</details>