### PR TITLE
Ensure `models.llamacpp` Doesn't Have Implicit `max_tokens`

### DIFF
--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -166,7 +166,9 @@ class LlamaCpp:
 
         # Somehow `llama-cpp-python` generates `max_tokens + 1`  tokens
         if "max_tokens" not in llama_cpp_params:
-            if max_tokens is not None:
+            if max_tokens is None:
+                llama_cpp_params["max_tokens"] = -1  # indicates unlimited tokens
+            else:
                 llama_cpp_params["max_tokens"] = max_tokens - 1
         else:
             llama_cpp_params["max_tokens"] = llama_cpp_params["max_tokens"] - 1

--- a/tests/generate/test_integration_llamacpp.py
+++ b/tests/generate/test_integration_llamacpp.py
@@ -356,3 +356,22 @@ def test_tokenizer_vocabulary_decode_sanity():
         ]
     )
     assert decoded_nl_token == vocab_nl_token
+
+
+def test_no_length_constraint_when_unset():
+    """Assert that models.llamacpp doesn't have an implicit max_tokens preventing full sequence generation"""
+    import llama_cpp
+
+    model = models.llamacpp(
+        repo_id="M4-ai/TinyMistral-248M-v2-Instruct-GGUF",
+        filename="TinyMistral-248M-v2-Instruct.Q4_K_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "Locutusque/TinyMistral-248M-Instruct"
+        ),
+    )
+
+    long_pattern = "abcdefg" * 10
+    generator = generate.regex(model, long_pattern)
+
+    output = generator("a")
+    assert re.match(long_pattern, output)


### PR DESCRIPTION
Fixes #973 

## Problem

In #973 an invalid pattern was being generated, however it was only invalid because it was incomplete. in the `LlamaCpp.generate()` call `llama_cpp_params["max_tokens"]` was unset, however the model was still finishing for reason "length":

```
[{'text': '{ "name": "Grace Lee", "age":32, "', 'index': 0, 'logprobs': None, 'finish_reason': 'length'}]                                                                                                         
```

In turns out the max tokens was being implicitly set to `30`.

## Solution

Allow 2**30 tokens if `max_length` is unset /`None`, because `llama_cpp_params` requires an `int` for the `max_tokens` field.