### PR TITLE
Remove unused dependencies, add `deptry` to make sure the dependencies stay up-to-date

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+    - name: Check dependencies
+      run: |
+        deptry .
     - name: Run tests
       run: |
         pytest --cov=outlines

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Outlines 〰 has new releases and features coming every week. Make sure to ⭐ s
 ## Why should I use structured generation?
 
 * It doesn't add any overhead during inference (cost-free)
+* It allows Open Source models to beat closed source models ([Mistral](https://x.com/dottxtai/status/1797692104023363765), [GPT-4](https://x.com/dottxtai/status/1798443290913853770))
 * [It speeds up inference](http://blog.dottxt.co/coalescence.html)
 * [It improves the performance of base models (GSM8K)](http://blog.dottxt.co/performance-gsm8k.html)
 * [It improves the performance of finetuned models (CoNNL)](https://predibase.com/blog/lorax-outlines-better-json-extraction-with-structured-generation-and-lora)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,10 @@ dependencies = [
    "jsonschema",
    "requests",
    "tqdm",
-   "datasets",
    "pycountry",
    "pyairports",
+   "typing_extensions",
+   "torch",
 ]
 dynamic = ["version"]
 
@@ -51,6 +52,7 @@ test = [
     "pytest-mock",
     "coverage[toml]>=5.1",
     "diff-cover",
+    "deptry",
     "accelerate",
     "beartype<0.16.0",
     "responses",
@@ -58,12 +60,10 @@ test = [
     "huggingface_hub",
     "openai>=1.0.0",
     "vllm",
-    "torch",
     "transformers",
 ]
 serve = [
     "vllm>=0.3.0",
-    "ray==2.9.0",
     "uvicorn",
     "fastapi",
     "pydantic>=2.0",
@@ -157,3 +157,7 @@ show_missing = true
 [tool.diff_cover]
 compare_branch = "origin/main"
 diff_range_notation = ".."
+
+[tool.deptry]
+extend_exclude = ["examples", "benchmarks", "outlines/integrations", "outlines/models"]
+pep621_dev_dependency_groups = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,5 +157,5 @@ compare_branch = "origin/main"
 diff_range_notation = ".."
 
 [tool.deptry]
-extend_exclude = ["examples", "benchmarks", "outlines/integrations", "outlines/models"]
+extend_exclude = ["examples", "benchmarks", "outlines/integrations", "outlines/models", ".myenv", "build"]
 pep621_dev_dependency_groups = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ dependencies = [
    "jsonschema",
    "requests",
    "tqdm",
-   "pycountry",
-   "pyairports",
    "typing_extensions",
    "torch",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
    "tqdm",
    "typing_extensions",
    "torch",
+   "pycountry",
+   "pyairports",
 ]
 dynamic = ["version"]
 
@@ -50,7 +52,7 @@ test = [
     "pytest-mock",
     "coverage[toml]>=5.1",
     "diff-cover",
-    "deptry",
+    "deptry>=0.16.1",
     "accelerate",
     "beartype<0.16.0",
     "responses",


### PR DESCRIPTION
Running [`deptry`](https://deptry.com/) on the codebase with this configuration

```

[tool.deptry]
extend_exclude = ["examples", "benchmarks", "outlines/integrations", "outlines/models"]
pep621_dev_dependency_groups = ["test"]
```

gives:

```
outlines/fsm/types.py:5:1: DEP003 'typing_extensions' imported but it is a transitive dependency
outlines/generate/api.py:161:16: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/api.py:279:16: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/generator.py:65:12: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/generator.py:205:12: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/generator.py:228:12: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/generator.py:269:12: DEP004 'torch' imported but declared as a dev dependency
outlines/generate/generator.py:304:12: DEP004 'torch' imported but declared as a dev dependency
outlines/samplers.py:67:16: DEP004 'torch' imported but declared as a dev dependency
outlines/samplers.py:147:16: DEP004 'torch' imported but declared as a dev dependency
outlines/samplers.py:177:12: DEP004 'torch' imported but declared as a dev dependency
outlines/samplers.py:202:12: DEP004 'torch' imported but declared as a dev dependency
outlines/samplers.py:287:16: DEP004 'torch' imported but declared as a dev dependency
outlines/types/email.py:3:1: DEP003 'typing_extensions' imported but it is a transitive dependency
outlines/types/isbn.py:3:1: DEP003 'typing_extensions' imported but it is a transitive dependency
outlines/types/phone_numbers.py:8:1: DEP003 'typing_extensions' imported but it is a transitive dependency
outlines/types/zip_codes.py:7:1: DEP003 'typing_extensions' imported but it is a transitive dependency
pyproject.toml: DEP002 'datasets' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'ray' defined as a dependency but not used in the codebase
Found 19 dependency issues.

For more information, see the documentation: https://deptry.com/
```

This PR proposes to fix these issues. In addition, it proposes to remove `pyairports` and `pycountry`, since their imports are wrapped in a try-except block:

```py
try:
    from pyairports.airports import AIRPORT_LIST
except ImportError:
    raise ImportError(
        'The `airports` module requires "pyairports" to be installed. You can install it with "pip install pyairports"'
    )
```

This PR also proposes to add `deptry` to the CI/CD pipeline to make sure the list of dependencies stays up to date.

Feel free to let me now your thoughts on this PR, or to close the PR if you think it is not a useful addition.

Disclaimer: I am the author of `deptry`.