### PR TITLE
Adding `MLXLM`, `VLLM` classes to `LogitsGenerator` type

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -15,4 +15,4 @@ from .openai import OpenAI, azure_openai, openai
 from .transformers import Transformers, transformers
 from .vllm import VLLM, vllm
 
-LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, Mamba]
+LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, Mamba, MLXLM, VLLM]


### PR DESCRIPTION
Very excited about the mlx integration in [v0.0.44](https://github.com/outlines-dev/outlines/releases/tag/0.0.44)! 

Began integrating it into a project, but noticed that type hinting was throwing some errors around the `LogitsGenerator` type. Essentially, it looks as though this type wasn't synced up with the creation of the two new models. 

This PR just adds the two models to this type in `models/__init__.py`: 

```python
LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, Mamba, MLXLM, VLLM]
```

However, it brought up a bigger design question I'm curious about. What was the reasoning to go with this pattern (building a custom type using `Union`) as opposed to an abstract `LogitsGenerator` class, which all future model classes subclass? This way:

- You wouldn't need to worry about first creating the model, and then going to update `LogitsGenerator`
- We'd have stricter constraints over what a valid model is (i.e a `generate()` function returning a `float` is a no-go)
- We could type the 'loader functions' (`llamacpp`, `mamba`, `mlxlm`, etc.) to explicitly return a `LogitsGenerator`

Thanks! 