### PR TITLE
Auto-apply chat template in `SequenceGenerator` and `SequenceGeneratorAdapter`, if available

### DIFF
--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
 from outlines.generate.generator import sequence_generator
-from outlines.models.transformers import TransformerTokenizer
 from outlines.samplers import BeamSearchSampler, GreedySampler, MultinomialSampler
 
 if TYPE_CHECKING:
@@ -571,6 +570,8 @@ class SequenceGeneratorAdapter:
 
 
 def apply_chat_template_util(model, prompts: Union[str, List[str]]) -> List[str]:
+    from outlines.models.transformers import TransformerTokenizer
+
     if isinstance(prompts, str):
         prompts = [prompts]
     if not isinstance(model.tokenizer, TransformerTokenizer):
@@ -578,7 +579,7 @@ def apply_chat_template_util(model, prompts: Union[str, List[str]]) -> List[str]
             "Chat template is only supported for `Transformer` models for now. The raw prompts will be used instead."
         )
         return prompts
-    tokenizer: TransformerTokenizer = model.tokenizer
+    tokenizer: "TransformerTokenizer" = model.tokenizer
     if getattr(tokenizer.tokenizer, "chat_template", None) is None:
         warnings.warn(
             "The model does not have chat template support. The raw prompts will be used instead. To turn this warning off, either explicitly set the `apply_chat_template` argument to 'False' or assign a value to `model.tokenizer.tokenizer.chat_template`."

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -22,6 +22,7 @@ class SequenceGenerator:
         model,
         sampler,
         device,
+        apply_chat_template: bool = True,
     ):
         self.fsm = fsm
         self.model = model
@@ -29,6 +30,7 @@ class SequenceGenerator:
         self.tokenizer = model.tokenizer
         self.device = device
         self.num_samples = sampler.samples
+        self.apply_chat_template = apply_chat_template
 
     def get_generated_token_ids(
         self,
@@ -134,7 +136,7 @@ class SequenceGenerator:
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
         rng: Optional["torch.Generator"] = None,
-        apply_chat_template: bool = True,
+        apply_chat_template: Optional[bool] = None,
     ) -> Union[FormattedOutput, List[FormattedOutput], List[List[FormattedOutput]]]:
         """Generate the full text sequence.
 
@@ -157,31 +159,23 @@ class SequenceGenerator:
             The random number generator. Defaults to a non-seeded `torch.Generator`
             instance.
         apply_chat_template
-            Whether to apply the chat template to the prompts. Defaults to `True`.
-            Only applies to `TransformerTokenizer` for now.
+            Whether to apply the chat template to the prompts. Defaults to the value
+            set at init. Only applies to `TransformerTokenizer` for now.
 
         Returns
         -------
         The generation(s), potentially cast to another type.
         """
+        if apply_chat_template is None:
+            apply_chat_template = self.apply_chat_template
+
         import torch
 
         if isinstance(prompts, str):
             prompts = [prompts]
 
         if apply_chat_template:
-            if not isinstance(self.tokenizer, TransformerTokenizer):
-                warnings.warn(
-                    "Chat template is only supported for `Transformer` models for now. The raw prompts will be used instead."
-                )
-            elif getattr(self.tokenizer.tokenizer, "chat_template", None) is None:
-                warnings.warn(
-                    "The model does not have chat template support. The raw prompts will be used instead. To turn this warning off, either explicitly set the `apply_chat_template` argument to 'False' or assign a value to `tokenizer.tokenizer.chat_template`."
-                )
-            else:
-                prompts = [
-                    self.tokenizer.apply_chat_template(prompt) for prompt in prompts
-                ]
+            apply_chat_template_util(self.model, prompts)
 
         if isinstance(stop_at, str):
             stop_at = [stop_at]
@@ -270,6 +264,7 @@ class SequenceGenerator:
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
         rng: Optional["torch.Generator"] = None,
+        apply_chat_template: Optional[bool] = None,
     ) -> Iterator[Union[List[str], str, List[List[str]]]]:
         """Generate the text sequence one token at a time.
 
@@ -290,16 +285,25 @@ class SequenceGenerator:
         rng
             The random number generator. Defaults to a non-seeded `torch.Generator`
             instance.
+        apply_chat_template
+            Whether to apply the chat template to the prompts. Defaults to the value
+            set at init. Only applies to `TransformerTokenizer` for now.
 
         Returns
         -------
         A string or list of strings that contain the generated text.
 
         """
+        if apply_chat_template is None:
+            apply_chat_template = self.apply_chat_template
+
         import torch
 
         if isinstance(prompts, str):
             prompts = [prompts]
+
+        if apply_chat_template:
+            apply_chat_template_util(self.model, prompts)
 
         if isinstance(stop_at, str):
             stop_at = [stop_at]
@@ -443,7 +447,9 @@ class SequenceGeneratorAdapter:
 
     """
 
-    def __init__(self, model, logits_processor, sampler):
+    def __init__(
+        self, model, logits_processor, sampler, apply_chat_template: bool = True
+    ):
         self.model = model
         self.logits_processor = logits_processor
 
@@ -463,6 +469,8 @@ class SequenceGeneratorAdapter:
             self.sampling_params = SamplingParameters(
                 "beam_search", sampler.samples, None, None, 1.0
             )
+
+        self.apply_chat_template = apply_chat_template
 
     def prepare_generation_parameters(
         self,
@@ -505,9 +513,15 @@ class SequenceGeneratorAdapter:
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
         seed: Optional[int] = None,
+        apply_chat_template: Optional[bool] = None,
         **model_specific_params,
     ):
         """Generate text from a prompt of list of prompts."""
+        if apply_chat_template is None:
+            apply_chat_template = self.apply_chat_template
+
+        if apply_chat_template:
+            apply_chat_template_util(self.model, prompts)
 
         def format(sequences):
             """Apply formatting to every string in a completion."""
@@ -536,9 +550,14 @@ class SequenceGeneratorAdapter:
         max_tokens: Optional[int] = None,
         stop_at: Optional[Union[str, List[str]]] = None,
         seed: Optional[int] = None,
+        apply_chat_template: Optional[bool] = None,
         **model_specific_params,
     ):
         """Return a text generator from a prompt or a list of prompts."""
+        if apply_chat_template is None:
+            apply_chat_template = self.apply_chat_template
+        if apply_chat_template:
+            apply_chat_template_util(self.model, prompts)
         generation_params = self.prepare_generation_parameters(
             max_tokens, stop_at, seed
         )
@@ -549,3 +568,20 @@ class SequenceGeneratorAdapter:
             self.sampling_params,
             **model_specific_params,
         )
+
+
+def apply_chat_template_util(model, prompts: Union[str, List[str]]) -> List[str]:
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if not isinstance(model.tokenizer, TransformerTokenizer):
+        warnings.warn(
+            "Chat template is only supported for `Transformer` models for now. The raw prompts will be used instead."
+        )
+        return prompts
+    tokenizer: TransformerTokenizer = model.tokenizer
+    if getattr(tokenizer.tokenizer, "chat_template", None) is None:
+        warnings.warn(
+            "The model does not have chat template support. The raw prompts will be used instead. To turn this warning off, either explicitly set the `apply_chat_template` argument to 'False' or assign a value to `model.tokenizer.tokenizer.chat_template`."
+        )
+        return prompts
+    return [tokenizer.apply_chat_template(prompt) for prompt in prompts]

--- a/outlines/generate/cfg.py
+++ b/outlines/generate/cfg.py
@@ -10,7 +10,12 @@ from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
-def cfg(model, cfg_str: str, sampler: Sampler = multinomial()) -> SequenceGenerator:
+def cfg(
+    model,
+    cfg_str: str,
+    sampler: Sampler = multinomial(),
+    apply_chat_template: bool = True,
+) -> SequenceGenerator:
     """Generate text in the language of a Context-Free Grammar
 
     Arguments
@@ -29,7 +34,7 @@ def cfg(model, cfg_str: str, sampler: Sampler = multinomial()) -> SequenceGenera
     """
     fsm = CFGGuide(cfg_str, model.tokenizer)
     device = model.device
-    generator = SequenceGenerator(fsm, model, sampler, device)
+    generator = SequenceGenerator(fsm, model, sampler, device, apply_chat_template)
 
     return generator
 
@@ -40,6 +45,7 @@ def cfg_unimplemented(
     model,
     cfg_str: str,
     sampler: Sampler = multinomial(),
+    apply_chat_template: bool = True,
 ):
     raise NotImplementedError(
         f"The CFG Logits processor is not available for {type(model)}."
@@ -55,7 +61,9 @@ def cfg_llamacpp(
     from outlines.integrations.llamacpp import CFGLogitsProcessor
 
     logits_processor = CFGLogitsProcessor(cfg_str, model.model)
-    return SequenceGeneratorAdapter(model, logits_processor, sampler)
+    return SequenceGeneratorAdapter(
+        model, logits_processor, sampler, apply_chat_template=False
+    )
 
 
 @cfg.register(OpenAI)

--- a/outlines/generate/fsm.py
+++ b/outlines/generate/fsm.py
@@ -6,9 +6,12 @@ from outlines.samplers import Sampler, multinomial
 
 
 def fsm(
-    model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()
+    model,
+    fsm: interegular.fsm.FSM,
+    sampler: Sampler = multinomial(),
+    apply_chat_template: bool = True,
 ) -> SequenceGenerator:
     fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
     device = model.device
-    generator = SequenceGenerator(fsm, model, sampler, device)
+    generator = SequenceGenerator(fsm, model, sampler, device, apply_chat_template)
     return generator

--- a/outlines/generate/text.py
+++ b/outlines/generate/text.py
@@ -7,7 +7,9 @@ from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
-def text(model, sampler: Sampler = multinomial()) -> SequenceGenerator:
+def text(
+    model, sampler: Sampler = multinomial(), apply_chat_template: bool = True
+) -> SequenceGenerator:
     """Generate text with a `Transformer` model.
 
     Note
@@ -31,24 +33,28 @@ def text(model, sampler: Sampler = multinomial()) -> SequenceGenerator:
     """
     fsm = StopAtEOSGuide(model.tokenizer)
     device = model.device
-    generator = SequenceGenerator(fsm, model, sampler, device)
+    generator = SequenceGenerator(fsm, model, sampler, device, apply_chat_template)
 
     return generator
 
 
 @text.register(MLXLM)
-def text_mlxlm(model: MLXLM, sampler: Sampler = multinomial()):
-    return SequenceGeneratorAdapter(model, None, sampler)
+def text_mlxlm(
+    model: MLXLM, sampler: Sampler = multinomial(), apply_chat_template: bool = True
+):
+    return SequenceGeneratorAdapter(model, None, sampler, apply_chat_template)
 
 
 @text.register(VLLM)
-def text_vllm(model: VLLM, sampler: Sampler = multinomial()):
-    return SequenceGeneratorAdapter(model, None, sampler)
+def text_vllm(
+    model: VLLM, sampler: Sampler = multinomial(), apply_chat_template: bool = True
+):
+    return SequenceGeneratorAdapter(model, None, sampler, apply_chat_template)
 
 
 @text.register(LlamaCpp)
 def text_llamacpp(model: LlamaCpp, sampler: Sampler = multinomial()):
-    return SequenceGeneratorAdapter(model, None, sampler)
+    return SequenceGeneratorAdapter(model, None, sampler, apply_chat_template=False)
 
 
 @text.register(OpenAI)

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 from datasets.fingerprint import Hasher
 
@@ -76,6 +76,14 @@ class TransformerTokenizer(Tokenizer):
         self.vocabulary = self.tokenizer.get_vocab()
         self.is_llama = isinstance(self.tokenizer, get_llama_tokenizer_types())
 
+        # set to None if no system message
+        self.SYSTEM_MESSAGE = {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        }
+        self.USER_MESSAGE_TEMPLATE = lambda x: {"role": "user", "content": x}
+        self.ASSISTANT_MESSAGE_TEMPLATE = lambda x: {"role": "assistant", "content": x}
+
     def encode(
         self, prompt: Union[str, List[str]], **kwargs
     ) -> Tuple["torch.LongTensor", "torch.LongTensor"]:
@@ -99,6 +107,24 @@ class TransformerTokenizer(Tokenizer):
                 return " " + string
 
         return string
+
+    def get_messages(self, prompt: str) -> List[Dict[str, str]]:
+        """
+        Template for one-turn chat.
+        """
+        return (
+            [self.SYSTEM_MESSAGE.copy(), self.USER_MESSAGE_TEMPLATE(prompt)]
+            if self.SYSTEM_MESSAGE is not None
+            else [self.USER_MESSAGE_TEMPLATE(prompt)]
+        )
+
+    def apply_chat_template(self, prompt: str) -> str:
+        messages = self.get_messages(prompt)
+        return self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
 
     def __eq__(self, other):
         if isinstance(other, type(self)):

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -6,7 +6,11 @@ from outlines.models.tokenizer import Tokenizer
 
 if TYPE_CHECKING:
     import torch
-    from transformers import PreTrainedModel, PreTrainedTokenizer
+    from transformers import (
+        PreTrainedModel,
+        PreTrainedTokenizer,
+        PreTrainedTokenizerFast,
+    )
 
 __all__ = ["transformers"]
 
@@ -59,7 +63,11 @@ def get_llama_tokenizer_types():
 class TransformerTokenizer(Tokenizer):
     """Represents a tokenizer for models in the `transformers` library."""
 
-    def __init__(self, tokenizer: "PreTrainedTokenizer", **kwargs):
+    def __init__(
+        self,
+        tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
+        **kwargs,
+    ):
         self.tokenizer = tokenizer
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 from outlines.generate.api import GenerationParameters, SamplingParameters
 
+from .transformers import TransformerTokenizer
+
 if TYPE_CHECKING:
     from vllm import LLM
     from vllm.sampling_params import SamplingParams
@@ -20,6 +22,7 @@ class VLLM:
 
     def __init__(self, model: "LLM"):
         self.model = model
+        self.tokenizer = TransformerTokenizer(self.model.get_tokenizer())
         self.lora_request = None
 
     def generate(


### PR DESCRIPTION
This PR auto-applies chat templates by default when using instruct/chat models. Doesn't support LlamaCPP for now tho.

---

### Why?

Instruct/Chat models tend to be annoyingly template dependent (i.e. they perform worse if the prompts don't follow the chat template used in the finetuning step). And the more and longer they are finetuned, the worse the problem gets. Hence this PR.

Also see this issue https://github.com/outlines-dev/outlines/issues/987 raised by @lapp0 

---

### Interface changes

This PR has minimal impact on the interface. It just changes the default behavior of the generation step.

However, this feature can be disabled either on the creation of the generator:
```python
generator = outlines.generate.choice(model, ["Positive", "Negative"], apply_chat_template=False)
```
Or when calling the generator
```python
answer = generator(prompt, apply_chat_template=False)
```

