### PR TITLE
Use `outlines.processors` for `models.llamacpp`

### DIFF
--- a/outlines/generate/regex.py
+++ b/outlines/generate/regex.py
@@ -41,6 +41,7 @@ def regex(model, regex_str: str, sampler: Sampler = multinomial()):
 
 @regex.register(MLXLM)
 @regex.register(Transformers)
+@regex.register(LlamaCpp)
 def regex_unified(
     model,
     regex_str: str,
@@ -49,18 +50,6 @@ def regex_unified(
     from outlines.processors import RegexLogitsProcessor
 
     logits_processor = RegexLogitsProcessor(regex_str, tokenizer=model.tokenizer)
-    return SequenceGeneratorAdapter(model, logits_processor, sampler)
-
-
-@regex.register(LlamaCpp)
-def regex_llamacpp(
-    model: LlamaCpp,
-    regex_str: str,
-    sampler: Sampler = multinomial(),
-):
-    from outlines.integrations.llamacpp import RegexLogitsProcessor
-
-    logits_processor = RegexLogitsProcessor(regex_str, llm=model.model)
     return SequenceGeneratorAdapter(model, logits_processor, sampler)
 
 

--- a/outlines/generate/text.py
+++ b/outlines/generate/text.py
@@ -38,17 +38,13 @@ def text(model, sampler: Sampler = multinomial()) -> SequenceGenerator:
 
 @text.register(MLXLM)
 @text.register(Transformers)
+@text.register(LlamaCpp)
 def text_unified(model, sampler: Sampler = multinomial()):
     return SequenceGeneratorAdapter(model, None, sampler)
 
 
 @text.register(VLLM)
 def text_vllm(model: VLLM, sampler: Sampler = multinomial()):
-    return SequenceGeneratorAdapter(model, None, sampler)
-
-
-@text.register(LlamaCpp)
-def text_llamacpp(model: LlamaCpp, sampler: Sampler = multinomial()):
     return SequenceGeneratorAdapter(model, None, sampler)
 
 

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -141,6 +141,10 @@ class LlamaCpp:
     def __init__(self, model: "Llama"):
         self.model = model
 
+    @property
+    def tokenizer(self):
+        return LlamaCppTokenizer(self.model)
+
     def prepare_generation_parameters(
         self,
         generation_parameters: GenerationParameters,

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -182,10 +182,6 @@ class Transformers:
 
         return output.logits, output.past_key_values
 
-    @property
-    def device(self):
-        return self.model.device
-
     def __call__(
         self,
         input_ids: "torch.LongTensor",

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -182,6 +182,10 @@ class Transformers:
 
         return output.logits, output.past_key_values
 
+    @property
+    def device(self):
+        return self.model.device
+
     def __call__(
         self,
         input_ids: "torch.LongTensor",

--- a/outlines/processors/base_logits_processor.py
+++ b/outlines/processors/base_logits_processor.py
@@ -42,7 +42,7 @@ class OutlinesLogitsProcessor(Protocol):
         input_ids and logits are always 2D tensors for handling a batch of sequences.
 
         - input_ids -> List[List[tokens]]
-        - logits.shape[0] -> 2D_Tensor[logits]
+        - logits -> 2D_Tensor[logit floats]
 
         Important to keep in mind when designing universal logits processors
         - logits processors are only used once and never re-applied for a new sequence generator

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -103,6 +103,17 @@ def test_generate_text_stream(request, model_fixture):
 
 @pytest.mark.parametrize("pattern", REGEX_PATTERNS)
 @pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_fsm(request, model_fixture, pattern):
+    import interegular
+
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.fsm(model, interegular.parse_pattern(pattern).to_fsm())
+    res = generator("test")
+    assert re.fullmatch(pattern, res) is not None, res
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
 def test_generate_regex(request, model_fixture, pattern):
     model = request.getfixturevalue(model_fixture)
     generator = generate.regex(model, pattern)


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/965

## Problem

in `main`
- `generate.fsm` only supports `SequenceGenerator`, 
- `models.llamacpp` doesn't support `SequenceGenerator`, it only supports `SequenceGeneratorAdapter`
- `integrations.llamacpp` doesn't have a FSM logits processor.

## Solution

- Ensure `models.llamacpp` uses `outlines.processors` / `SequenceGeneratorAdapter` for all generators
- Update `generate.fsm` to use `SequenceGeneratorAdapter` for all unified models
- `test_generate.py` tests for `generate.fsm` on `MLXLM`, `llamacpp`, and `transformers` (the three models using  `outlines.processors`)
  - fix critical `generate.fsm` bug discovered through this test in `guide.py` impacting all models