### PR TITLE
Add asknews example

### DIFF
--- a/docs/community/examples.md
+++ b/docs/community/examples.md
@@ -13,3 +13,5 @@ Publishing examples and articles about Outlines are a meaningful way to contrinu
 [gigax](https://github.com/GigaxGames/gigax) is an Open-Source library that allows to create real-time LLM-powered NPCs for video games.
 
 [Improving Prompt Consistency with Structured Generations](https://huggingface.co/blog/evaluation-structured-outputs) shows how structured generation can improve consistency of evaluation runs by reducing sensitivity to changes in prompt format.
+
+[AskNews](https://asknews.app) is a news curation service processing 300k news articles per day in a structured way, with Outlines.


### PR DESCRIPTION
AskNews is processing 300k articles per day on-premise with vLLM and outlines. Outlines enables much deeper analysis of each article, since the LLM doesnt need to worry about structure. Instead, it can focus attention on important output like extracting "Reporting Voice" typed as a `Literal[str]`.

Thanks to the maintainers of this project!