### PR TITLE
Allow Parenthesis in `STRING_INNER`

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -10,7 +10,7 @@ from referencing import Registry, Resource
 from referencing._core import Resolver
 from referencing.jsonschema import DRAFT202012
 
-STRING_INNER = r'([^("\\\x00-\x1f\x7f-\x9f)]|\\\\)'
+STRING_INNER = r'([^"\\\x00-\x1f\x7f-\x9f]|\\\\)'
 STRING = f'"{STRING_INNER}*"'
 INTEGER = r"(-)?(0|[1-9][0-9]*)"
 NUMBER = rf"({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -119,6 +119,8 @@ def test_match_number(pattern, does_match):
             STRING,
             [
                 ("unquotedstring", False),
+                ('"(parenthesized_string)"', True),
+                ('"malformed) parenthesis (((() string"', True),
                 ('"quoted_string"', True),
                 (r'"escape_\character"', False),
                 (r'"double_\\escape"', True),


### PR DESCRIPTION
Fix #838

https://github.com/outlines-dev/outlines/commit/06d565496966f0dbe184dd619b62ea276035f562 erroneously disallowed parenthesis in strings. This PR allows parenthesis in strings.