### PR TITLE
Fix samplers documentation

### DIFF
--- a/docs/cookbook/classification.md
+++ b/docs/cookbook/classification.md
@@ -45,7 +45,7 @@ Outlines provides a shortcut to do multi-label classification, using the `outlin
 ```python
 from outlines.samplers import greedy
 
-generator = outlines.generate.choice(model, ["URGENT", "STANDARD"], sampler=greedy)
+generator = outlines.generate.choice(model, ["URGENT", "STANDARD"], sampler=greedy())
 ```
 Outlines supports batched requests, so we will pass two requests to the model:
 
@@ -96,7 +96,7 @@ class Classification(BaseModel):
 and we can use `generate.json` by passing this Pydantic model we just defined, and call the generator:
 
 ```python
-generator = outlines.generate.json(model, Classification, sampler=greedy)
+generator = outlines.generate.json(model, Classification, sampler=greedy())
 labels = generator(prompts)
 print(labels)
 # [Classification(label=<Label.urgent: 'URGENT'>), Classification(label=<Label.standard: 'STANDARD'>)]

--- a/outlines/samplers.py
+++ b/outlines/samplers.py
@@ -77,7 +77,7 @@ class GreedySampler:
         return next_token_ids, ancestors, weights
 
 
-greedy = GreedySampler()
+greedy = GreedySampler
 
 
 class MultinomialSampler:
@@ -162,7 +162,7 @@ class MultinomialSampler:
         return next_token_ids, ancestors, weights
 
 
-multinomial = MultinomialSampler()
+multinomial = MultinomialSampler
 
 
 def keep_top_k_logits(k: int) -> Callable[["torch.Tensor"], "torch.Tensor"]:
@@ -321,4 +321,4 @@ class BeamSearchSampler:
         return next_token_ids, ancestors, weights
 
 
-beam_search = BeamSearchSampler()
+beam_search = BeamSearchSampler

--- a/outlines/samplers.py
+++ b/outlines/samplers.py
@@ -77,7 +77,7 @@ class GreedySampler:
         return next_token_ids, ancestors, weights
 
 
-greedy = GreedySampler
+greedy = GreedySampler()
 
 
 class MultinomialSampler:
@@ -162,7 +162,7 @@ class MultinomialSampler:
         return next_token_ids, ancestors, weights
 
 
-multinomial = MultinomialSampler
+multinomial = MultinomialSampler()
 
 
 def keep_top_k_logits(k: int) -> Callable[["torch.Tensor"], "torch.Tensor"]:
@@ -321,4 +321,4 @@ class BeamSearchSampler:
         return next_token_ids, ancestors, weights
 
 
-beam_search = BeamSearchSampler
+beam_search = BeamSearchSampler()


### PR DESCRIPTION
This fixes issue #978. Specifically for the classification example in the outlines cookbook section [here](https://outlines-dev.github.io/outlines/cookbook/classification/),  it fixes the piece of code in outlines.generate.api.SequenceGeneratorAdapter that keeps returning the wrong result (i.e. returning False even if a specific sampler is passed (greedy, multinomial, or beam search).