### PR TITLE
Fix null byte `\x00` issue in byte level fsm resulting in `KeyError` in `BetterFSM::FSMInfo` 

### DIFF
--- a/outlines/fsm/parsing.py
+++ b/outlines/fsm/parsing.py
@@ -38,6 +38,7 @@ from lark.parsers.lalr_parser import LALR_Parser, ParseConf, ParserState, _Parse
 from outlines.fsm.regex import (
     fsm_union,
     get_sub_fsms_from_seq,
+    get_token_transitions,
     make_deterministic_fsm,
     walk_fsm,
 )
@@ -569,9 +570,15 @@ class PartialScanner(Scanner):
 
         text_part = text[start_pos:]
 
+        text_transitions = get_token_transitions(
+            self.fsm.fsm_info.alphabet_symbol_mapping,
+            self.fsm.fsm_info.alphabet_anything_value,
+            text_part,
+        )
+
         state_seq = walk_fsm(
             self.fsm,
-            text_part,
+            text_transitions,
             start_state,
             full_match=self.match_whole,
         )

--- a/outlines/fsm/parsing.py
+++ b/outlines/fsm/parsing.py
@@ -38,7 +38,7 @@ from lark.parsers.lalr_parser import LALR_Parser, ParseConf, ParserState, _Parse
 from outlines.fsm.regex import (
     fsm_union,
     get_sub_fsms_from_seq,
-    get_token_transitions,
+    get_token_transition_keys,
     make_deterministic_fsm,
     walk_fsm,
 )
@@ -570,7 +570,7 @@ class PartialScanner(Scanner):
 
         text_part = text[start_pos:]
 
-        text_transitions = get_token_transitions(
+        text_transitions = get_token_transition_keys(
             self.fsm.fsm_info.alphabet_symbol_mapping,
             self.fsm.fsm_info.alphabet_anything_value,
             text_part,

--- a/outlines/fsm/regex.py
+++ b/outlines/fsm/regex.py
@@ -414,7 +414,7 @@ def _walk_fsm(
     fsm_transitions: Dict[Tuple[int, int], int],
     fsm_initial: int,
     fsm_finals: Set[int],
-    token_trans_key_seq: Sequence[int],
+    token_transition_keys: Sequence[int],
     start_state: int,
     full_match: bool = True,
 ) -> List[int]:
@@ -424,7 +424,7 @@ def _walk_fsm(
 
     # Iterate over token transition key sequence. The transition key
     # sequence represents the FSM traversal rules of the tokens symbols.
-    for i, trans_key in enumerate(token_trans_key_seq):
+    for i, trans_key in enumerate(token_transition_keys):
         new_state = fsm_transitions.get((state, trans_key))
 
         if new_state is None:
@@ -448,7 +448,7 @@ def _walk_fsm(
 
 def walk_fsm(
     fsm: BetterFSM,
-    token_trans_key_seq: Sequence[int],
+    token_transition_keys: Sequence[int],
     start_state: int,
     full_match: bool = True,
 ) -> List[int]:
@@ -462,7 +462,7 @@ def walk_fsm(
 
     # Iterate over token transition key sequence. The transition key
     # sequence represents the FSM traversal rules of the tokens symbols.
-    for i, trans_key in enumerate(token_trans_key_seq):
+    for i, trans_key in enumerate(token_transition_keys):
         new_state = fsm_transitions.get((state, trans_key))
 
         if new_state is None:
@@ -703,10 +703,10 @@ def get_token_transition_keys(
             alphabet_symbol_mapping.get(symbol, alphabet_anything_value)
         )
 
-    tok_trans_array = np.empty(len(token_transition_keys), dtype=np.int64)
+    token_transition_keys_array = np.empty(len(token_transition_keys), dtype=np.int64)
     for j in range(len(token_transition_keys)):
-        tok_trans_array[j] = token_transition_keys[j]
-    return tok_trans_array
+        token_transition_keys_array[j] = token_transition_keys[j]
+    return token_transition_keys_array
 
 
 @numba.njit(cache=True, nogil=True)
@@ -718,14 +718,14 @@ def get_vocabulary_transition_keys(
     """
     Calculate the sequence transition keys for each token str within a vocabulary
     """
-    tokens_trans_keys = numba.typed.List.empty_list(numba.int64[:])
+    vocab_transition_keys = numba.typed.List.empty_list(numba.int64[:])
     for token_str, _ in vocabulary:
-        trans_key_seq_array = get_token_transition_keys(
+        token_transition_keys = get_token_transition_keys(
             alphabet_symbol_mapping, alphabet_anything_value, token_str
         )
-        tokens_trans_keys.append(trans_key_seq_array)
+        vocab_transition_keys.append(token_transition_keys)
 
-    return tokens_trans_keys
+    return vocab_transition_keys
 
 
 def create_fsm_index_end_to_end(

--- a/tests/fsm/test_parsing.py
+++ b/tests/fsm/test_parsing.py
@@ -9,7 +9,14 @@ from lark.lexer import UnexpectedCharacters, UnexpectedToken
 from outlines.fsm.parsing import PartialLark, PartialPythonIndenter
 
 
-def test_partial_parsing():
+@pytest.fixture
+def cleanup_lark_import():
+    yield
+    # Clean up lark.lark.LarkOptions._defaults
+    importlib.reload(lark.lark)
+
+
+def test_partial_parsing(cleanup_lark_import):
     lp = PartialLark.open_from_package(
         "tests",
         "partial_python.lark",
@@ -136,11 +143,8 @@ def test_partial_parsing():
     assert len(parser_state.state_stack) == 4
     assert parser_state.value_stack[-1].type == "LPAR"
 
-    # Clean up lark.lark.LarkOptions._defaults
-    importlib.reload(lark.lark)
 
-
-def test_sequential_parse_example():
+def test_sequential_parse_example(cleanup_lark_import):
     input_tokens = [
         "x ",
         "= ",

--- a/tests/fsm/test_parsing.py
+++ b/tests/fsm/test_parsing.py
@@ -204,6 +204,3 @@ def test_sequential_parse_example(cleanup_lark_import):
 
         if i + 1 == len(input_tokens):
             assert all(tk in next_vocab for tk in ["\n", "\nde", "  ", " + 1"])
-
-    # Clean up lark.lark.LarkOptions._defaults
-    importlib.reload(lark.lark)


### PR DESCRIPTION
Follow-up to https://github.com/outlines-dev/outlines/pull/904 by @M0gician  -- Closes #904

Fixes https://github.com/outlines-dev/outlines/issues/833

# Problem 1

@m0gician identified [a bug in numba's handling of `UnicodeCharSeq`](https://github.com/numba/numba/issues/9542). if the elements first item is `\x00`, the entire element is null. This numba bug resulted in a `KeyError` while compiling a patterns index for certain characters.

More problem details available in #904

### Solution 1

@m0gician implemented the base solution - represent token bytes with `numba.unicode_type` to avoid this bug.

https://github.com/outlines-dev/outlines/commit/4a5ef55d683f72f18f50e5f7e49ede742cee91fa

# Problem 2

Use of `unicode_type` results in ambiguous representation of hex-bytes / chars.

E.g. in main a `UnicodeCharSeq` will keep the hex bytes and characters separate`["😇", "9", "F", "9F"]`   

Because we use unicode_type instead a List[UnicodeCharSeq(2)], the example sequence would be represented as

`["😇", "9", "F", "9F"]` -> `'😇9F9F'`

This demonstrates a problem, we have no idea whether consecutive hex characters represent a byte or two separate utf-8 characters.

### Solution 2

To resolve this, we prefix a hex-byte with a null byte.

`["😇", "9", "F", "9F"]` -> `'😇9F\x009F'`.

https://github.com/outlines-dev/outlines/commit/83c4d3a37f6d340e3ad21e5d93209f51c4bfe557

# Problem 3

Parsing a token to separate bytes and chars during `_walk_fsm` is inefficient and resulted in index compilation taking ~2.2x as long as `main`

### Solution 3

Instead of iterating over a string in `_walk_fsm`, we precompute a mapping of token -> transition key seq via `get_tokens_transition_keys()` and iterate over list of integer transition keys for each token in `_walk_fsm()`

https://github.com/outlines-dev/outlines/commit/56ea9572cd343778e2c566a66dddde2ec75489ab

Now instead of taking ~2.2x as long as `main`, index compilation takes ~0.65x as long as `main`. However Numba takes 16% longer to compile.

Benchmark Suite Results:

Benchmarks that have improved:

|    | Before [0b4d12b0]    | After [fe5cb3df]    |   Ratio | Benchmark (Parameter)                                                                                     |
|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------------------------------------------|
| -        | 8.03±0.1s            | 5.29±0.02s          |    0.66 | JsonSchemaBenchmark.time_json_schema_to_fsm('complex_schema')                           |
| -        | 5.86±0.06s           | 3.72±0.07s          |    0.64 | JsonSchemaBenchmark.time_json_schema_to_fsm('simple_schema')                            |
| -        | 4.41±0.07s           | 2.77±0.01s          |    0.63 | RegexGuideBenchmark.time_regex_to_guide('complex_phone')                                |
| -        | 9.57±0.01s           | 6.37±0.02s          |    0.67 | RegexGuideBenchmark.time_regex_to_guide('complex_span_constrained_relation_extraction') |
| -        | 4.20±0.02s           | 2.63±0.01s          |    0.63 | RegexGuideBenchmark.time_regex_to_guide('date')                                         |
| -        | 4.12±0.04s           | 2.56±0.01s          |    0.62 | RegexGuideBenchmark.time_regex_to_guide('email')                                        |
| -        | 4.07±0.04s           | 2.54±0.01s          |    0.62 | RegexGuideBenchmark.time_regex_to_guide('ip')                                           |
| -        | 3.97±0.08s           | 2.48±0.03s          |    0.62 | RegexGuideBenchmark.time_regex_to_guide('simple_phone')                                 |
| -        | 3.89±0.02s           | 2.41±0.02s          |    0.62 | RegexGuideBenchmark.time_regex_to_guide('ssn')                                          |
| -        | 3.96±0.03s           | 2.49±0.01s          |    0.63 | RegexGuideBenchmark.time_regex_to_guide('time')                                         |
| -        | 4.22±0.04s           | 2.67±0.01s          |    0.63 | RegexGuideBenchmark.time_regex_to_guide('url')                                          |

Benchmarks that have stayed the same:

|    | Before [0b4d12b0]    | After [fe5cb3df]    |   Ratio | Benchmark (Parameter)                                                                                              |
|----------|----------------------|---------------------|---------|--------------------------------------------------------------------------------------------------------------------|
|          | 88.4±1μs             | 86.5±1μs            |    0.98 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('complex_schema')                                  |
|          | 49.2±0.4μs           | 48.6±0.3μs          |    0.99 | JsonSchemaBenchmark.time_json_schema_to_regex('simple_schema')                                   |
|          | 598M                 | 600M                |    1    | MemoryRegexGuideBenchmark.peakmem_regex_to_guide('complex_span_constrained_relation_extraction') |
|          | 496M                 | 499M                |    1.01 | MemoryRegexGuideBenchmark.peakmem_regex_to_guide('simple_phone')                                 |

Benchmarks that have got worse:

|    | Before [0b4d12b0]    | After [fe5cb3df]    |   Ratio | Benchmark (Parameter)                                        |
|----------|----------------------|---------------------|---------|--------------------------------------------------------------|
| +        | 4.98±0.05s           | 5.77±0.03s          |    1.16 | NumbaCompileBenchmark.time_compile_numba |

Performance degradation detected!