### PR TITLE
fix `models.mlxlm` whitespace prefix handling

### DIFF
--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -106,13 +106,20 @@ class MLXLM:
         # https://github.com/ml-explore/mlx-examples/blob/4872727/llms/mlx_lm/utils.py#L267
         prompt_tokens = mx.array(self.mlx_tokenizer.encode(prompts))
 
+        detokenizer = self.mlx_tokenizer.detokenizer
+        detokenizer.reset()
+
         for (token, prob), n in zip(
             self.generate_step(prompt_tokens, **generate_kwargs),
             range(max_tokens),
         ):
             if token == self.tokenizer.eos_token_id:
                 break
-            yield self.tokenizer.decode([token])[0]
+            detokenizer.add_token(token)
+            yield detokenizer.last_segment
+
+        detokenizer.finalize()
+        yield detokenizer.last_segment
 
     def generate_step(
         self,

--- a/tests/generate/conftest.py
+++ b/tests/generate/conftest.py
@@ -17,7 +17,7 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "model_fixture" in item.fixturenames:
                 model_param = item.callspec.params.get("model_fixture", None)
-                if model_param == "model_mlxlm":
+                if model_param.startswith("model_mlxlm"):
                     item.add_marker(skip_marker)
 
 

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -20,13 +20,18 @@ def model_mlxlm(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def model_mlxlm_phi3(tmp_path_factory):
+    return models.mlxlm("mlx-community/Phi-3-mini-4k-instruct-4bit")
+
+
+@pytest.fixture(scope="session")
 def model_transformers(tmp_path_factory):
     return models.transformers("Locutusque/TinyMistral-248M-v2-Instruct", device="cpu")
 
 
 @pytest.mark.parametrize(
     "model_fixture",
-    ("model_llamacpp", "model_mlxlm", "model_transformers"),
+    ("model_llamacpp", "model_mlxlm", "model_transformers", "model_mlxlm_phi3"),
 )
 def test_generate_text(request, model_fixture):
     model = request.getfixturevalue(model_fixture)
@@ -37,11 +42,12 @@ def test_generate_text(request, model_fixture):
 
 @pytest.mark.parametrize(
     "model_fixture",
-    ("model_llamacpp", "model_mlxlm", "model_transformers"),
+    ("model_llamacpp", "model_mlxlm", "model_transformers", "model_mlxlm_phi3"),
 )
 @pytest.mark.parametrize(
     "pattern",
     (
+        "a b c d e",  # test model tokenizer whitespace prefix handling
         "[0-9]",
         "abc*",
         "\\+?[1-9][0-9]{7,14}",


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/982

## Problem

`models.mlxlm` didn't properly apply whitespace prefixes for some tokenizers such as `phi3`.

## Solution

Use official `mlx-lm` implementations `tokenizer.detokenizer` to manage last-token str representation when iterating over token strings.