### PR TITLE
fix pattern-string in `json_schema.py` by removing anchors

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -312,7 +312,7 @@ def to_regex(
             elif "pattern" in instance:
                 pattern = instance["pattern"]
                 if pattern[0] == "^" and pattern[-1] == "$":
-                    return rf'(^"{pattern[1:-1]}"$)'
+                    return rf'("{pattern[1:-1]}")'
                 else:
                     return rf'("{pattern}")'
             elif "format" in instance:

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -151,7 +151,7 @@ def test_match_number(pattern, does_match):
         # String defined by a regular expression
         (
             {"title": "Foo", "type": "string", "pattern": r"^[a-z]$"},
-            r'(^"[a-z]"$)',
+            r'("[a-z]")',
             [('"a"', True), ('"1"', False)],
         ),
         # Boolean
@@ -749,6 +749,7 @@ def test_match_number(pattern, does_match):
     ],
 )
 def test_match(schema, regex, examples):
+    interegular.parse_pattern(regex)
     schema = json.dumps(schema)
     test_regex = build_regex_from_schema(schema)
     assert test_regex == regex
@@ -827,6 +828,7 @@ def test_match(schema, regex, examples):
     ],
 )
 def test_format(schema, regex, examples):
+    interegular.parse_pattern(regex)
     schema = json.dumps(schema)
     test_regex = build_regex_from_schema(schema)
     assert test_regex == regex


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/931

## Problem

`interegular` doesn't support anchors, `^` and `$`, however `json_schema.py` explicitly allowed their inclusion in `main`, resulting in `interegular.patterns.Unsupported: '^'`.

## Solution

- Strip anchors in pattern-strings.
- update `json_schema.py` tests so any produced regex is run through `interegular.parse_pattern(regex)` to check for `interegular` incompatibility. 