### PR TITLE
Fix Incorrect Token Normalization Method for `LlamaCppTokenizer`

### DIFF
--- a/tests/generate/test_integration_llamacpp.py
+++ b/tests/generate/test_integration_llamacpp.py
@@ -334,3 +334,25 @@ def test_RegexGuide_caching(model, temp_cache_dir):
     assert re.fullmatch(regex, structured)
     assert re.fullmatch(regex, structured_2)
     assert structured != structured_2
+
+
+def test_tokenizer_vocabulary_decode_sanity():
+    """Assert the decoded newline token (198) is the same as the normalized vocab token"""
+    import llama_cpp
+
+    model = models.llamacpp(
+        "bartowski/Meta-Llama-3-8B-Instruct-GGUF",
+        "Meta-Llama-3-8B-Instruct-IQ1_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+        ),
+    )
+    tokenizer = generate.regex(model, "a").logits_processor.tokenizer
+
+    decoded_nl_token = tokenizer.decode([198])[0]
+    vocab_nl_token = tokenizer.convert_token_to_string(
+        [token for token, token_id in tokenizer.vocabulary.items() if token_id == 198][
+            0
+        ]
+    )
+    assert decoded_nl_token == vocab_nl_token


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/952

## Problem

During FSM index creation, the **normalized** vocabulary is used to determine token validity for each state in the automata. 

Because the set of token strings in `tokenizer.vocabulary` isn't equivalent to the token strings created by `tokenizer.decode` the vocabulary tokens must be normalized to ensure the FSM selects tokens from the vocabulary which, when decoded, conform to the pattern. 

In `models.llamacpp` there wasn't any normalization, and the `\n` token is represented in vocabulary as `Ċ`

```
>>> tokenizer.vocabulary['Ċ']
198
>>> tokenizer.decode([198])
['\n']
```

During FSM compilation, Outlines understood `"Ċ"` to be a valid json string, however in reality, the invalid json string `"\n"` was decoded.

## Solution

Implement working normalization function, `convert_token_to_string()`, to ensure behavior is correct when using a huggingface transformers tokenizer with `models.llamacpp`.