### PR TITLE
Prevent Illegal Look-Around for OneOf in JSONSchema

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -195,13 +195,7 @@ def to_regex(
             to_regex(resolver, t, whitespace_pattern) for t in instance["oneOf"]
         ]
 
-        xor_patterns = []
-        # json schema validation ensured there is no overlapping schemas in oneOf
-        for subregex in subregexes:
-            other_subregexes = filter(lambda r: r != subregex, subregexes)
-            other_subregexes_str = "|".join([f"{s}" for s in other_subregexes])
-            negative_lookahead = f"(?!.*({other_subregexes_str}))"
-            xor_patterns.append(f"({subregex}){negative_lookahead}")
+        xor_patterns = [f"(?:{subregex})" for subregex in subregexes]
 
         return rf"({'|'.join(xor_patterns)})"
 


### PR DESCRIPTION
Fixes #823

This comment details the issues error: https://github.com/outlines-dev/outlines/issues/823#issuecomment-2116490949

The reproduction code provided results in a json schema with `OneOf[pets]`:

```
class Model(BaseModel):
    pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
```

Before this PR: `OneOf` uses negative lookaheads to assert that only one schema member is included. This is illegal in `interegular`, more details available here: https://github.com/outlines-dev/outlines/issues/456

After `OneOf` uses or-joined non-capturing groups which don't have the same issues with `interegular`.