### PR TITLE
Ensure regex matches valid JSON for "const" and "enum" with booleans, nulls, and strings

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -269,19 +269,18 @@ def to_regex(
     elif "enum" in instance:
         choices = []
         for choice in instance["enum"]:
-            if type(choice) in [int, float, bool, None]:
-                choices.append(re.escape(str(choice)))
-            elif type(choice) == str:
-                choices.append(f'"{re.escape(choice)}"')
-
+            if type(choice) in [int, float, bool, type(None), str]:
+                choices.append(re.escape(json.dumps(choice)))
+            else:
+                raise TypeError(f"Unsupported data type in enum: {type(choice)}")
         return f"({'|'.join(choices)})"
 
     elif "const" in instance:
         const = instance["const"]
-        if type(const) in [int, float, bool, None]:
-            const = re.escape(str(const))
-        elif type(const) == str:
-            const = f'"{re.escape(const)}"'
+        if type(const) in [int, float, bool, type(None), str]:
+            const = re.escape(json.dumps(const))
+        else:
+            raise TypeError(f"Unsupported data type in const: {type(const)}")
         return const
 
     elif "$ref" in instance:


### PR DESCRIPTION
Use JSON's serialization, rather than Python's, in this case.

Fixes #971. Note that this still does not correctly handle arrays and objects, which are allowed by the JSON schema spec; however, those would be more complex to handle correctly.