### PR TITLE
Fix Missing `pyproject.toml` Deps, Breaking `Release PyPi` Workflow & Add Build Wheel / SDist Check to PR Workflow

### DIFF
--- a/.github/scripts/build_sdist_and_wheel.sh
+++ b/.github/scripts/build_sdist_and_wheel.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Build sdist and wheel
+python -m pip install -U pip
+python -m pip install build
+python -m build
+
+# Check sdist install and imports
+mkdir -p test-sdist
+cd test-sdist
+python -m venv venv-sdist
+venv-sdist/bin/python -m pip install ../dist/outlines-*.tar.gz
+venv-sdist/bin/python -c "import outlines"
+cd ..
+
+# Check wheel install and imports
+mkdir -p test-wheel
+cd test-wheel
+python -m venv venv-wheel
+venv-wheel/bin/python -m pip install ../dist/outlines-*.whl
+venv-wheel/bin/python -c "import outlines"
+cd ..

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,32 +11,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - name: Build sdist and wheel
-      run: |
-        python -m pip install -U pip
-        python -m pip install build
-        python -m build
+    - name: Build SDist and Wheel
+      run: ./.github/scripts/build_sdist_and_wheel.sh
     - name: Check that the package version matches the Release name
       run: |
         grep -Rq "^Version: ${GITHUB_REF:10}$" outlines.egg-info/PKG-INFO
-    - name: Check sdist install and imports
-      run: |
-        mkdir -p test-sdist
-        cd test-sdist
-        python -m venv venv-sdist
-        venv-sdist/bin/python -m pip install ../dist/outlines-*.tar.gz
-        venv-sdist/bin/python -c "import outlines"
-    - name: Check wheel install and imports
-      run: |
-        mkdir -p test-wheel
-        cd test-wheel
-        python -m venv venv-wheel
-        venv-wheel/bin/python -m pip install ../dist/outlines-*.whl
-        venv-wheel/bin/python -c "import outlines"
     - name: Publish to PyPi
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,6 +11,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
     - name: Build SDist and Wheel
       run: ./.github/scripts/build_sdist_and_wheel.sh
     - name: Check that the package version matches the Release name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,3 +88,11 @@ jobs:
           name: html-report
           path: htmlcov
         if: ${{ failure() }}
+
+  build-wheel:
+    name: Build Wheel and Test SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build SDist and Wheel
+        run: ./.github/scripts/build_sdist_and_wheel.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
    "requests",
    "tqdm",
    "datasets",
+   "pycountry",
+   "pyairports",
 ]
 dynamic = ["version"]
 
@@ -58,8 +60,6 @@ test = [
     "vllm",
     "torch",
     "transformers",
-    "pycountry",
-    "pyairports",
 ]
 serve = [
     "vllm>=0.3.0",


### PR DESCRIPTION
Fixes #934

## Problem

- Release to PyPi failed for v0.0.42 because `pycountry` and `pyairports` wasn't in `pyproject.toml` required dependencies
- We merged code which caused this failure without detecting it.

## Solution

- Add `pycountry` and `pyairports` to `pyproject.toml` required dependencies
- Add Test SDist and Build Wheel to PR Test Suite

Example: failing workflow without `pycountry` and `pyairports`
- https://github.com/lapp0/outlines/actions/runs/9332636096/job/25688717515


Example: Release to PyPi using new workflow, works up to the point it 403s. I expect it to release provided a correct pypi token, but I can smoke test first if you prefer.
- https://github.com/lapp0/outlines/actions/runs/9333098031/job/25689734009