### PR TITLE
Update `models.transformers` to use `SequenceGeneratorAdapter` and `OutlinesLogitsProcessors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,9 @@ model = outlines.models.transformers("mistralai/Mistral-7B-Instruct-v0.2")
 generator = outlines.generate.json(model, Character)
 
 # Draw a sample
-rng = torch.Generator(device="cuda")
-rng.manual_seed(789001)
+seed = 789001
 
-character = generator("Give me a character description", rng=rng)
+character = generator("Give me a character description", seed=seed)
 
 print(repr(character))
 # Character(name='Anderson', age=28, armor=<Armor.chainmail: 'chainmail'>, weapon=<Weapon.sword: 'sword'>, strength=8)

--- a/docs/reference/text.md
+++ b/docs/reference/text.md
@@ -80,8 +80,7 @@ from outlines import models, generate
 
 model = models.transformers("mistralai/Mistral-7B-v0.1")
 
-rng = torch.Generator(device="cuda")
-rng.manual_seed(789001)
+seed = 789001
 
-answer = generator("What is 2+2?", rng=rng)
+answer = generator("What is 2+2?", seed=seed)
 ```

--- a/examples/llamacpp_example.py
+++ b/examples/llamacpp_example.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-import torch
 from pydantic import BaseModel, constr
 
 import outlines
@@ -37,10 +36,9 @@ if __name__ == "__main__":
     generator = outlines.generate.json(model, Character)
 
     # Draw a sample
-    rng = torch.Generator(device="cpu")
-    rng.manual_seed(789005)
+    seed = 789005
 
     prompt = "Instruct: You are a leading role play gamer. You have seen thousands of different characters and their attributes.\nPlease return a JSON object with common attributes of an RPG character. Give me a character description\nOutput:"
 
-    sequence = generator(prompt, rng=rng, max_tokens=512)
+    sequence = generator(prompt, seed=seed, max_tokens=512)
     print(sequence)

--- a/outlines/generate/cfg.py
+++ b/outlines/generate/cfg.py
@@ -1,16 +1,14 @@
 from functools import singledispatch
 
-from outlines.fsm.guide import CFGGuide
-from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
+from outlines.generate.api import SequenceGeneratorAdapter
 from outlines.models import OpenAI
-from outlines.models.llamacpp import LlamaCpp
-from outlines.models.mlxlm import MLXLM
-from outlines.models.vllm import VLLM
 from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
-def cfg(model, cfg_str: str, sampler: Sampler = multinomial()) -> SequenceGenerator:
+def cfg(
+    model, cfg_str: str, sampler: Sampler = multinomial()
+) -> SequenceGeneratorAdapter:
     """Generate text in the language of a Context-Free Grammar
 
     Arguments
@@ -24,38 +22,14 @@ def cfg(model, cfg_str: str, sampler: Sampler = multinomial()) -> SequenceGenera
 
     Returns
     -------
-    A `SequenceGenerator` instance that generates text.
+    A `SequenceGeneratorAdapter` instance that generates text.
 
     """
-    fsm = CFGGuide(cfg_str, model.tokenizer)
-    device = model.device
-    generator = SequenceGenerator(fsm, model, sampler, device)
-
-    return generator
-
-
-@cfg.register(MLXLM)
-@cfg.register(VLLM)
-def cfg_unimplemented(
-    model,
-    cfg_str: str,
-    sampler: Sampler = multinomial(),
-):
     raise NotImplementedError(
-        f"The CFG Logits processor is not available for {type(model)}."
+        f"The CFG Logits processor is not available for {type(model)}. "
+        + "Please subscribe to https://github.com/outlines-dev/outlines/issues/684"
+        + " for updates on the fix."
     )
-
-
-@cfg.register(LlamaCpp)
-def cfg_llamacpp(
-    model: LlamaCpp,
-    cfg_str: str,
-    sampler: Sampler = multinomial(),
-):
-    from outlines.integrations.llamacpp import CFGLogitsProcessor
-
-    logits_processor = CFGLogitsProcessor(cfg_str, model.model)
-    return SequenceGeneratorAdapter(model, logits_processor, sampler)
 
 
 @cfg.register(OpenAI)

--- a/outlines/generate/regex.py
+++ b/outlines/generate/regex.py
@@ -5,6 +5,7 @@ from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.models.llamacpp import LlamaCpp
 from outlines.models.mlxlm import MLXLM
+from outlines.models.transformers import Transformers
 from outlines.models.vllm import VLLM
 from outlines.samplers import Sampler, multinomial
 
@@ -39,8 +40,9 @@ def regex(model, regex_str: str, sampler: Sampler = multinomial()):
 
 
 @regex.register(MLXLM)
-def regex_mlxlm(
-    model: MLXLM,
+@regex.register(Transformers)
+def regex_unified(
+    model,
     regex_str: str,
     sampler: Sampler = multinomial(),
 ):

--- a/outlines/generate/text.py
+++ b/outlines/generate/text.py
@@ -2,7 +2,7 @@ from functools import singledispatch
 
 from outlines.fsm.guide import StopAtEOSGuide
 from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
-from outlines.models import MLXLM, VLLM, LlamaCpp, OpenAI
+from outlines.models import MLXLM, VLLM, LlamaCpp, OpenAI, Transformers
 from outlines.samplers import Sampler, multinomial
 
 
@@ -37,7 +37,8 @@ def text(model, sampler: Sampler = multinomial()) -> SequenceGenerator:
 
 
 @text.register(MLXLM)
-def text_mlxlm(model: MLXLM, sampler: Sampler = multinomial()):
+@text.register(Transformers)
+def text_unified(model, sampler: Sampler = multinomial()):
     return SequenceGeneratorAdapter(model, None, sampler)
 
 

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -12,7 +12,7 @@ from .llamacpp import LlamaCpp, llamacpp
 from .mamba import Mamba, mamba
 from .mlxlm import MLXLM, mlxlm
 from .openai import OpenAI, azure_openai, openai
-from .transformers import Transformers, transformers
+from .transformers import Transformers, TransformerTokenizer, transformers
 from .vllm import VLLM, vllm
 
 LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, Mamba, MLXLM, VLLM]

--- a/tests/generate/test_integration_llamacpp.py
+++ b/tests/generate/test_integration_llamacpp.py
@@ -25,7 +25,7 @@ def model(tmp_path_factory):
     (
         (generate.text, []),
         (generate.regex, ("[0-9]",)),
-        (generate.cfg, (grammars.arithmetic,)),
+        # (generate.cfg, (grammars.arithmetic,)),  # Awaiting CFG fix
     ),
 )
 def test_llamacpp_generation_api(model, generator_type, params):
@@ -245,8 +245,11 @@ def test_llamacpp_json_schema(model):
 
 def test_llamacpp_cfg(model):
     prompt = "<|im_start|>user\nOutput a short and valid JSON object with two keys.<|im_end|>\n><|im_start|>assistant\n"
-    result = generate.cfg(model, grammars.arithmetic)(prompt, seed=11)
-    assert isinstance(result, str)
+
+    # remove this statement once cfg is implemented
+    with pytest.raises(NotImplementedError):
+        result = generate.cfg(model, grammars.arithmetic)(prompt, seed=11)
+        assert isinstance(result, str)
 
 
 @pytest.mark.parametrize(

--- a/tests/generate/test_integration_transformers.py
+++ b/tests/generate/test_integration_transformers.py
@@ -14,44 +14,50 @@ from outlines.models.transformers import Transformers, TransformerTokenizer
 from outlines.samplers import beam_search, greedy, multinomial
 
 
-def test_transformers_integration_text():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
+@pytest.fixture(scope="session")
+def model(tmp_path_factory):
+    return models.transformers(
+        "hf-internal-testing/tiny-random-GPTJForCausalLM", device="cpu"
+    )
 
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
-    sequence = generate.text(model)("Write a short sentence ", rng=rng)
+
+def test_transformers_integration_text(model):
+    sequence = generate.text(model)(
+        "Write a short sentence ", seed=10000, max_tokens=10
+    )
     assert isinstance(sequence, str)
     assert model.tokenizer.eos_token not in sequence
 
     sequence = generate.text(model)(
-        "Write a short sentence ", max_tokens=10, stop_at=".", rng=rng
+        "Write a short sentence ",
+        max_tokens=20,
+        stop_at="a",
+        seed=10000,
     )
     assert isinstance(sequence, str)
 
     prompts = ["Write a short sentence ", "And another one "]
-    sequence = generate.text(model)(prompts, max_tokens=10, stop_at=[".", ","], rng=rng)
+    sequence = generate.text(model)(
+        prompts, max_tokens=10, stop_at=[".", ","], seed=10000
+    )
     assert isinstance(sequence, list)
     assert len(sequence) == 2
     assert isinstance(sequence[0], str)
 
 
-def test_transformers_integration_text_multiple_samples():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_text_multiple_samples(model):
     sampler = multinomial(2)
 
-    sequence = generate.text(model, sampler=sampler)("Write a short sentence ", rng=rng)
+    sequence = generate.text(model, sampler=sampler)(
+        "Write a short sentence ", seed=10000
+    )
     assert isinstance(sequence, list)
     assert len(sequence) == 2
     assert model.tokenizer.eos_token not in sequence
 
     prompts = ["Write a short sentence ", "And another one "]
     sequence = generate.text(model, sampler=sampler)(
-        prompts, max_tokens=10, stop_at=[".", ","], rng=rng
+        prompts, max_tokens=10, stop_at=[".", ","], seed=10000
     )
     assert isinstance(sequence, list)
     assert len(sequence) == 2
@@ -60,14 +66,9 @@ def test_transformers_integration_text_multiple_samples():
     assert isinstance(sequence[0][0], str)
 
 
-def test_transformers_integration_streaming():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_streaming(model):
     sequence = generate.text(model).stream(
-        "Write a short sentence ", max_tokens=10, stop_at=[".", ","], rng=rng
+        "Write a short sentence ", max_tokens=10, stop_at=[".", ","], seed=10000
     )
 
     token = next(sequence)
@@ -77,7 +78,7 @@ def test_transformers_integration_streaming():
     assert isinstance(remaining, str)
 
     sequence = generate.text(model).stream(
-        ["Prompt1", "Prompt2"], max_tokens=10, stop_at=[".", ","], rng=rng
+        ["Prompt1", "Prompt2"], max_tokens=10, stop_at=[".", ","], seed=10000
     )
     tokens = next(sequence)
     assert isinstance(tokens, list)
@@ -85,19 +86,11 @@ def test_transformers_integration_streaming():
     assert isinstance(tokens[1], str)
 
 
-def test_transformers_integration_streaming_batch_samples():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_streaming_batch_samples(model):
     sampler = multinomial(samples=2)
 
     sequence = generate.text(model, sampler=sampler).stream(
-        ["Prompt1", "Prompt2"],
-        max_tokens=10,
-        stop_at=[".", ","],
-        rng=rng,
+        ["Prompt1", "Prompt2"], max_tokens=10, stop_at=[".", ","], seed=10000
     )
     tokens = next(sequence)
     assert isinstance(tokens, list)
@@ -108,19 +101,11 @@ def test_transformers_integration_streaming_batch_samples():
     assert len(tokens[1]) == 2
 
 
-def test_transformers_integration_streaming_batch_beam_search():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_streaming_batch_beam_search(model):
     sampler = beam_search(beams=2)
 
-    sequence = generate.text(model, sampler=sampler).stream(
-        ["Prompt1", "Prompt2"],
-        max_tokens=10,
-        stop_at=[".", ","],
-        rng=rng,
+    sequence = generate.regex(model, r"ab[cd]e", sampler=sampler).stream(
+        ["Prompt1", "Prompt2"], max_tokens=10, stop_at=["c", "d"], seed=10000
     )
     tokens = next(sequence)
     assert isinstance(tokens, list)
@@ -131,61 +116,41 @@ def test_transformers_integration_streaming_batch_beam_search():
     assert len(tokens[1]) == 2
 
 
-def test_transformers_integration_text_stop():
-    rng = torch.Generator()
-    rng.manual_seed(10000)  # Choosen so <EOS> is generated
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_text_stop(model):
     prompt = "Write a short sentence "
-    sequence = generate.text(model)(prompt, stop_at="a", rng=rng)
+    sequence = generate.text(model)(prompt, stop_at="a", seed=10000)
     assert sequence[len(prompt) :].find("a") == -1
 
 
-def test_transformers_various_regexes():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_various_regexes(model):
     prompt = "Write an email address"
     regex_str = r"([a-z]{10})@([a-z]{5})\.([a-z]{3})"
     generator = generate.regex(model, regex_str)
 
     # One prompt
-    sequence = generator(prompt, rng=rng)
+    sequence = generator(prompt, seed=0)
     assert re.fullmatch(regex_str, sequence) is not None
 
 
-def test_transformers_various_regexes_prompt_list():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_various_regexes_prompt_list(model):
     prompt = "Write an email address"
     regex_str = r"([a-z]{10})@([a-z]{5})\.([a-z]{3})"
     generator = generate.regex(model, regex_str)
 
     # Two prompts
-    sequence = generator([prompt, prompt], rng=rng)
+    sequence = generator([prompt, prompt], seed=0)
     assert re.fullmatch(regex_str, sequence[0]) is not None
     assert re.fullmatch(regex_str, sequence[1]) is not None
 
 
-def test_transformers_various_regexes_prompt_list_multiple_samples():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_various_regexes_prompt_list_multiple_samples(model):
     sampler = multinomial(samples=2)
     prompt = "Write an email address"
     regex_str = r"([a-z]{10})@([a-z]{5})\.([a-z]{3})"
     generator = generate.regex(model, regex_str, sampler=sampler)
 
     # Two prompts
-    sequence = generator([prompt, prompt], rng=rng)
+    sequence = generator([prompt, prompt], seed=0, max_tokens=500)
     assert isinstance(sequence, list)
     assert len(sequence) == 2
     assert re.fullmatch(regex_str, sequence[0][0]) is not None
@@ -194,12 +159,7 @@ def test_transformers_various_regexes_prompt_list_multiple_samples():
     assert re.fullmatch(regex_str, sequence[1][1]) is not None
 
 
-def test_transformers_various_regexes_prompt_list_beam_search():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_various_regexes_prompt_list_beam_search(model):
     sampler = beam_search(5)
     prompt_1 = "Write an email address"
     prompt_2 = "Random"
@@ -207,7 +167,7 @@ def test_transformers_various_regexes_prompt_list_beam_search():
     generator = generate.regex(model, regex_str, sampler=sampler)
 
     # Two prompts
-    sequence = generator([prompt_1, prompt_2], rng=rng)
+    sequence = generator([prompt_1, prompt_2], seed=0)
     assert isinstance(sequence, list)
     assert len(sequence) == 2
     assert len(sequence[0]) == 5
@@ -217,105 +177,65 @@ def test_transformers_various_regexes_prompt_list_beam_search():
     assert re.fullmatch(regex_str, sequence[1][1]) is not None
 
 
-def test_transformers_integration_integer():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_integer(model):
     prompt = "Write a short sentence"
-    sequence = generate.format(model, int)(prompt, max_tokens=10, rng=rng)
+    sequence = generate.format(model, int)(prompt, max_tokens=10, seed=0)
 
     assert isinstance(sequence, int)
 
 
-def test_transformers_integration_integer_array():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_integer_array(model):
     prompts = ["Give me a number", "And another one"]
-    sequence = generate.format(model, int)(prompts, max_tokens=10, rng=rng)
+    sequence = generate.format(model, int)(prompts, max_tokens=10, seed=0)
     assert isinstance(sequence, list)
     assert len(sequence) == 2
     assert isinstance(sequence[0], int)
     assert isinstance(sequence[1], int)
 
 
-def test_transformers_integration_float():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_float(model):
     prompt = "Write a short sentence"
-    sequence = generate.format(model, float)(prompt, max_tokens=10, rng=rng)
+    sequence = generate.format(model, float)(prompt, max_tokens=10, seed=0)
 
     assert sequence != ""
     assert isinstance(sequence, float)
 
 
-def test_transformers_integration_bool():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_bool(model):
     prompt = "Is this True or False?"
-    sequence = generate.format(model, bool)(prompt, max_tokens=10, rng=rng)
+    sequence = generate.format(model, bool)(prompt, max_tokens=10, seed=0)
 
     assert sequence != ""
     assert isinstance(sequence, bool)
 
 
-def test_transformers_integration_date():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_date(model):
     prompt = "What day is it today?"
-    sequence = generate.format(model, datetime.date)(prompt, max_tokens=10, rng=rng)
+    sequence = generate.format(model, datetime.date)(prompt, max_tokens=10, seed=0)
 
     assert sequence != ""
     assert isinstance(sequence, datetime.date)
 
 
-def test_transformers_integration_time():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_time(model):
     prompt = "What time is it?"
-    sequence = generate.format(model, datetime.time)(prompt, max_tokens=10, rng=rng)
+    sequence = generate.format(model, datetime.time)(prompt, max_tokens=10, seed=0)
 
     assert sequence != ""
     assert isinstance(sequence, datetime.time)
 
 
-def test_transformers_integration_datetime():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_integration_datetime(model):
     prompt = "What time is it?"
-    sequence = generate.format(model, datetime.datetime)(prompt, max_tokens=20, rng=rng)
+    sequence = generate.format(model, datetime.datetime)(prompt, max_tokens=20, seed=0)
 
     assert sequence != 0
     assert isinstance(sequence, datetime.datetime)
 
 
-def test_transformers_integration_choice():
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_integration_choice(model):
     prompt = "Write a short sentence "
-    sequence = generate.choice(model, ["test", "choice"])(prompt, rng=rng)
+    sequence = generate.choice(model, ["test", "choice"])(prompt, seed=0)
 
     assert sequence == "test" or sequence == "choice"
 
@@ -327,9 +247,7 @@ def test_transformers_integration_with_pad_token():
     assert model.tokenizer.pad_token == "<pad>"
 
 
-def test_transformers_json_basic():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_basic(model):
     prompt = "Output some JSON "
 
     class Spam(BaseModel):
@@ -338,10 +256,7 @@ def test_transformers_json_basic():
         spam: constr(max_length=10)
         fuzz: bool
 
-    rng = torch.Generator()
-    rng.manual_seed(0)  # make sure that `bar` is not an int
-
-    result = generate.json(model, Spam)(prompt, max_tokens=500, rng=rng)
+    result = generate.json(model, Spam)(prompt, max_tokens=500, seed=0)
     assert isinstance(result, BaseModel)
     assert isinstance(result.foo, int)
     assert isinstance(result.bar, float)
@@ -350,9 +265,7 @@ def test_transformers_json_basic():
     assert len(result.spam) <= 10
 
 
-def test_transformers_json_schema():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_schema(model):
     prompt = "Output some JSON "
 
     schema = """{
@@ -366,18 +279,13 @@ def test_transformers_json_schema():
       }
     """
 
-    rng = torch.Generator()
-    rng.manual_seed(0)  # make sure that `bar` is not an int
-
-    result = generate.json(model, schema)(prompt, max_tokens=500, rng=rng)
+    result = generate.json(model, schema)(prompt, max_tokens=500, seed=0)
     assert isinstance(result, dict)
     assert isinstance(result["foo"], int)
     assert isinstance(result["bar"], str)
 
 
-def test_transformers_json_batch():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_batch(model):
     prompts = ["Output some JSON ", "Output more JSON"]
 
     class Spam(BaseModel):
@@ -386,17 +294,12 @@ def test_transformers_json_batch():
         spam: constr(max_length=10)
         fuzz: bool
 
-    rng = torch.Generator()
-    rng.manual_seed(0)  # make sure that `bar` is not an int
-
-    result = generate.json(model, Spam)(prompts, max_tokens=500, rng=rng)
+    result = generate.json(model, Spam)(prompts, max_tokens=500, seed=0)
     assert isinstance(result[0], BaseModel)
     assert isinstance(result[1], BaseModel)
 
 
-def test_transformers_json_batch_multiple_samples():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_batch_multiple_samples(model):
     sampler = multinomial(samples=2)
     prompts = ["Output some JSON ", "Output more JSON"]
 
@@ -406,11 +309,8 @@ def test_transformers_json_batch_multiple_samples():
         spam: constr(max_length=10)
         fuzz: bool
 
-    rng = torch.Generator()
-    rng.manual_seed(0)  # make sure that `bar` is not an int
-
     result = generate.json(model, Spam, sampler=sampler)(
-        prompts, max_tokens=500, rng=rng
+        prompts, max_tokens=500, seed=0
     )
     assert isinstance(result, list)
     assert len(result) == 2
@@ -420,13 +320,8 @@ def test_transformers_json_batch_multiple_samples():
     assert isinstance(result[1][1], BaseModel)
 
 
-def test_transformers_json_str_enum():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_str_enum(model):
     prompt = "Output some JSON "
-
-    rng = torch.Generator()
-    rng.manual_seed(0)
 
     class Name(str, Enum):
         john = "John"
@@ -437,19 +332,14 @@ def test_transformers_json_str_enum():
         user_id: int
         name: Name
 
-    result = generate.json(model, User)(prompt, rng=rng)
+    result = generate.json(model, User)(prompt, seed=0)
     assert isinstance(result, BaseModel)
     assert isinstance(result.user_id, int)
     assert result.name in ["John", "Marc", "Michel"]
 
 
-def test_transformers_json_int_enum():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_int_enum(model):
     prompt = "Output some JSON "
-
-    rng = torch.Generator()
-    rng.manual_seed(0)
 
     class Id(int, Enum):
         one = 1
@@ -458,25 +348,20 @@ def test_transformers_json_int_enum():
     class User(BaseModel):
         user_id: Id
 
-    result = generate.json(model, User)(prompt, rng=rng)
+    result = generate.json(model, User)(prompt, seed=0)
     assert isinstance(result, BaseModel)
     assert isinstance(result.user_id, int)
     assert result.user_id in [1, 2]
 
 
-def test_transformers_json_array():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_array(model):
     prompt = "Output some JSON "
 
     class User(BaseModel):
         user_id: int
         value: List[float]
 
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
-    result = generate.json(model, User)(prompt, rng=rng)
+    result = generate.json(model, User)(prompt, seed=0)
     assert isinstance(result, BaseModel)
     assert isinstance(result.user_id, int)
     assert isinstance(result.value, list)
@@ -485,19 +370,14 @@ def test_transformers_json_array():
 
 
 @pytest.mark.xfail(reason="The implementation of `anyOf` is incorrect")
-def test_transformers_json_union():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_union(model):
     prompt = "Output some JSON "
 
     class Spam(BaseModel):
         foo: int
         bar: Union[constr(max_length=10), float]
 
-    rng = torch.Generator()
-    rng.manual_seed(4)
-
-    result = generate.json(model, Spam)(prompt, max_tokens=100, rng=rng)
+    result = generate.json(model, Spam)(prompt, max_tokens=100, seed=4)
     assert isinstance(result, BaseModel)
     assert (
         isinstance(result.bar, int)
@@ -506,26 +386,18 @@ def test_transformers_json_union():
     )
 
 
-def test_transformers_json_function():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name)
+def test_transformers_json_function(model):
     prompt = "Output arguments for the function"
 
     def function(foo: int, bar: List[int]):
         return foo + sum(bar)
 
-    rng = torch.Generator()
-    rng.manual_seed(4)
-
-    sequence = generate.json(model, function)(prompt, max_tokens=100, rng=rng)
+    sequence = generate.json(model, function)(prompt, max_tokens=100, seed=4)
     assert isinstance(sequence, dict)
     assert isinstance(function(**sequence), int)
 
 
-def test_transformers_logits_vocab_size():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
-
+def test_transformers_logits_vocab_size(model):
     # Artificially increase the weights/logits size relative
     # to the vocabulary
     model.model.resize_token_embeddings(pad_to_multiple_of=3)
@@ -535,16 +407,11 @@ def test_transformers_logits_vocab_size():
 
     generator = generate.choice(model, ["True", "False"])
 
-    rng = torch.Generator()
-    rng.manual_seed(101)
-
-    sequence = generator("blah", rng=rng)
+    sequence = generator("blah", seed=101)
     assert sequence == "False"
 
 
-def test_transformers_json_custom_ws():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-    model = models.transformers(model_name, device="cpu")
+def test_transformers_json_custom_ws(model):
     prompt = "Output some JSON with newlines"  # try to force model to use newlines
 
     schema = """{
@@ -558,12 +425,9 @@ def test_transformers_json_custom_ws():
       }
     """
 
-    rng = torch.Generator()
-    rng.manual_seed(0)
-
     generator = generate.json(model, schema, whitespace_pattern=r"[ ]?")
     generator.format_sequence = lambda x: x  # patch to return raw text
-    assert "\n" not in generator(prompt, max_tokens=500, rng=rng)
+    assert "\n" not in generator(prompt, max_tokens=500, seed=0)
 
 
 def test_transformers_reduced_vocabulary_caching():
@@ -582,11 +446,8 @@ def test_transformers_reduced_vocabulary_caching():
     assert vocab2 is vocab
 
 
-def test_custom_sampler():
-    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
-
-    model = models.transformers(model_name)
-
+@pytest.mark.skip(reason="Custom Sampler Disabled in Transformers Integration")
+def test_custom_sampler(model):
     seen = False
     target_token_ids = model.tokenizer.encode(["c"])[0]
 
@@ -623,14 +484,11 @@ def test_custom_sampler():
 def test_transformers_use_existing_model_and_tokenizer():
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    rng = torch.Generator()
-    rng.manual_seed(10000)
-
     model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
     hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
     hf_model = AutoModelForCausalLM.from_pretrained(model_name)
     model = Transformers(hf_model, hf_tokenizer)
-    sequence = generate.text(model)("Write a short sentence ", rng=rng)
+    sequence = generate.text(model)("Write a short sentence ", seed=10000)
     assert isinstance(sequence, str)
 
 
@@ -652,22 +510,30 @@ def test_RegexGuide_caching(temp_cache_dir):
     assert create_states_mapping.__memory__ is cache
 
     model = models.transformers(
-        "hf-internal-testing/tiny-random-XLMRobertaXLForCausalLM"
+        "hf-internal-testing/tiny-random-XLMRobertaXLForCausalLM", device="cpu"
     )
     generator = generate.regex(model, regex, sampler=greedy())
     assert cache.stats() == (0, 1)
 
-    model_2 = models.transformers("hf-internal-testing/tiny-random-GPTJForCausalLM")
+    model_2 = models.transformers(
+        "hf-internal-testing/tiny-random-GPTJForCausalLM", device="cpu"
+    )
     generator_2 = generate.regex(model_2, regex, sampler=greedy())
     assert cache.stats() == (0, 2)
 
     # These two different models and tokenizers should not have the same state
     # mapping results
-    assert generator.fsm.states_to_token_maps != generator_2.fsm.states_to_token_maps
+    assert (
+        generator.logits_processor.fsm.states_to_token_maps
+        != generator_2.logits_processor.fsm.states_to_token_maps
+    )
 
     generator_3 = generate.regex(model_2, regex, sampler=greedy())
     assert cache.stats() == (1, 2)
-    assert generator_2.fsm.states_to_token_maps == generator_3.fsm.states_to_token_maps
+    assert (
+        generator_2.logits_processor.fsm.states_to_token_maps
+        == generator_3.logits_processor.fsm.states_to_token_maps
+    )
 
     # Just for fun...
     structured = generator(prompt, max_tokens=30)

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -63,20 +63,17 @@ def test_llama_tokenizer():
 
 
 def test_model():
-    with pytest.raises(ValueError, match="When passing device_map as a string"):
-        transformers(TEST_MODEL, device="non_existent")
-
     model = transformers(TEST_MODEL, device="cpu")
     assert isinstance(model.tokenizer, TransformerTokenizer)
-    assert model.device.type == "cpu"
+    assert model.model.device.type == "cpu"
 
     model = transformers(TEST_MODEL, model_kwargs={"device_map": "cpu"})
     assert isinstance(model.tokenizer, TransformerTokenizer)
-    assert model.device.type == "cpu"
+    assert model.model.device.type == "cpu"
 
     model = transformers(TEST_MODEL, device="cpu", model_kwargs={"device_map": "cuda"})
     assert isinstance(model.tokenizer, TransformerTokenizer)
-    assert model.device.type == "cpu"
+    assert model.model.device.type == "cpu"
 
     input_ids = torch.tensor([[0, 1, 2]])
     logits, kv_cache = model(input_ids, torch.ones_like(input_ids))


### PR DESCRIPTION
~~In draft until https://github.com/huggingface/transformers/pull/31448 makes it into a new `transformers` release~~

Fixes https://github.com/outlines-dev/outlines/issues/1021

Fixes #789

Fixes #806 (does everything except remove the issues requirement of "remove `torch`")

Closes https://github.com/outlines-dev/outlines/pull/910 (device inconsistency issue handled through other means)

# Problem

- For #789 in `SequenceGenerator` if `input_ids` is empty, it fails.
- Generally, `models.transformers` has an inconsistent implementation with other modules making the codebase harder to manage.


# Solution

- Use `SequenceGeneratorAdapter` for transformers instead of `SequenceGenerator`
- Implement `Transformers.generate` and `Transformers.stream` which use `model.generate(logits_processor=...)` argument with `outlines.processors.OutlinesLogitsProcessor`

### Additional Changes

- ~~Temporarily disables `stop_at` argument for transformers and implements test to determine whether upstream is fixed (https://github.com/huggingface/transformers/issues/31435)~~
  - fixed upstream, change reverted
- Update docs and examples to use `seed` instead of `rng`
- Disables `outlines.generate.cfg` for now (https://github.com/outlines-dev/outlines/issues/959)

# TODO:

- [x] Determine cause of regression when generating json
  - was caused by `GenerationConfig` default `max_tokens` being 20
- [x] replace `rng` with `seed` in all tests and all documentation.
- [x] Awaiting `transformers` fix for https://github.com/huggingface/transformers/issues/31435 so `stop_at` works.