### PR TITLE
Allow Objects Which are Unconstrained (No `additionalProperties`) in JSON Schemas 

### DIFF
--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -710,6 +710,19 @@ def test_format(schema, regex, examples):
                 ('{"time":20:20:39Z}', False),  # missing quotes for value
             ],
         ),
+        # Unconstrained Object
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+            },
+            [
+                ("{}", True),
+                ('{"a": 1, "b": null}', True),
+                ('{"a": {"z": {"g": 4}}, "b": null}', True),
+                ("1234", False),  # not an object
+            ],
+        ),
     ],
 )
 def test_format_without_regex(schema, examples):


### PR DESCRIPTION
Fixes #844

## Problem:

We cannot create a pattern using `build_regex_from_schema()` using `{"type": "object"}` unless `additionalProperties` is set. The JSON Schema spec allows `additionalProperties` to be unset. If it's unset, the object has no constraints.

## Solution:

If `additionalProperties` is unset, create pattern allowing for object with any value type by recursively passing `{"anyOf": [{"type": "number"}, ...]}` to `build_regex_from_schema()`.

To keep the pattern finite, we set the default object nesting depth to 2.

## TODO
- [x] fix #844
- [x] tests