### PR TITLE
Allow escaped strings in `json_schema.py`

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -10,8 +10,10 @@ from referencing import Registry, Resource
 from referencing._core import Resolver
 from referencing.jsonschema import DRAFT202012
 
-STRING_INNER = r'([^"\\\x00-\x1f\x7f-\x9f]|\\\\)'
+# allow `\"`, `\\`, or any character which isn't a control sequence
+STRING_INNER = r'([^"\\\x00-\x1F\x7F-\x9F]|\\["\\])'
 STRING = f'"{STRING_INNER}*"'
+
 INTEGER = r"(-)?(0|[1-9][0-9]*)"
 NUMBER = rf"({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"
 BOOLEAN = r"(true|false)"

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -124,6 +124,10 @@ def test_match_number(pattern, does_match):
                 ('"quoted_string"', True),
                 (r'"escape_\character"', False),
                 (r'"double_\\escape"', True),
+                (r'"\n"', False),
+                (r'"\\n"', True),
+                (r'"unescaped " quote"', False),
+                (r'"escaped \" quote"', True),
             ],
         ),
         # String with maximum length


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/935

## Problem

On `main` in `json_schema.py`,

`STRING_INNER = r'([^"\\\x00-\x1f\x7f-\x9f]|\\\\)' `

This pattern requires `\` to be followed by a second `\`.

`\\` is legal, `\"` is not.

## Solution

Modify the pattern so `\\` AND `\"` are allowed.