### PR TITLE
add args to prompt

### DIFF
--- a/docs/reference/prompting.md
+++ b/docs/reference/prompting.md
@@ -223,7 +223,7 @@ Several projects (e.g.[Toolformer](https://arxiv.org/abs/2302.04761), [ViperGPT]
     Can you do something?
 
     COMMANDS
-    1. my_tool: Tool description, args: arg1:str, arg2:int
+    1. my_tool: Tool description., args: arg1: str, arg2: int
 
     def my_tool(arg1: str, arg2: int):
         """Tool description.

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -207,6 +207,7 @@ def render(template: str, **values: Optional[Dict[str, Any]]) -> str:
     env.filters["source"] = get_fn_source
     env.filters["signature"] = get_fn_signature
     env.filters["schema"] = get_schema
+    env.filters["args"] = get_fn_args
 
     jinja_template = env.from_string(cleaned_template)
 
@@ -224,6 +225,23 @@ def get_fn_name(fn: Callable):
         name = fn.__name__
 
     return name
+
+
+def get_fn_args(fn: Callable):
+    """Returns the arguments of a function with annotations and default values if provided."""
+    if not callable(fn):
+        raise TypeError("The `args` filter only applies to callables.")
+
+    arg_str_list = []
+    signature = inspect.signature(fn)
+    for name, param in signature.parameters.items():
+        annotation_str = f":{param.annotation.__name__}" if param.annotation != inspect.Parameter.empty else ""
+        default_str = f"={param.default}" if param.default != inspect.Parameter.empty else ""
+        arg_str = f"{name}{annotation_str}{default_str}"
+        arg_str_list.append(arg_str)
+
+    arg_str = ', '.join(arg_str_list)
+    return arg_str
 
 
 def get_fn_description(fn: Callable):

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -234,12 +234,7 @@ def get_fn_args(fn: Callable):
 
     arg_str_list = []
     signature = inspect.signature(fn)
-    for name, param in signature.parameters.items():
-        annotation_str = f":{param.annotation.__name__}" if param.annotation != inspect.Parameter.empty else ""
-        default_str = f"={param.default}" if param.default != inspect.Parameter.empty else ""
-        arg_str = f"{name}{annotation_str}{default_str}"
-        arg_str_list.append(arg_str)
-
+    arg_str_list = [str(param) for param in signature.parameters.values()]
     arg_str = ', '.join(arg_str_list)
     return arg_str
 

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -235,7 +235,7 @@ def get_fn_args(fn: Callable):
     arg_str_list = []
     signature = inspect.signature(fn)
     arg_str_list = [str(param) for param in signature.parameters.values()]
-    arg_str = ', '.join(arg_str_list)
+    arg_str = ", ".join(arg_str_list)
     return arg_str
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -278,3 +278,16 @@ def test_prompt_args():
         x4:bool=True, y4:str="Hi", z4:Dict[int, List[str]]={4:["I", "love", "outlines"]},
         ):
         pass
+
+    @outlines.prompt
+    def args_prompt(fn):
+        """args: {{ fn | args }}"""
+
+
+    args_prompt(no_args)
+    args_prompt(with_args)
+    args_prompt(with_annotations)
+    args_prompt(with_defaults)
+    args_prompt(with_annotations_and_defaults)
+    args_prompt(with_all)
+

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -283,11 +283,9 @@ def test_prompt_args():
     def args_prompt(fn):
         """args: {{ fn | args }}"""
 
-
-    args_prompt(no_args)
-    args_prompt(with_args)
-    args_prompt(with_annotations)
-    args_prompt(with_defaults)
-    args_prompt(with_annotations_and_defaults)
-    args_prompt(with_all)
-
+    assert args_prompt(no_args) == "args: "
+    assert args_prompt(with_args) == "args: x, y, z"
+    assert args_prompt(with_annotations) == "args: x: bool, y: str, z: Dict[int, List[str]]"
+    assert args_prompt(with_defaults) == "args: x=True, y='Hi', z={4: ['I', 'love', 'outlines']}"
+    assert args_prompt(with_annotations_and_defaults) == "args: x: bool = True, y: str = 'Hi', z: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"
+    assert args_prompt(with_all) == "args: x1, y1, z1, x2: bool, y2: str, z2: Dict[int, List[str]], x3=True, y3='Hi', z3={4: ['I', 'love', 'outlines']}, x4: bool = True, y4: str = 'Hi', z4: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 
 import pytest
 from pydantic import BaseModel, Field
@@ -252,3 +252,29 @@ def test_prompt_dict_response():
 
     prompt = source_ppt(response)
     assert prompt == '{\n  "one": "a description",\n  "two": ""\n}'
+
+
+def test_prompt_args():
+
+    def no_args():
+        pass
+
+    def with_args(x, y, z):
+        pass
+
+    def with_annotations(x:bool, y:str, z: Dict[int, List[str]]):
+        pass
+
+    def with_defaults(x=True, y="Hi", z={4:["I", "love", "outlines"]}):
+        pass
+
+    def with_annotations_and_defaults(x:bool=True, y:str="Hi", z:Dict[int, List[str]]={4:["I", "love", "outlines"]}):
+        pass
+
+    def with_all(
+        x1, y1, z1,
+        x2:bool, y2:str, z2: Dict[int, List[str]],
+        x3=True, y3="Hi", z3={4:["I", "love", "outlines"]},
+        x4:bool=True, y4:str="Hi", z4:Dict[int, List[str]]={4:["I", "love", "outlines"]},
+        ):
+        pass

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -255,28 +255,39 @@ def test_prompt_dict_response():
 
 
 def test_prompt_args():
-
     def no_args():
         pass
 
     def with_args(x, y, z):
         pass
 
-    def with_annotations(x:bool, y:str, z: Dict[int, List[str]]):
+    def with_annotations(x: bool, y: str, z: Dict[int, List[str]]):
         pass
 
-    def with_defaults(x=True, y="Hi", z={4:["I", "love", "outlines"]}):
+    def with_defaults(x=True, y="Hi", z={4: ["I", "love", "outlines"]}):
         pass
 
-    def with_annotations_and_defaults(x:bool=True, y:str="Hi", z:Dict[int, List[str]]={4:["I", "love", "outlines"]}):
+    def with_annotations_and_defaults(
+        x: bool = True,
+        y: str = "Hi",
+        z: Dict[int, List[str]] = {4: ["I", "love", "outlines"]},
+    ):
         pass
 
     def with_all(
-        x1, y1, z1,
-        x2:bool, y2:str, z2: Dict[int, List[str]],
-        x3=True, y3="Hi", z3={4:["I", "love", "outlines"]},
-        x4:bool=True, y4:str="Hi", z4:Dict[int, List[str]]={4:["I", "love", "outlines"]},
-        ):
+        x1,
+        y1,
+        z1,
+        x2: bool,
+        y2: str,
+        z2: Dict[int, List[str]],
+        x3=True,
+        y3="Hi",
+        z3={4: ["I", "love", "outlines"]},
+        x4: bool = True,
+        y4: str = "Hi",
+        z4: Dict[int, List[str]] = {4: ["I", "love", "outlines"]},
+    ):
         pass
 
     @outlines.prompt
@@ -285,7 +296,19 @@ def test_prompt_args():
 
     assert args_prompt(no_args) == "args: "
     assert args_prompt(with_args) == "args: x, y, z"
-    assert args_prompt(with_annotations) == "args: x: bool, y: str, z: Dict[int, List[str]]"
-    assert args_prompt(with_defaults) == "args: x=True, y='Hi', z={4: ['I', 'love', 'outlines']}"
-    assert args_prompt(with_annotations_and_defaults) == "args: x: bool = True, y: str = 'Hi', z: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"
-    assert args_prompt(with_all) == "args: x1, y1, z1, x2: bool, y2: str, z2: Dict[int, List[str]], x3=True, y3='Hi', z3={4: ['I', 'love', 'outlines']}, x4: bool = True, y4: str = 'Hi', z4: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"
+    assert (
+        args_prompt(with_annotations)
+        == "args: x: bool, y: str, z: Dict[int, List[str]]"
+    )
+    assert (
+        args_prompt(with_defaults)
+        == "args: x=True, y='Hi', z={4: ['I', 'love', 'outlines']}"
+    )
+    assert (
+        args_prompt(with_annotations_and_defaults)
+        == "args: x: bool = True, y: str = 'Hi', z: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"
+    )
+    assert (
+        args_prompt(with_all)
+        == "args: x1, y1, z1, x2: bool, y2: str, z2: Dict[int, List[str]], x3=True, y3='Hi', z3={4: ['I', 'love', 'outlines']}, x4: bool = True, y4: str = 'Hi', z4: Dict[int, List[str]] = {4: ['I', 'love', 'outlines']}"
+    )


### PR DESCRIPTION
In the outlines docs, we have the example
```python
import outlines

def my_tool(arg1: str, arg2: int):
    """Tool description.

    The rest of the docstring
    """
    pass

@outlines.prompt
def tool_prompt(question, tool):
    """{{ question }}

    COMMANDS
    1. {{ tool | name }}: {{ tool | description }}, args: {{ tool | args }}

    {{ tool | source }}
    """

prompt = tool_prompt("Can you do something?", my_tool)
print(prompt)
```
However, when I tried running this code, it did not work because the `args` filter used in `{{ tool | args }}` was not implemented. I implemented the `args` filter so now this example works.

Now the args filter will output all of the arguments with the type annotations and default values (if they are provided).
Example:
```python
from typing import List

def foo(x, y: str, z: List[int]=[1, 2, 3]):
    pass

@outlines.prompt
def tool_prompt(fn):
    """My args: {{ fn | args }}"""

prompt = tool_prompt(foo)
print(prompt)
```
which outputs
```python
My args: x, y: str, z: List[int] = [1, 2, 3]
```