### PR TITLE
Make sure that logits are always on the device where the model weights are

### DIFF
--- a/outlines/generate/generator.py
+++ b/outlines/generate/generator.py
@@ -76,7 +76,7 @@ def sequence_generator(
             raise ContextLengthExceededError(
                 "The input length exceeds the context length of the model."
             )
-
+        logits = logits.to(model.device)
         allowed_tokens = get_allowed_tokens(fsms, fsm_states)
         biased_logits = bias_logits(logits, allowed_tokens)
         next_token_ids, ancestors, sequence_weights = sampler(


### PR DESCRIPTION
The issue was due to the logits always being in device=0, I made it such that the logits generated by the model should always be in the model's device.