### PR TITLE
Fix some dependency issues and remove obsolete try-except block

### DIFF
--- a/outlines/types/airports.py
+++ b/outlines/types/airports.py
@@ -1,13 +1,7 @@
 """Generate valid airport codes."""
 from enum import Enum
 
-try:
-    from pyairports.airports import AIRPORT_LIST
-except ImportError:
-    raise ImportError(
-        'The `airports` module requires "pyairports" to be installed. You can install it with "pip install pyairports"'
-    )
-
+from pyairports.airports import AIRPORT_LIST
 
 AIRPORT_IATA_LIST = list(
     {(airport[3], airport[3]) for airport in AIRPORT_LIST if airport[3] != ""}

--- a/outlines/types/countries.py
+++ b/outlines/types/countries.py
@@ -1,12 +1,7 @@
 """Generate valid country codes and names."""
 from enum import Enum
 
-try:
-    import pycountry
-except ImportError:
-    raise ImportError(
-        'The `countries` module requires "pycountry" to be installed. You can install it with "pip install pycountry"'
-    )
+import pycountry
 
 ALPHA_2_CODE = [(country.alpha_2, country.alpha_2) for country in pycountry.countries]
 Alpha2 = Enum("Alpha_2", ALPHA_2_CODE)  # type:ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
    "requests",
    "tqdm",
    "datasets",
+   "typing_extensions",
    "pycountry",
    "pyairports",
 ]
@@ -64,7 +65,6 @@ test = [
 ]
 serve = [
     "vllm>=0.3.0",
-    "ray==2.9.0",
     "uvicorn",
     "fastapi",
     "pydantic>=2.0",


### PR DESCRIPTION
Since https://github.com/outlines-dev/outlines/pull/955 was closed with the reason that there was no interest in adding another step to the CI pipeline, it might still be worthwhile to resolve some issues with the project's dependencies without adding `deptry` to the project or the CI pipeline. This PR:

- Removes the obsolete try-except blocks for importing `pyairports` and `pycountry`, since they are listed in the project's dependencies.
- Add the transitive dependency `typing_extensions` to the dependencies
- Remove `ray` as a development dependency

Let me know your thoughts :) Feel free to close if you think it does not bring improvement to the project