### PR TITLE
Improve `outlines.processors`, add integration tests to test_generate.py

### DIFF
--- a/benchmarks/bench_processors.py
+++ b/benchmarks/bench_processors.py
@@ -1,0 +1,52 @@
+import mlx.core as mx
+import numpy as np
+import torch
+
+from outlines.processors import OutlinesLogitsProcessor
+
+
+def is_mlx_lm_allowed():
+    try:
+        import mlx.core as mx
+    except ImportError:
+        return False
+    return mx.metal.is_available()
+
+
+class HalvingLogitsProcessor(OutlinesLogitsProcessor):
+    """Simply halve the passed logits"""
+
+    def process_logits(self, input_ids, logits):
+        return logits / 2
+
+
+class LogitsProcessorBenchmark:
+    params = ["torch", "numpy"]
+    if mx.metal.is_available():
+        params += ["mlx"]
+
+    def setup(self, array_library):
+        self.logits_processor = HalvingLogitsProcessor()
+
+        # logits: (4, 30,000 ) dtype=float
+        # input_ids shape: (4, 2048) dtype=int
+        if array_library == "torch":
+            self.logits = torch.rand((4, 30000), dtype=torch.float)
+            self.input_ids = torch.randint(
+                low=0, high=30000, size=(4, 2048), dtype=torch.int
+            )
+        elif array_library == "numpy":
+            self.logits = np.random.rand(4, 30000).astype(np.float32)
+            self.input_ids = np.random.randint(low=0, high=30000, size=(4, 2048))
+        elif array_library == "mlx":
+            self.logits = mx.random.uniform(
+                low=-1e9, high=1e9, shape=(4, 30000), dtype=mx.float32
+            )
+            self.input_ids = mx.random.randint(
+                low=0, high=30000, shape=(4, 2048), dtype=mx.int32
+            )
+        else:
+            raise ValueError
+
+    def time_logits_processor(self, array_library):
+        self.logits_processor(self.input_ids, self.logits)

--- a/outlines/__init__.py
+++ b/outlines/__init__.py
@@ -2,6 +2,7 @@
 import outlines.generate
 import outlines.grammars
 import outlines.models
+import outlines.processors
 import outlines.types
 from outlines.base import vectorize
 from outlines.caching import clear_cache, disable_cache, get_cache

--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer
 
     from outlines.generate.api import GenerationParameters, SamplingParameters
-    from outlines.processors import BaseLogitsProcessor
+    from outlines.processors import OutlinesLogitsProcessor
 
 
 class MLXLM:
@@ -127,7 +127,7 @@ class MLXLM:
         temp: Optional[float],
         top_p: Optional[float],
         sampler: str,
-        logits_processor: "BaseLogitsProcessor",
+        logits_processor: "OutlinesLogitsProcessor",
     ) -> Generator[Tuple[int, float], None, None]:
         """
         Adapted from
@@ -142,7 +142,7 @@ class MLXLM:
                 top_p (float, optional): Nulceus sampling, higher means model considers
                   more less likely words.
                 sampler (str): The sampler string defined by SequenceGeneratorAdapter
-                logits_processor (BaseLogitsProcessor): Augment logits before sampling.
+                logits_processor (OutlinesLogitsProcessor): Augment logits before sampling.
         """
         import mlx.core as mx
         import mlx_lm

--- a/outlines/processors/__init__.py
+++ b/outlines/processors/__init__.py
@@ -1,7 +1,7 @@
 from .structured import (
-    BaseLogitsProcessor,
     CFGLogitsProcessor,
     FSMLogitsProcessor,
     JSONLogitsProcessor,
+    OutlinesLogitsProcessor,
     RegexLogitsProcessor,
 )

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -1,9 +1,11 @@
+import contextlib
 import re
 
 import pytest
 
 import outlines.generate as generate
 import outlines.models as models
+import outlines.samplers as samplers
 
 
 @pytest.fixture(scope="session")
@@ -25,36 +27,160 @@ def model_mlxlm_phi3(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def model_transformers(tmp_path_factory):
-    return models.transformers("Locutusque/TinyMistral-248M-v2-Instruct", device="cpu")
+def model_transformers_random(tmp_path_factory):
+    return models.transformers("hf-internal-testing/tiny-random-gpt2", device="cpu")
 
 
-@pytest.mark.parametrize(
-    "model_fixture",
-    ("model_llamacpp", "model_mlxlm", "model_transformers", "model_mlxlm_phi3"),
+@pytest.fixture(scope="session")
+def model_transformers_opt125m(tmp_path_factory):
+    return models.transformers("facebook/opt-125m", device="cpu")
+
+
+ALL_MODEL_FIXTURES = (
+    "model_llamacpp",
+    "model_mlxlm",
+    "model_mlxlm_phi3",
+    "model_transformers_random",
+    "model_transformers_opt125m",
 )
-def test_generate_text(request, model_fixture):
+
+
+NOT_IMPLEMENTED = {
+    "stream": ["model_vllm"],
+    "batch": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],
+    "beam_search": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],
+    "multiple_samples": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],
+}
+
+
+def enforce_not_implemented(model_fixture, *task_names):
+    """
+    Per `NOT_IMPLEMENTED`, mapping, if a model hasn't implemented a task,
+    assert an NotImplementedError is raised. Otherwise, run normally
+    """
+    for task_name in task_names:
+        if model_fixture in NOT_IMPLEMENTED.get(task_name, []):
+            return pytest.raises(NotImplementedError)
+    else:
+        return contextlib.nullcontext()
+
+
+REGEX_PATTERNS = [
+    "a b c d e",  # ensure proper tokenizer whitespace prefix handling
+    "(123456789)|(abcdefghijklmnop)",  # ensure consistent correct sequence handling during batch
+    r"([a-z]{10})@([a-z]{5})\.([a-z]{3})",  # email example
+]
+
+
+@pytest.mark.parametrize("sampler_name", ("greedy", "multinomial", "beam_search"))
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_text(request, model_fixture, sampler_name):
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.text(model, getattr(samplers, sampler_name)())
+    with enforce_not_implemented(model_fixture, sampler_name):
+        res = generator("test", max_tokens=10)
+        assert isinstance(res, str)
+
+
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_batch_text(request, model_fixture):
     model = request.getfixturevalue(model_fixture)
     generator = generate.text(model)
-    res = generator("test", max_tokens=10)
-    assert isinstance(res, str)
+    with enforce_not_implemented(model_fixture, "batch"):
+        res = generator(["test", "test2"], max_tokens=10)
+        assert isinstance(res, list)
+        assert isinstance(res[0], str)
 
 
-@pytest.mark.parametrize(
-    "model_fixture",
-    ("model_llamacpp", "model_mlxlm", "model_transformers", "model_mlxlm_phi3"),
-)
-@pytest.mark.parametrize(
-    "pattern",
-    (
-        "a b c d e",  # test model tokenizer whitespace prefix handling
-        "[0-9]",
-        "abc*",
-        "\\+?[1-9][0-9]{7,14}",
-    ),
-)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_text_stream(request, model_fixture):
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.text(model)
+    with enforce_not_implemented(model_fixture, "stream"):
+        for token in generator.stream("a b c ", max_tokens=10):
+            assert isinstance(token, str)
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
 def test_generate_regex(request, model_fixture, pattern):
     model = request.getfixturevalue(model_fixture)
     generator = generate.regex(model, pattern)
     res = generator("foobarbaz", max_tokens=20)
-    assert re.match(pattern, res) is not None, res
+    assert re.fullmatch(pattern, res) is not None, res
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_stream(request, model_fixture, pattern):
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern)
+    with enforce_not_implemented(model_fixture, "stream"):
+        output = ""
+        for token in generator.stream("output:", max_tokens=20):
+            output += token
+        assert re.fullmatch(pattern, output) is not None, output
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_batch_stream(request, model_fixture, pattern):
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern)
+    with enforce_not_implemented(model_fixture, "batch", "stream"):
+        outputs = ["", ""]
+        for tokens in generator.stream(["input 0", "input 1"], max_tokens=20):
+            outputs[0] += tokens[0]
+            outputs[1] += tokens[1]
+        for output in outputs:
+            assert re.fullmatch(pattern, output) is not None, output
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_batch(request, model_fixture, pattern):
+    """Ensure batch requests work and fsm order is maintained"""
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern)
+    with enforce_not_implemented(model_fixture, "batch"):
+        outputs = generator(["abc", "123", "123bce", "33aa"], max_tokens=20)
+        for output in outputs:
+            assert re.fullmatch(pattern, output) is not None, output
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_single_multinomial(request, model_fixture, pattern):
+    """Ensure batch requests work and fsm order is maintained"""
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern, sampler=samplers.multinomial(4))
+    with enforce_not_implemented(model_fixture, "multiple_samples"):
+        output_sample_groups = generator("single input", max_tokens=40)
+        for output in output_sample_groups:
+            assert re.fullmatch(pattern, output) is not None, output
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_batch_multinomial(request, model_fixture, pattern):
+    """Ensure batch requests work and fsm order is maintained"""
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern, sampler=samplers.multinomial(4))
+    with enforce_not_implemented(model_fixture, "batch", "multiple_samples"):
+        output_batch_groups = generator(["abc", "123", "123bce", "33aa"], max_tokens=40)
+        for output_sample_groups in output_batch_groups:
+            for output in output_sample_groups:
+                assert re.fullmatch(pattern, output) is not None, output
+
+
+@pytest.mark.parametrize("pattern", REGEX_PATTERNS)
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_regex_batch_beam_search(request, model_fixture, pattern):
+    """Ensure batch requests work and fsm order is maintained"""
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.regex(model, pattern, sampler=samplers.beam_search(4))
+    with enforce_not_implemented(model_fixture, "batch", "multiple_samples"):
+        output_batch_groups = generator(["abc", "123", "123bce", "33aa"], max_tokens=40)
+        for output_sample_groups in output_batch_groups:
+            for output in output_sample_groups:
+                assert re.fullmatch(pattern, output) is not None, output


### PR DESCRIPTION
A lot of these fixes were intended for https://github.com/outlines-dev/outlines/pull/966 however that's blocked until there's a new `transformers` release. 

These improvements are general to all models and will enable PRs resolving https://github.com/outlines-dev/outlines/issues/806 and https://github.com/outlines-dev/outlines/issues/965

# Structure of `OutlinesLogitsProcessor`

The goal is to create a base class which allows a logits processors to be implemented once and used for any `outlines.models` inference library.

To accomplish this we must normalize the input array. It must have a consistent type (`torch.Tensor`) and consistent dimensionality (2). We can normalize both of these simply, and without any copy operations.

`mlx.core.array`, `numpy.array`, and `torch.Tensor` all support [pythons array standard `__dlpack__`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html). This standard allows for casting between array types without copying.

`torch.Tensor` is the only input type which cannot always be cast to any other type because torch tensors may live in GPU memory. Therefore, we cast all arrays to `torch.Tensor`, implement logits processors using torch methods, and convert back to the original array type in `OutlinesLogitsProcessor`. See docstring of `OutlinesLogitsProcessor.__call__()` for more details.

# Detailed Changes
- Rename `BaseLogitsProcessor` to `OutlinesLogitsProcessor`
- Ensure `OutlinesLogitsProcessor.process_logits()` is always passed a 2D batch request with `torch.Tensor` logits and `List` input_ids. Also clean up code to be more readable in `OutlinesLogitsProcessor__call__()`
- Ensure `FSMLogitsProcessor` allows unstable sequence ordering (beam search in transformers and vLLM change the order of sequences)
- Update `tests/generate/test_generate.py` to cover more permutations of 
  - regex / text 
  - batch / single
  - greedy / multinomial / beam search
  - `stream()` / `generate()`
- Ensure performance stability with difference array libraries through `benchmark_processors.py`