### PR TITLE
Allow json schema of `{}`, resulting in unconstrained json value

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -126,7 +126,22 @@ def to_regex(
     if whitespace_pattern is None:
         whitespace_pattern = WHITESPACE
 
-    if "properties" in instance:
+    if instance == {}:
+        # JSON Schema Spec: Empty object means unconstrained, any json type is legal
+        types = [
+            {"type": "boolean"},
+            {"type": "null"},
+            {"type": "number"},
+            {"type": "integer"},
+            {"type": "string"},
+            {"type": "array"},
+            {"type": "object"},
+        ]
+        regexes = [to_regex(resolver, t, whitespace_pattern) for t in types]
+        regexes = [rf"({r})" for r in regexes]
+        return rf"{'|'.join(regexes)}"
+
+    elif "properties" in instance:
         regex = ""
         regex += r"\{"
         properties = instance["properties"]

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -759,6 +759,20 @@ def test_format(schema, regex, examples):
                 ('{"a": "a"}', False),  # not an array
             ],
         ),
+        # No schema / unconstrained value
+        (
+            {},
+            [
+                ('"aaabbuecuh"', True),  # string
+                ("5.554", True),  # number
+                ("true", True),  # boolean
+                ("null", True),  # null
+                ("5999", True),  # integer
+                ('["a", "b"]', True),  # array
+                ('{"key": {"k2": "value"}}', True),  # nested object
+                ("this isnt valid json", False),
+            ],
+        ),
     ],
 )
 def test_format_without_regex(schema, examples):


### PR DESCRIPTION
Fix #749 

`{}` wasn't handled at all in `json_schema.py`, resulting in a `ValueError`.

Now it follows the json schema spec: allow **anything**: bool, int, object, etc, etc.