### PR TITLE
change int regex

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -13,6 +13,7 @@ from referencing.jsonschema import DRAFT202012
 STRING_INNER = r'([^("\\\x00-\x1f\x7f-\x9f)]|\\\\)'
 STRING = f'"{STRING_INNER}*"'
 INTEGER = r"(-)?(0|[1-9][0-9]*)"
+INTEGER = r"[+-]?(0|[1-9][0-9]*)"
 NUMBER = rf"({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"
 BOOLEAN = r"(true|false)"
 NULL = r"null"

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -212,7 +212,7 @@ def test_match_number(pattern, does_match):
                 "properties": {"count": {"title": "Count", "type": "integer"}},
                 "required": ["count"],
             },
-            '\\{[\\n ]*"count"[\\n ]*:[\\n ]*(-)?(0|[1-9][0-9]*)[\\n ]*\\}',
+            '\\{[\\n ]*"count"[\\n ]*:[\\n ]*[+-]?(0|[1-9][0-9]*)[\\n ]*\\}',
             [('{\n  "count": 100\n}', True)],
         ),
         # array


### PR DESCRIPTION
I also noticed that we have two different definitions of `INTEGER`. In `json_schema.py` we have 
```python
INTEGER = r"(-)?(0|[1-9][0-9]*)"
```
and in `types.py` we have
```python
INTEGER = r"[+-]?(0|[1-9][0-9]*)"
```
I changed the definition in `json_schema.py` to be the same as that in `types.py` because `INTEGER` in `types.py` allows both `+` and `-` in front of the number and the definition in `json_schema.py` does not allow this.

More generally, it may be helpful to store these types in one single location. Perhaps we should keep all the types in `types.py` and we can import these types into `json_schema.py` when we need it. That way we won't have diverging definitions again.

What do you think?