### PR TITLE
[Issue #820] Cannot convert token � (29333) to bytes: � for some model vocabularies when using llama.cpp

### DIFF
--- a/outlines/fsm/regex.py
+++ b/outlines/fsm/regex.py
@@ -726,8 +726,8 @@ re_replacement_seq = re.compile(r"^▁*�+$")
 @lru_cache()
 def gpt2_bytes_to_unicode():
     """
-    Returns list of utf-8 byte and a mapping to unicode strings. We specifically avoids mapping to whitespace/control
-    characters the bpe code barfs on.
+    Returns list of utf-8 byte and a mapping to unicode strings. We specifically avoids mapping to control characters
+    the bpe code barfs on. We added the replacement character � (\ufffd).
 
     The reversible bpe codes work on unicode strings. This means you need a large # of unicode characters in your vocab
     if you want to avoid UNKs. When you're at something like a 10B token dataset you end up needing around 5K for
@@ -735,9 +735,10 @@ def gpt2_bytes_to_unicode():
     tables between utf-8 bytes and unicode strings.
     """
     bs = (
-        list(range(ord("!"), ord("~") + 1))
+        list(range(ord(" "), ord("~") + 1))
         + list(range(ord("¡"), ord("¬") + 1))
         + list(range(ord("®"), ord("ÿ") + 1))
+        + [ord("�")]
     )
     cs = bs[:]
     n = 0

--- a/outlines/fsm/regex.py
+++ b/outlines/fsm/regex.py
@@ -727,7 +727,7 @@ re_replacement_seq = re.compile(r"^▁*�+$")
 def gpt2_bytes_to_unicode():
     """
     Returns list of utf-8 byte and a mapping to unicode strings. We specifically avoids mapping to control characters
-    the bpe code barfs on. We added the replacement character � (\ufffd).
+    the bpe code barfs on. We added the replacement character � (\ufffd) and Ń (\u0144).
 
     The reversible bpe codes work on unicode strings. This means you need a large # of unicode characters in your vocab
     if you want to avoid UNKs. When you're at something like a 10B token dataset you end up needing around 5K for
@@ -738,7 +738,7 @@ def gpt2_bytes_to_unicode():
         list(range(ord(" "), ord("~") + 1))
         + list(range(ord("¡"), ord("¬") + 1))
         + list(range(ord("®"), ord("ÿ") + 1))
-        + [ord("�")]
+        + [ord("�"), ord("Ń")]
     )
     cs = bs[:]
     n = 0


### PR DESCRIPTION
Attempt at solving issue #820 - RuntimeError: Cannot convert token � (29333) to bytes: �

With additional characters in the `gpt2_bytes_to_unicode()` map, I don't get errors anymore.
However, it doesn't seem good to add ad-hoc characters like that. We should test on many more kinds of tokenizers.

Benchmarks pass:
![image](https://github.com/outlines-dev/outlines/assets/6545903/b39de66a-eab2-4014-9434-a465bc15cff2)

Side note: Had to switch to Linux for development because of the `vllm` dependency, see their [Requirements](https://docs.vllm.ai/en/latest/getting_started/installation.html#requirements).