### PR TITLE
Update `pyproject.toml`, enable `mlx-lm` requirement only on darwin, disable `vllm` requirement on darwin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ test = [
     "beartype<0.16.0",
     "responses",
     "llama-cpp-python",
-    "mlx-lm",
+    "mlx-lm; platform_machine == 'arm64' and sys_platform == 'darwin'",
     "huggingface_hub",
     "openai>=1.0.0",
-    "vllm",
+    "vllm; sys_platform != 'darwin'",
     "torch",
     "transformers",
 ]


### PR DESCRIPTION
- Fixes Discord user Vibhath's issue with `mlx-lm` on linux.
- Fixes https://github.com/outlines-dev/outlines/issues/989

## Problem

`pip install -e .[test]` fails under two addressed conditions:
- gnu/linux user attempts to install `mlx-lm` dependency
- darwin user attempts to install `vllm` dependency.

## Solution

Update `pyproject.toml`, ensure `vllm` and `mlx-lm` are installed only on appropriate systems.