### PR TITLE
Pin Numpy: `numpy<2.0.0`, Prevent `ModuleNotFoundError`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
    "jinja2",
    "lark",
    "nest_asyncio",
-   "numpy",
+   "numpy<2.0.0",
    "cloudpickle",
    "diskcache",
    "pydantic>=2.0",


### PR DESCRIPTION
Addresses: https://github.com/outlines-dev/outlines/issues/976

Fixes https://github.com/vllm-project/vllm/pull/5582

We should close 976 **after** we fix Outlines to be compatible with Numpy >= 2.0.0, which this PR doesn't do.

### Problem

Cannot `import outlines` due to `outlines/base.py` importing `from numpy.lib.function_base import (` which no longer exists in numpy 2.0.0.

### Temporary Solution

Pin `numpy<2.0.0`