### PR TITLE
Circumvent Broken llama.cpp Pre-Tokenizer

### DIFF
--- a/outlines/integrations/llamacpp.py
+++ b/outlines/integrations/llamacpp.py
@@ -49,11 +49,19 @@ class LlamaCppTokenizer:
         self.special_tokens: Set[int] = set()
 
         self.vocabulary: Dict[str, int] = dict()
-        for t in range(model.n_vocab()):
-            token_piece = model.tokenizer().decode([t])
-            self.vocabulary[token_piece] = t
 
-        self.decode = model.tokenizer().decode
+        tokenizer = model.tokenizer()
+
+        self.decode = tokenizer.decode
+
+        # TODO: Remove when https://github.com/ggerganov/llama.cpp/pull/5613 is resolved
+        try:
+            self.vocabulary = model.tokenizer_.hf_tokenizer.get_vocab()
+        except AttributeError:
+            # ###
+            for t in range(model.n_vocab()):
+                token_piece = model.tokenizer().decode([t])
+                self.vocabulary[token_piece] = t
 
     def convert_token_to_string(self, token: str) -> str:
         return token

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -1,4 +1,5 @@
 import dataclasses
+import warnings
 from typing import TYPE_CHECKING, Iterator, List, Optional, TypedDict, Union
 
 from typing_extensions import Unpack
@@ -287,6 +288,16 @@ def llamacpp(
 
     if "verbose" not in llamacpp_model_params:
         llamacpp_model_params["verbose"] = False
+
+    # TODO: Remove when https://github.com/ggerganov/llama.cpp/pull/5613 is resolved
+    if "tokenizer" not in llamacpp_model_params:
+        warnings.warn(
+            "The pre-tokenizer in `llama.cpp` handles unicode improperly "
+            + "(https://github.com/ggerganov/llama.cpp/pull/5613)\n"
+            + "Outlines may raise a `RuntimeError` when building the regex index.\n"
+            + "To circumvent this error when using `models.llamacpp()` you may pass the argument"
+            + "`tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(<hf_repo_id>)`\n"
+        )
 
     model = Llama.from_pretrained(repo_id, filename, **llamacpp_model_params)
 


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/820

## Problem:

llama.cpp's pre-tokenizer doesn't handle unicode properly (draft PR: https://github.com/ggerganov/llama.cpp/pull/5613). This results in tokens which are incompatible with Outlines byte-wise FSM and causes #820's error.

## Solution:

- 1) If `models.llamacpp()` specifies a `LlamaHFTokenizer`, populate the vocabulary used in index construction with `tokenizer.get_vocab()`. This takes advantage of huggingface's working pre-tokenizer.
- 2) Warn users that they should pass a `LlamaHFTokenizer`:

```
>>> from outlines import models, generate
>>> model = models.llamacpp("Qwen/Qwen1.5-0.5B-Chat-GGUF", "*q8*.gguf")
/opt/conda/lib/python3.10/site-packages/outlines/models/llamacpp.py:294: UserWarning: llama.cpp pre-tokenizer is broken. You may recieve an Outlines error during Regex index construction.
To avoid this error when using `models.llamacpp` you may pass `tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(<hf_repo_id>)` to `models.llamacpp()`
  warnings.warn(
```
 
## Debug Notes / Observations:
- The problematic token in Qwen1.5 is `29333` (`b' \xef\xbf\xbd'`)
- The issue can be reproduced with `models.llamacpp`, but not `models.transformers`
- `AutoTokenizer`'s `get_vocab()` is inconsistent with its `encode` / `decode` output. 
  - `get_vocab()[ b'\xc4\xa0\xc3\xaf\xc2\xbf\xc2\xbd'.decode()]` = `29333`
  - `get_vocab()[ b' \xef\xbf\xbd'.decode()]` -> `KeyError`
  - `encode( b'\xc4\xa0\xc3\xaf\xc2\xbf\xc2\xbd'.decode())` = `[144242,  37572,  30182,  26062]`
  - `encode(b' \xef\xbf\xbd'.decode())` = `[29333]`

`tokenizer.get_vocab()` has a distinct mapping from `tokenizer.decode` due to the pre-tokenizer:

```
>>> tokenizer = transformers.AutoTokenizer.from_pretrained("Qwen/Qwen1.5-0.5B-Chat")
>>> tokenizer.backend_tokenizer.pre_tokenizer.pre_tokenize_str(b' \xef\xbf\xbd'.decode())[0][0].encode()
b'\xc4\xa0\xc3\xaf\xc2\xbf\xc2\xbd'
```