### PR TITLE
Update caching and add tokenizer to `create_states_mapping`

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+from datasets.fingerprint import Hasher
+
 from outlines.models.tokenizer import Tokenizer
 
 if TYPE_CHECKING:
@@ -109,9 +111,14 @@ class TransformerTokenizer(Tokenizer):
         return NotImplemented
 
     def __hash__(self):
-        from datasets.fingerprint import Hasher
-
         return hash(Hasher.hash(self.tokenizer))
+
+    def __getstate__(self):
+        state = {"tokenizer": self.tokenizer}
+        return state
+
+    def __setstate__(self, state):
+        self.__init__(state["tokenizer"])
 
 
 class Transformers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
    "referencing",
    "jsonschema",
    "requests",
-   "tqdm"
+   "tqdm",
+   "datasets",
 ]
 dynamic = ["version"]
 
@@ -50,7 +51,6 @@ test = [
     "diff-cover",
     "accelerate",
     "beartype<0.16.0",
-    "datasets",
     "responses",
     "llama-cpp-python",
     "huggingface_hub",

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -107,6 +107,14 @@ def test_tokenizer_eq_hash():
     tokenizer_hf = AutoTokenizer.from_pretrained("gpt2")
 
     tokenizer = TransformerTokenizer(tokenizer_hf)
-    tokenizer2 = TransformerTokenizer(tokenizer_hf)
-    assert tokenizer == tokenizer2
-    assert hash(tokenizer) == hash(tokenizer2)
+    tokenizer_2 = TransformerTokenizer(tokenizer_hf)
+
+    assert tokenizer == tokenizer_2
+    assert hash(tokenizer) == hash(tokenizer_2)
+
+    tokenizer_hf_2 = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer_hf_2.add_tokens(["test_token"])
+
+    tokenizer_3 = TransformerTokenizer(tokenizer_hf_2)
+    assert tokenizer != tokenizer_3
+    assert hash(tokenizer) != hash(tokenizer_3)


### PR DESCRIPTION
This PR removes the use of hash values as the keys to the underlying function call cache.  It also adds the tokenizer to the arguments of `create_states_mapping`.

The main change here is that `hash_arguments` has been removed and replaced with a `Disk` subclass, `CloudpickleDisk`, that uses `cloudpickle`.  This allows all the same objects to be cacheable as before, while also removing the use of hash values as keys.  The latter is especially important, since hash collisions at the key level can return the wrong results from the cache.

Likewise, the `key_function` argument to `cache` has been removed.  If one needs this sort of functionality, they can wrap the corresponding arguments with objects that properly implement serialization.

Closes #872