### PR TITLE
Fix use of `os.environ` in documentation

### DIFF
--- a/docs/reference/models/openai.md
+++ b/docs/reference/models/openai.md
@@ -26,7 +26,7 @@ from outlines import models
 
 model = models.openai(
     "gpt-3.5-turbo",
-    api_key=os.environ("OPENAI_API_KEY")
+    api_key=os.environ["OPENAI_API_KEY"]
 )
 ```
 


### PR DESCRIPTION
Superses #990 since couldn't push to author's branch