### PR TITLE
Translate JSON Schema to YAML regex

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
     - id: mypy
       args: [--allow-redefinition]
       exclude: ^examples/
-      additional_dependencies: [types-tqdm]
+      additional_dependencies: [types-tqdm, types-PyYAML]

--- a/outlines/fsm/yaml_schema.py
+++ b/outlines/fsm/yaml_schema.py
@@ -1,0 +1,574 @@
+import inspect
+import json
+import re
+import warnings
+from typing import Callable, Optional, Tuple
+
+import yaml
+from jsonschema.protocols import Validator
+from pydantic import create_model
+from referencing import Registry, Resource
+from referencing._core import Resolver
+from referencing.jsonschema import DRAFT202012
+
+# taken from https://github.com/yaml/pyyaml/blob/main/lib/yaml/resolver.py
+TRUE = r"(?:yes|Yes|YES|true|True|TRUE|on|On|ON)"
+FALSE = r"(?:no|No|NO|false|False|FALSE|off|Off|OFF)"
+BOOLEAN = (
+    r"(?:yes|Yes|YES|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)"
+)
+INTEGER = r"(?:[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?(?:0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)"
+NUMBER = (
+    r"(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?"
+    r"|\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?"
+    r"|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*"
+    r"|[-+]?\.(?:inf|Inf|INF)"
+    r"|\.(?:nan|NaN|NAN))"
+)
+NULL = r"(?: ~|null|Null|NULL| )"
+TIMESTAMP = (
+    r"^(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
+    r"|[0-9][0-9][0-9][0-9] -[0-9][0-9]? -[0-9][0-9]?"
+    r"(?:[Tt]|[ \t]+)[0-9][0-9]?"
+    r":[0-9][0-9] :[0-9][0-9] (?:\.[0-9]*)?"
+    r"(?:[ \t]*(?:Z|[-+][0-9][0-9]?(?::[0-9][0-9])?))?)$"
+)
+
+# allow `\"`, `\\`, or any character which isn't a control sequence
+STRING_INNER = r'([^"\\\x00-\x1F\x7F-\x9F]|\\["\\])'
+STRING = rf"(\"{STRING_INNER}*\"|'{STRING_INNER}*'|(?!{BOOLEAN}|{INTEGER}|{NUMBER}|{NULL}){STRING_INNER}*)"
+
+
+WHITESPACE = r"[ ]*"
+
+type_to_regex = {
+    "string": STRING,
+    "integer": INTEGER,
+    "number": NUMBER,
+    "boolean": BOOLEAN,
+    "null": NULL,
+}
+
+DATE_TIME = r'"(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]{3})?(Z)?"'
+DATE = r'"(?:\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])"'
+TIME = r'"(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?"'
+UUID = r'"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+
+format_to_regex = {
+    "uuid": UUID,
+    "date-time": DATE_TIME,
+    "date": DATE,
+    "time": TIME,
+}
+
+
+def build_regex_from_schema(schema: str, whitespace_pattern: Optional[str] = None):
+    """Turn a JSON schema into a regex that matches any JSON object that follows
+    this schema.
+
+    JSON Schema is a declarative language that allows to annotate JSON documents
+    with types and descriptions. These schemas can be generated from any Python
+    datastructure that has type annotation: namedtuples, dataclasses, Pydantic
+    models. And by ensuring that the generation respects the schema we ensure
+    that the output can be parsed into these objects.
+    This function parses the provided schema and builds a generation schedule which
+    mixes deterministic generation (fixed strings), and sampling with constraints.
+
+    Parameters
+    ----------
+    schema
+        A string that represents a JSON Schema.
+    whitespace_pattern
+        Pattern to use for JSON syntactic whitespace (doesn't impact string literals)
+        Example: allow only a single space or newline with `whitespace_pattern=r"[\n ]?"`
+
+    Returns
+    -------
+    A generation schedule. A list of strings that represent the JSON
+    schema's structure and regular expression that define the structure of
+    the fields.
+
+    References
+    ----------
+    .. [0] JSON Schema. https://json-schema.org/
+
+    """
+
+    schema = json.loads(schema)
+    Validator.check_schema(schema)
+
+    # Build reference resolver
+    schema = Resource(contents=schema, specification=DRAFT202012)
+    uri = schema.id() if schema.id() is not None else ""
+    registry = Registry().with_resource(uri=uri, resource=schema)
+    resolver = registry.resolver()
+
+    content = schema.contents
+    return to_regex(resolver, content, whitespace_pattern)
+
+
+def _get_num_items_pattern(min_items, max_items, whitespace_pattern):
+    # Helper function for arrays and objects
+    min_items = int(min_items or 0)
+    if max_items is None:
+        return rf"{{{max(min_items - 1, 0)},}}"
+    else:
+        max_items = int(max_items)
+        if max_items < 1:
+            return None
+        return rf"{{{max(min_items - 1, 0)},{max_items - 1}}}"
+
+
+def validate_quantifiers(
+    min_bound: Optional[str], max_bound: Optional[str], start_offset: int = 0
+) -> Tuple[str, str]:
+    """
+    Ensures that the bounds of a number are valid. Bounds are used as quantifiers in the regex.
+
+    Parameters
+    ----------
+    min_bound
+        The minimum value that the number can take.
+    max_bound
+        The maximum value that the number can take.
+    start_offset
+        Number of elements that are already present in the regex but still need to be counted.
+        ex: if the regex is already "(-)?(0|[1-9][0-9])", we will always have at least 1 digit, so the start_offset is 1.
+
+    Returns
+    -------
+    min_bound
+        The minimum value that the number can take.
+    max_bound
+        The maximum value that the number can take.
+
+    Raises
+    ------
+    ValueError
+        If the minimum bound is greater than the maximum bound.
+
+    TypeError or ValueError
+        If the minimum bound is not an integer or None.
+        or
+        If the maximum bound is not an integer or None.
+    """
+    min_bound = "" if min_bound is None else str(int(min_bound) - start_offset)
+    max_bound = "" if max_bound is None else str(int(max_bound) - start_offset)
+    if min_bound and max_bound:
+        if int(max_bound) < int(min_bound):
+            raise ValueError("max bound must be greater than or equal to min bound")
+    return min_bound, max_bound
+
+
+def to_regex(
+    resolver: Resolver, instance: dict, whitespace_pattern: Optional[str] = None
+):
+    """Translate a JSON Schema instance into a regex that validates the schema.
+
+    Note
+    ----
+    Many features of JSON schema are missing:
+    - Handle `additionalProperties` keyword
+    - Handle types defined as a list
+    - Handle constraints on numbers
+    - Handle special patterns: `date`, `uri`, etc.
+
+    This does not support recursive definitions.
+
+    Parameters
+    ----------
+    resolver
+        An object that resolves references to other instances within a schema
+    instance
+        The instance to translate
+    whitespace_pattern
+        Pattern to use for JSON syntactic whitespace (doesn't impact string literals)
+        Example: allow only a single space or newline with `whitespace_pattern=r"[\n ]?"`
+    """
+
+    # set whitespace pattern
+    if whitespace_pattern is None:
+        whitespace_pattern = WHITESPACE
+
+    if instance == {}:
+        # JSON Schema Spec: Empty object means unconstrained, any json type is legal
+        types = [
+            {"type": "boolean"},
+            {"type": "null"},
+            {"type": "number"},
+            {"type": "integer"},
+            {"type": "string"},
+            {"type": "array"},
+            {"type": "object"},
+        ]
+        regexes = [to_regex(resolver, t, whitespace_pattern) for t in types]
+        regexes = [rf"({r})" for r in regexes]
+        return rf"{'|'.join(regexes)}"
+
+    elif "properties" in instance:
+        regex = ""
+        properties = instance["properties"]
+        required_properties = instance.get("required", [])
+        is_required = [item in required_properties for item in properties]
+        print(instance)
+        # If at least one property is required, we include the one in the lastest position
+        # without any comma.
+        # For each property before it (optional or required), we add with a comma after the property.
+        # For each property after it (optional), we add with a comma before the property.
+        if any(is_required):
+            last_required_pos = max([i for i, value in enumerate(is_required) if value])
+            for i, (name, value) in enumerate(properties.items()):
+                subregex = f"{whitespace_pattern}{re.escape(name)}:"
+                if value.get("type") == "object":
+                    subregex += r"( \{{\}}|\n"
+                elif value.get("$ref") is not None:
+                    # exception, we might refer to an object or something else
+                    pass
+                else:
+                    subregex += whitespace_pattern
+                subregex += to_regex(resolver, value, whitespace_pattern)
+                if i < last_required_pos:
+                    subregex = rf"{subregex}\n"
+                elif i > last_required_pos:
+                    subregex = rf"\n{subregex}"
+                if value.get("type") == "object":
+                    subregex += r")"
+                regex += subregex if is_required[i] else f"({subregex})?"
+
+        # If no property is required, we have to create a possible pattern for each property in which
+        # it's the last one necessarilly present. Then, we add the others as optional before and after
+        # following the same strategy as described above.
+        # The whole block is made optional to allow the case in which no property is returned.
+        else:
+            property_subregexes = []
+            for i, (name, value) in enumerate(properties.items()):
+                subregex = rf"{whitespace_pattern}{name}:"
+                if value.get("type") == "object":
+                    subregex += r"( \{\}|\n"
+                elif value.get("$ref") is not None:
+                    # exception, we might refer to an object or something else
+                    pass
+                else:
+                    subregex += whitespace_pattern
+                subregex += to_regex(resolver, value, whitespace_pattern)
+                if value.get("type") == "object":
+                    subregex += r")"
+                property_subregexes.append(subregex)
+            possible_patterns = []
+            for i in range(len(property_subregexes)):
+                pattern = ""
+                for subregex in property_subregexes[:i]:
+                    pattern += rf"({subregex}\n)?"
+                pattern += property_subregexes[i]
+                for subregex in property_subregexes[i + 1 :]:
+                    pattern += rf"(\n{subregex})?"
+                possible_patterns.append(pattern)
+            regex += rf"({'|'.join(possible_patterns)})?"
+
+        regex += rf"{whitespace_pattern}"
+
+        return regex
+
+    # To validate against allOf, the given data must be valid against all of the
+    # given subschemas.
+    elif "allOf" in instance:
+        subregexes = [
+            to_regex(resolver, t, whitespace_pattern) for t in instance["allOf"]
+        ]
+        subregexes_str = [f"{subregex}" for subregex in subregexes]
+        return rf"({''.join(subregexes_str)})"
+
+    # To validate against `anyOf`, the given data must be valid against
+    # any (one or more) of the given subschemas.
+    elif "anyOf" in instance:
+        subregexes = [
+            to_regex(resolver, t, whitespace_pattern) for t in instance["anyOf"]
+        ]
+        return rf"({'|'.join(subregexes)})"
+
+    # To validate against oneOf, the given data must be valid against exactly
+    # one of the given subschemas.
+    elif "oneOf" in instance:
+        subregexes = [
+            to_regex(resolver, t, whitespace_pattern) for t in instance["oneOf"]
+        ]
+
+        xor_patterns = [f"(?:{subregex})" for subregex in subregexes]
+
+        return rf"({'|'.join(xor_patterns)})"
+
+    # Create pattern for Tuples, per JSON Schema spec, `prefixItems` determines types at each idx
+    elif "prefixItems" in instance:
+        element_patterns = [
+            to_regex(resolver, t, whitespace_pattern) for t in instance["prefixItems"]
+        ]
+        split_pattern = rf"\n-{whitespace_pattern}"
+        tuple_inner = split_pattern.join(element_patterns)
+        return rf"-{whitespace_pattern}{tuple_inner}"
+
+    # The enum keyword is used to restrict a value to a fixed set of values. It
+    # must be an array with at least one element, where each element is unique.
+    elif "enum" in instance:
+        choices = []
+        for choice in instance["enum"]:
+            if isinstance(choice, bool):
+                if choice is True:
+                    choices.append(TRUE)
+                else:
+                    choices.append(FALSE)
+            elif isinstance(choice, type(None)) and choice is None:
+                choices.append(NULL)
+            elif type(choice) in [int, float, str]:
+                choices.append(
+                    re.escape(yaml.dump(choice).strip().removesuffix("...").strip())
+                )
+            else:
+                raise TypeError(f"Unsupported data type in enum: {type(choice)}")
+        return f"({'|'.join(choices)})"
+
+    elif "const" in instance:
+        const = instance["const"]
+        if isinstance(const, bool):
+            if const is True:
+                return TRUE
+            else:
+                return FALSE
+        elif isinstance(const, type(None)):
+            return NULL
+        elif type(const) in [int, float, str]:
+            const = re.escape(yaml.dump(const).strip().removesuffix("...").strip())
+        else:
+            raise TypeError(f"Unsupported data type in const: {type(const)}")
+        return const
+
+    elif "$ref" in instance:
+        path = f"{instance['$ref']}"
+        instance = resolver.lookup(path).contents
+        if instance.get("type") == "object":
+            subregex = r"\n"
+        else:
+            subregex = whitespace_pattern
+        subregex += to_regex(resolver, instance, whitespace_pattern)
+        print(subregex)
+        return subregex
+
+    # The type keyword may either be a string or an array:
+    # - If it's a string, it is the name of one of the basic types.
+    # - If it is an array, it must be an array of strings, where each string is
+    # the name of one of the basic types, and each element is unique. In this
+    # case, the JSON snippet is valid if it matches any of the given types.
+    elif "type" in instance:
+        instance_type = instance["type"]
+        if instance_type == "string":
+            if "maxLength" in instance or "minLength" in instance:
+                max_items = instance.get("maxLength", "")
+                min_items = instance.get("minLength", "")
+                try:
+                    if int(max_items) < int(min_items):
+                        raise ValueError(
+                            "maxLength must be greater than or equal to minLength"
+                        )  # FIXME this raises an error but is caught right away by the except (meant for int("") I assume)
+                except ValueError:
+                    pass
+                return f'"{STRING_INNER}{{{min_items},{max_items}}}"'
+            elif "pattern" in instance:
+                pattern = instance["pattern"]
+                if pattern[0] == "^" and pattern[-1] == "$":
+                    return rf'("{pattern[1:-1]}")'
+                else:
+                    return rf'("{pattern}")'
+            elif "format" in instance:
+                format = instance["format"]
+                if format == "date-time":
+                    return format_to_regex["date-time"]
+                elif format == "uuid":
+                    return format_to_regex["uuid"]
+                elif format == "date":
+                    return format_to_regex["date"]
+                elif format == "time":
+                    return format_to_regex["time"]
+                else:
+                    raise NotImplementedError(
+                        f"Format {format} is not supported by Outlines"
+                    )
+            else:
+                return type_to_regex["string"]
+
+        elif instance_type == "number":
+            bounds = {
+                "minDigitsInteger",
+                "maxDigitsInteger",
+                "minDigitsFraction",
+                "maxDigitsFraction",
+                "minDigitsExponent",
+                "maxDigitsExponent",
+            }
+            if bounds.intersection(set(instance.keys())):
+                min_digits_integer, max_digits_integer = validate_quantifiers(
+                    instance.get("minDigitsInteger"),
+                    instance.get("maxDigitsInteger"),
+                    start_offset=1,
+                )
+                min_digits_fraction, max_digits_fraction = validate_quantifiers(
+                    instance.get("minDigitsFraction"), instance.get("maxDigitsFraction")
+                )
+                min_digits_exponent, max_digits_exponent = validate_quantifiers(
+                    instance.get("minDigitsExponent"), instance.get("maxDigitsExponent")
+                )
+                integers_quantifier = (
+                    f"{{{min_digits_integer},{max_digits_integer}}}"
+                    if min_digits_integer or max_digits_integer
+                    else "*"
+                )
+                fraction_quantifier = (
+                    f"{{{min_digits_fraction},{max_digits_fraction}}}"
+                    if min_digits_fraction or max_digits_fraction
+                    else "+"
+                )
+                exponent_quantifier = (
+                    f"{{{min_digits_exponent},{max_digits_exponent}}}"
+                    if min_digits_exponent or max_digits_exponent
+                    else "+"
+                )
+                return rf"((-)?(0|[1-9][0-9]{integers_quantifier}))(\.[0-9]{fraction_quantifier})?([eE][+-][0-9]{exponent_quantifier})?"
+            return type_to_regex["number"]
+
+        elif instance_type == "integer":
+            if "minDigits" in instance or "maxDigits" in instance:
+                min_digits, max_digits = validate_quantifiers(
+                    instance.get("minDigits"), instance.get("maxDigits"), start_offset=1
+                )
+                return rf"(-)?(0|[1-9][0-9]{{{min_digits},{max_digits}}})"
+            return type_to_regex["integer"]
+
+        elif instance_type == "array":
+            num_repeats = _get_num_items_pattern(
+                instance.get("minItems"), instance.get("maxItems"), whitespace_pattern
+            )
+            if num_repeats is None:
+                return rf"\[{whitespace_pattern}\]"
+
+            allow_empty = "?" if int(instance.get("minItems", 0)) == 0 else ""
+
+            if "items" in instance:
+                items_regex = to_regex(resolver, instance["items"], whitespace_pattern)
+                return rf"-{whitespace_pattern}(({items_regex})(\n-{whitespace_pattern}({items_regex})){num_repeats}){allow_empty}{whitespace_pattern}"
+            else:
+                # Here we need to make the choice to exclude generating list of objects
+                # if the specification of the object is not given, even though a JSON
+                # object that contains an object here would be valid under the specification.
+                legal_types = [
+                    {"type": "boolean"},
+                    {"type": "null"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "string"},
+                ]
+                depth = instance.get("depth", 2)
+                if depth > 0:
+                    legal_types.append({"type": "object", "depth": depth - 1})
+                    legal_types.append({"type": "array", "depth": depth - 1})
+
+                regexes = [
+                    to_regex(resolver, t, whitespace_pattern) for t in legal_types
+                ]
+                return rf"{whitespace_pattern}({'|'.join(regexes)})(,{whitespace_pattern}({'|'.join(regexes)})){num_repeats}{allow_empty}{whitespace_pattern}"
+
+        elif instance_type == "object":
+            # pattern for json object with values defined by instance["additionalProperties"]
+            # enforces value type constraints recursively, "minProperties", and "maxProperties"
+            # doesn't enforce "required", "dependencies", "propertyNames" "any/all/on Of"
+            num_repeats = _get_num_items_pattern(
+                instance.get("minProperties"),
+                instance.get("maxProperties"),
+                whitespace_pattern,
+            )
+            if num_repeats is None:
+                return whitespace_pattern
+
+            allow_empty = "?" if int(instance.get("minProperties", 0)) == 0 else ""
+
+            additional_properties = instance.get("additionalProperties")
+            print(additional_properties)
+
+            if additional_properties is None or additional_properties is True:
+                # JSON Schema behavior: If the additionalProperties of an object is
+                # unset or True, it is unconstrained object.
+                # We handle this by setting additionalProperties to anyOf: {all types}
+
+                legal_types = [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "boolean"},
+                    {"type": "null"},
+                ]
+
+                # We set the object depth to 2 to keep the expression finite, but the "depth"
+                # key is not a true component of the JSON Schema specification.
+                depth = instance.get("depth", 2)
+                if depth > 0:
+                    legal_types.append({"type": "object", "depth": depth - 1})
+                    legal_types.append({"type": "array", "depth": depth - 1})
+                additional_properties = {"anyOf": legal_types}
+            value_pattern = to_regex(
+                resolver, additional_properties, whitespace_pattern
+            )
+            if additional_properties.get("type") == "object":
+                key_value_pattern = rf"{STRING}:( \{{\}}|\n{value_pattern})"
+            else:
+                key_value_pattern = f"{STRING}:{whitespace_pattern}{value_pattern}"
+            key_value_successor_pattern = rf"\n{whitespace_pattern}{key_value_pattern}"
+            multiple_key_value_pattern = f"({key_value_pattern}({key_value_successor_pattern}){num_repeats}){allow_empty}"
+
+            return whitespace_pattern + multiple_key_value_pattern + whitespace_pattern
+
+        elif instance_type == "boolean":
+            return type_to_regex["boolean"]
+
+        elif instance_type == "null":
+            return type_to_regex["null"]
+
+        elif isinstance(instance_type, list):
+            # Here we need to make the choice to exclude generating an object
+            # if the specification of the object is not give, even though a JSON
+            # object that contains an object here would be valid under the specification.
+            regexes = [
+                to_regex(resolver, {"type": t}, whitespace_pattern)
+                for t in instance_type
+                if t != "object"
+            ]
+            return rf"({'|'.join(regexes)})"
+
+    raise NotImplementedError(
+        f"""Could not translate the instance {instance} to a
+    regular expression. Make sure it is valid to the JSON Schema specification. If
+    it is, please open an issue on the Outlines repository"""
+    )
+
+
+def get_schema_from_signature(fn: Callable) -> str:
+    """Turn a function signature into a JSON schema.
+
+    Every JSON object valid to the output JSON Schema can be passed
+    to `fn` using the ** unpacking syntax.
+
+    """
+    signature = inspect.signature(fn)
+    arguments = {}
+    for name, arg in signature.parameters.items():
+        if arg.annotation == inspect._empty:
+            raise ValueError("Each argument must have a type annotation")
+        else:
+            arguments[name] = (arg.annotation, ...)
+
+    try:
+        fn_name = fn.__name__
+    except Exception as e:
+        fn_name = "Arguments"
+        warnings.warn(
+            f"The function name could not be determined. Using default name 'Arguments' instead. For debugging, here is exact error:\n{e}",
+            category=UserWarning,
+        )
+    model = create_model(fn_name, **arguments)
+
+    return model.model_json_schema()

--- a/tests/fsm/test_yaml_schema.py
+++ b/tests/fsm/test_yaml_schema.py
@@ -1,0 +1,762 @@
+import json
+import re
+
+import interegular
+import pytest
+from pydantic import BaseModel, constr
+
+from outlines.fsm.yaml_schema import (
+    BOOLEAN,
+    INTEGER,
+    NULL,
+    NUMBER,
+    STRING,
+    STRING_INNER,
+    TRUE,
+    WHITESPACE,
+    build_regex_from_schema,
+    to_regex,
+)
+
+
+def test_from_pydantic():
+    class User(BaseModel):
+        user_id: int
+        name: str
+        maxlength_name: constr(max_length=10)
+        minlength_name: constr(min_length=10)
+        value: float
+        is_true: bool
+
+    schema = json.dumps(User.model_json_schema(), sort_keys=False)
+    schedule = build_regex_from_schema(schema)
+    assert isinstance(schedule, str)
+
+
+@pytest.mark.parametrize(
+    "pattern,does_match",
+    [
+        ({"integer": "0"}, True),
+        ({"integer": "1"}, True),
+        ({"integer": "-1"}, True),
+        ({"integer": "01"}, True),
+        ({"integer": "1.3"}, False),
+        ({"integer": "t"}, False),
+    ],
+)
+def test_match_integer(pattern, does_match):
+    step = {"title": "Foo", "type": "integer"}
+    regex = to_regex(None, step)
+    assert regex == INTEGER
+
+    value = pattern["integer"]
+    match = re.fullmatch(regex, value)
+    if does_match:
+        assert match[0] == value
+        assert match.span() == (0, len(value))
+    else:
+        assert match is None
+
+
+@pytest.mark.parametrize(
+    "schema,regex,examples",
+    [
+        # String
+        (
+            {"title": "Foo", "type": "string"},
+            STRING,
+            [
+                ("unquotedstring", True),
+                ("(parenthesized_string)", True),
+                ("malformed) parenthesis (((() string", True),
+                ('"quoted_string"', True),
+                (r'"escape_\character"', False),
+                (r'"double_\\escape"', True),
+                (r'"\n"', False),
+                (r'"\\n"', True),
+                (r'"unescaped " quote"', False),
+                (r'"escaped \" quote"', True),
+                # unquoted other dtypes
+                ("yes", False),
+                ("NO", False),
+                ("TRUE", False),
+                ("false", False),
+                ("ON", False),
+                ("off", False),
+                ("null", False),
+                (" ~", False),
+                ("1", False),
+                ("123.456", False),
+                ("1e-9", False),
+                # quoted other dtypes
+                ('"yes"', True),
+                ('"NO"', True),
+                ('"TRUE"', True),
+                ('"false"', True),
+                ('"ON"', True),
+                ('"off"', True),
+                ('"null"', True),
+                ('" ~"', True),
+                ('"1"', True),
+                ('"123.456"', True),
+                ('"1e-9"', True),
+            ],
+        ),
+        # String with maximum length
+        (
+            {"title": "Foo", "type": "string", "maxLength": 3},
+            f'"{STRING_INNER}{{,3}}"',
+            [('"ab"', True), ('"a""', False), ('"abcd"', False)],
+        ),
+        # String with minimum length
+        (
+            {"title": "Foo", "type": "string", "minLength": 3},
+            f'"{STRING_INNER}{{3,}}"',
+            [('"ab"', False), ('"abcd"', True), ('"abc""', False)],
+        ),
+        # String with both minimum and maximum length
+        (
+            {"title": "Foo", "type": "string", "minLength": 3, "maxLength": 5},
+            f'"{STRING_INNER}{{3,5}}"',
+            [('"ab"', False), ('"abcd"', True), ('"abcdef""', False)],
+        ),
+        # String defined by a regular expression
+        (
+            {"title": "Foo", "type": "string", "pattern": r"^[a-z]$"},
+            r'("[a-z]")',
+            [('"a"', True), ('"1"', False)],
+        ),
+        # Boolean
+        (
+            {"title": "Foo", "type": "boolean"},
+            BOOLEAN,
+            [
+                ("true", True),
+                ("false", True),
+                ("True", True),
+                ("yes", True),
+                ("NO", True),
+                ("on", True),
+                ("Off", True),
+                ("null", False),
+                ("0", False),
+            ],
+        ),
+        # Null
+        (
+            {"title": "Foo", "type": "null"},
+            NULL,
+            [
+                ("null", True),
+                ("NULL", True),
+                (" ~", True),
+                (" ", True),
+                ("true", False),
+                ("0", False),
+            ],
+        ),
+        # Const string
+        (
+            {"title": "Foo", "const": "Marc", "type": "string"},
+            "Marc",
+            [("Marc", True), ('"Marc"', False), ("Jean", False), ("John", False)],
+        ),
+        # Make sure strings are escaped with regex escaping
+        (
+            {"title": "Foo", "const": ".*", "type": "string"},
+            r"\.\*",
+            [(".*", True), (r"\s*", False), (r"\.\*", False)],
+        ),
+        # Make sure strings are escaped with JSON escaping
+        (
+            {"title": "Foo", "const": '"', "type": "string"},
+            "'\"'",
+            [("'\"'", True), ('"', False), ("'", False)],
+        ),
+        # Const integer
+        (
+            {"title": "Foo", "const": 0, "type": "integer"},
+            "0",
+            [("0", True), ("1", False), ("a", False)],
+        ),
+        # Const float
+        (
+            {"title": "Foo", "const": 0.2, "type": "float"},
+            r"0\.2",
+            [("0.2", True), ("032", False)],
+        ),
+        # Const boolean
+        (
+            {"title": "Foo", "const": True, "type": "boolean"},
+            TRUE,
+            [
+                ("true", True),
+                ("True", True),
+                ("TRue", False),
+                ("TRUE", True),
+                ("1", False),
+            ],
+        ),
+        # Const null
+        (
+            {"title": "Foo", "const": None, "type": "null"},
+            NULL,
+            [("null", True), ("None", False), ("", False)],
+        ),
+        # Enum string
+        (
+            {"title": "Foo", "enum": ["Marc", "Jean"], "type": "string"},
+            "(Marc|Jean)",
+            [("Marc", True), ("Jean", True), ("John", False)],
+        ),
+        # Enum integer
+        (
+            {"title": "Foo", "enum": [0, 1], "type": "integer"},
+            "(0|1)",
+            [("0", True), ("1", True), ("a", False)],
+        ),
+        # Enum mix of types
+        (
+            {"title": "Foo", "enum": [6, 5.3, "potato", True, None]},
+            rf"(6|5\.3|potato|{TRUE}|{NULL})",
+            [
+                ("6", True),
+                ("5.3", True),
+                ("potato", True),
+                ("true", True),
+                ("null", True),
+                ("523", False),
+                ("True", True),
+                ("None", False),
+                ("TRue", False),
+                ('"potato"', False),
+            ],
+        ),
+        # integer
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {"count": {"title": "Count", "type": "integer"}},
+                "required": ["count"],
+            },
+            f"{WHITESPACE}count:{WHITESPACE}{INTEGER}{WHITESPACE}",
+            [("count: 100", True)],
+        ),
+        # integer with minimum digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {"title": "Count", "type": "integer", "minDigits": 3}
+                },
+                "required": ["count"],
+            },
+            # logic for integers with minimum digits hardcoded
+            f"{WHITESPACE}count:{WHITESPACE}(-)?(0|[1-9][0-9]{{2,}}){WHITESPACE}",
+            [("count: 10", False), ("count: 100", True)],
+        ),
+        # integer with maximum digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {"title": "Count", "type": "integer", "maxDigits": 3}
+                },
+                "required": ["count"],
+            },
+            # logic for integers with maximum digits hardcoded
+            f"{WHITESPACE}count:{WHITESPACE}(-)?(0|[1-9][0-9]{{,2}}){WHITESPACE}",
+            [("count: 100", True), ("count: 1000", False)],
+        ),
+        # integer with minimum and maximum digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "title": "Count",
+                        "type": "integer",
+                        "minDigits": 3,
+                        "maxDigits": 5,
+                    }
+                },
+                "required": ["count"],
+            },
+            # logic for integers with minimum and maximum digits hardcoded
+            f"{WHITESPACE}count:{WHITESPACE}(-)?(0|[1-9][0-9]{{2,4}}){WHITESPACE}",
+            [
+                ("count: 10", False),
+                ("count: 100", True),
+                ("count: 10000", True),
+                ("count: 100000", False),
+            ],
+        ),
+        # number
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {"count": {"title": "Count", "type": "number"}},
+                "required": ["count"],
+            },
+            rf"{WHITESPACE}count:{WHITESPACE}{NUMBER}{WHITESPACE}",
+            [
+                # integers are not included in number regex
+                ("count: 100", False),
+                ("count: 100.5", True),
+            ],
+        ),
+        # number with min and max integer digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "title": "Count",
+                        "type": "number",
+                        "minDigitsInteger": 3,
+                        "maxDigitsInteger": 5,
+                    }
+                },
+                "required": ["count"],
+            },
+            f"{WHITESPACE}count:{WHITESPACE}((-)?(0|[1-9][0-9]{{2,4}}))(\\.[0-9]+)?([eE][+-][0-9]+)?{WHITESPACE}",
+            [
+                ("count: 10.005", False),
+                ("count: 100.005", True),
+                ("count: 10000.005", True),
+                ("count: 100000.005", False),
+            ],
+        ),
+        # number with min and max fraction digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "title": "Count",
+                        "type": "number",
+                        "minDigitsFraction": 3,
+                        "maxDigitsFraction": 5,
+                    }
+                },
+                "required": ["count"],
+            },
+            f"{WHITESPACE}count:{WHITESPACE}((-)?(0|[1-9][0-9]*))(\\.[0-9]{{3,5}})?([eE][+-][0-9]+)?{WHITESPACE}",
+            [
+                ("count: 1.05", False),
+                ("count: 1.005", True),
+                ("count: 1.00005", True),
+                ("count: 1.000005", False),
+            ],
+        ),
+        # number with min and max exponent digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "title": "Count",
+                        "type": "number",
+                        "minDigitsExponent": 3,
+                        "maxDigitsExponent": 5,
+                    }
+                },
+                "required": ["count"],
+            },
+            f"{WHITESPACE}count:{WHITESPACE}((-)?(0|[1-9][0-9]*))(\\.[0-9]+)?([eE][+-][0-9]{{3,5}})?{WHITESPACE}",
+            [
+                ("count: 1.05e1", False),
+                ("count: 1.05e+001", True),
+                ("count: 1.05e-00001", True),
+                ("count: 1.05e0000001", False),
+            ],
+        ),
+        # number with min and max integer, fraction and exponent digits
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "title": "Count",
+                        "type": "number",
+                        "minDigitsInteger": 3,
+                        "maxDigitsInteger": 5,
+                        "minDigitsFraction": 3,
+                        "maxDigitsFraction": 5,
+                        "minDigitsExponent": 3,
+                        "maxDigitsExponent": 5,
+                    }
+                },
+                "required": ["count"],
+            },
+            f"{WHITESPACE}count:{WHITESPACE}((-)?(0|[1-9][0-9]{{2,4}}))(\\.[0-9]{{3,5}})?([eE][+-][0-9]{{3,5}})?{WHITESPACE}",
+            [
+                ("count: 1.05e1", False),
+                ("count: 100.005e+001", True),
+                ("count: 10000.00005e-00001", True),
+                ("count: 100000.000005e0000001", False),
+            ],
+        ),
+        # # array
+        # (
+        #     {"title": "Foo", "type": "array", "items": {"type": "number"}},
+        #     rf"-{WHITESPACE}(({NUMBER})(\n-{WHITESPACE}({NUMBER})){{0,}})?{WHITESPACE}",
+        #     [("- 1e+9\n- 1.3", True), ("[]", True), ("[1", False)],
+        # ),
+        # array with a set length of 1
+        (
+            {
+                "title": "Foo",
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 1,
+                "maxItems": 1,
+            },
+            rf"-{WHITESPACE}(({INTEGER})(\n-{WHITESPACE}({INTEGER})){{0,0}}){WHITESPACE}",
+            [("- 1", True), ("- 1\n- 2", False), ("- a", False), ("[]", False)],
+        ),
+        # array with a set length greather than 1
+        (
+            {
+                "title": "Foo",
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 3,
+                "maxItems": 3,
+            },
+            rf"-{WHITESPACE}(({INTEGER})(\n-{WHITESPACE}({INTEGER})){{2,2}}){WHITESPACE}",
+            [
+                ("- 1", False),
+                ("[]", False),
+                ("- 1\n- 2\n- 3", True),
+                ("- 1\n- 2\n- 3\n- 4", False),
+            ],
+        ),
+        # array with length 0
+        (
+            {
+                "title": "Foo",
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 0,
+                "maxItems": 0,
+            },
+            rf"\[{WHITESPACE}\]",
+            [
+                ("- 1", False),
+                ("[]", True),
+                ("- 1\n- 2\n- 3", False),
+                ("- 1\n- 2\n- 3\n- 4", False),
+            ],
+        ),
+        # object
+        (
+            {
+                "title": "TestSchema",
+                "type": "object",
+                "properties": {
+                    "test_dict": {
+                        "title": "Test Dict",
+                        "additionalProperties": {"type": "string"},
+                        "type": "object",
+                    }
+                },
+                "required": ["test_dict"],
+            },
+            rf"{WHITESPACE}test_dict:( \{{\}}|\n{WHITESPACE}({STRING}:{WHITESPACE}{STRING}(\n{WHITESPACE}{STRING}:{WHITESPACE}{STRING}){{0,}})?{WHITESPACE}){WHITESPACE}",
+            [
+                ("test_dict:\n  foo:  bar\n baz: bif", True),
+                ("test_dict:\n  foo:  bar", True),
+                ("test_dict: {}", True),
+                ("WRONG_KEY: {}", False),
+                ("test_dict:\n  wrong_type: 1", False),
+            ],
+        ),
+        # # object containing object
+        # (
+        #     {
+        #         "title": "TestSchema",
+        #         "type": "object",
+        #         "properties": {
+        #             "test_dict": {
+        #                 "title": "Test Dict",
+        #                 "additionalProperties": {
+        #                     "additionalProperties": {"type": "integer"},
+        #                     "type": "object",
+        #                 },
+        #                 "type": "object",
+        #             }
+        #         },
+        #         "required": ["test_dict"],
+        #     },
+        #     rf"{WHITESPACE}test_dict:( \{{\}}|\n{WHITESPACE}({STRING}:( \{{\}}|\n{WHITESPACE}({STRING}:{WHITESPACE}{INTEGER}(\n{WHITESPACE}{STRING}:{WHITESPACE}{INTEGER}){{0,}})?{WHITESPACE})(\n{WHITESPACE}({STRING}:( \{{\}}|\n{WHITESPACE}({STRING}:{WHITESPACE}{INTEGER}(\n{WHITESPACE}{STRING}:{WHITESPACE}{INTEGER}){{0,}})?{WHITESPACE})){{0,}})?{WHITESPACE}){WHITESPACE}",
+        #     [
+        #         (
+        #             """{"test_dict": {"foo": {"bar": 123, "apple": 99}, "baz": {"bif": 456}}}""",
+        #             True,
+        #         ),
+        #         (
+        #             """{"test_dict": {"anykey": {"anykey": 123}, "anykey2": {"bif": 456}}}""",
+        #             True,
+        #         ),
+        #         ("""{"test_dict": {}}""", True),
+        #         ("""{"test_dict": {"dict of empty dicts are ok": {} }}""", True),
+        #         (
+        #             """{"test_dict": {"anykey": {"ONLY Dict[Dict]": 123}, "No Dict[int]" 1: }}""",
+        #             False,
+        #         ),
+        #     ],
+        # ),
+        # oneOf
+        (
+            {
+                "title": "Foo",
+                "oneOf": [{"type": "string"}, {"type": "number"}, {"type": "boolean"}],
+            },
+            rf"((?:{STRING})|(?:{NUMBER})|(?:{BOOLEAN}))",
+            [
+                ("12.3", True),
+                ("true", True),
+                ("a", True),
+                ("null", False),
+                ("12true", False),
+                ('1.3"a"', False),
+                ('12.3true"a"', False),
+            ],
+        ),
+        # anyOf
+        (
+            {
+                "title": "Foo",
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+            },
+            rf"({STRING}|{INTEGER})",
+            [("12", True), ('"a"', True), ('1"a"', False)],
+        ),
+        # allOf
+        (
+            {
+                "title": "Foo",
+                "allOf": [{"type": "string"}, {"type": "integer"}],
+            },
+            rf"({STRING}{INTEGER})",
+            [('"a"1', True), ('"a"', False), ('"1"', False)],
+        ),
+        # Tuple / prefixItems
+        (
+            {
+                "title": "Foo",
+                "prefixItems": [{"type": "string"}, {"type": "integer"}],
+            },
+            rf"-{WHITESPACE}{STRING}\n-{WHITESPACE}{INTEGER}",
+            [("- a\n- 1", True), ("- a\n- 1\n-  1", False), ("[]", False)],
+        ),
+        # Nested schema
+        (
+            {
+                "title": "Bar",
+                "type": "object",
+                "properties": {
+                    "fuzz": {
+                        "title": "Foo",
+                        "type": "object",
+                        "properties": {"spam": {"title": "Spam", "type": "integer"}},
+                        "required": ["spam"],
+                    }
+                },
+                "required": ["fuzz"],
+            },
+            rf"{WHITESPACE}fuzz:( \{{\}}|\n{WHITESPACE}spam:{WHITESPACE}{INTEGER}{WHITESPACE}){WHITESPACE}",
+            [("fuzz:\n  spam: 100", True)],
+        ),
+        # Schema with a reference
+        (
+            {
+                "title": "User",
+                "type": "object",
+                "properties": {
+                    "user_id": {"title": "User Id", "type": "integer"},
+                    "name": {"title": "Name", "type": "string"},
+                    "a": {"$ref": "#/properties/name"},
+                },
+                "required": ["user_id", "name", "a"],
+            },
+            rf"{WHITESPACE}user_id:{WHITESPACE}{INTEGER}\n{WHITESPACE}name:{WHITESPACE}{STRING}\n{WHITESPACE}a:{WHITESPACE}{STRING}{WHITESPACE}",
+            [("user_id: 100\nname: John\na: Marc", True)],
+        ),
+        (
+            {
+                "title": "User",
+                "type": "object",
+                "$defs": {"name": {"title": "Name2", "type": "string"}},
+                "properties": {
+                    "user_id": {"title": "User Id", "type": "integer"},
+                    "name": {"title": "Name", "type": "string"},
+                    "name2": {"$ref": "#/$defs/name"},
+                },
+                "required": ["user_id", "name", "name2"],
+            },
+            rf"{WHITESPACE}user_id:{WHITESPACE}{INTEGER}\n{WHITESPACE}name:{WHITESPACE}{STRING}\n{WHITESPACE}name2:{WHITESPACE}{STRING}{WHITESPACE}",
+            [("user_id: 100\nname: John\nname2: Marc", True)],
+        ),
+        (
+            {
+                "$id": "customer",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "title": "Customer",
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "last_name": {"type": "string"},
+                    "address": {"$ref": "customer#/$defs/address"},
+                },
+                "required": [
+                    "name",
+                    "first_name",
+                    "last_name",
+                    "address",
+                    "shipping_address",
+                    "billing_address",
+                ],
+                "$defs": {
+                    "address": {
+                        "title": "Address",
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                        },
+                        "required": ["street_address", "city", "state"],
+                        "definitions": {
+                            "state": {
+                                "type": "object",
+                                "title": "State",
+                                "properties": {"name": {"type": "string"}},
+                                "required": ["name"],
+                            }
+                        },
+                    }
+                },
+            },
+            rf"{WHITESPACE}name:{WHITESPACE}{STRING}\n{WHITESPACE}last_name:{WHITESPACE}{STRING}\n{WHITESPACE}address:\n{WHITESPACE}city:{WHITESPACE}{STRING}{WHITESPACE}{WHITESPACE}",
+            [
+                (
+                    "name: John\nlast_name: Doe\naddress:\n  city: Paris",
+                    True,
+                )
+            ],
+        ),
+        # Optional properties
+        # Last required property in first position
+        (
+            {
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                    "weapon": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+                "required": ["name"],
+                "title": "Character",
+                "type": "object",
+            },
+            rf"{WHITESPACE}name:{WHITESPACE}{STRING}(\n{WHITESPACE}age:{WHITESPACE}({INTEGER}|{NULL}))?(\n{WHITESPACE}weapon:{WHITESPACE}({STRING}|{NULL}))?{WHITESPACE}",
+            [
+                ("name: Player", True),
+                ("name: Player\nweapon: sword", True),
+                ("age: 10\nweapon: sword", False),
+            ],
+        ),
+        # Last required property in middle position
+        (
+            {
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                    "weapon": {"type": "string"},
+                    "strength": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                },
+                "required": ["name", "weapon"],
+                "title": "Character",
+                "type": "object",
+            },
+            rf"{WHITESPACE}name:{WHITESPACE}{STRING}\n({WHITESPACE}age:{WHITESPACE}({INTEGER}|{NULL})\n)?{WHITESPACE}weapon:{WHITESPACE}{STRING}(\n{WHITESPACE}strength:{WHITESPACE}({INTEGER}|{NULL}))?{WHITESPACE}",
+            [
+                ("name: Player\nweapon: sword", True),
+                (
+                    "name: Player\nage: 10\nweapon: sword\nstrength: 10",
+                    True,
+                ),
+                ("weapon: sword", False),
+            ],
+        ),
+        # Last required property in last position
+        (
+            {
+                "properties": {
+                    "name": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "age": {"type": "integer"},
+                    "armor": {"type": "string"},
+                    "strength": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                    "weapon": {"title": "Weapon", "type": "string"},
+                },
+                "required": ["age", "armor", "weapon"],
+                "title": "Character",
+                "type": "object",
+            },
+            rf"({WHITESPACE}name:{WHITESPACE}({STRING}|{NULL})\n)?{WHITESPACE}age:{WHITESPACE}{INTEGER}\n{WHITESPACE}armor:{WHITESPACE}{STRING}\n({WHITESPACE}strength:{WHITESPACE}({INTEGER}|{NULL})\n)?{WHITESPACE}weapon:{WHITESPACE}{STRING}{WHITESPACE}",
+            [
+                (
+                    "name: Player\n age: 10\narmor: plate\nstrength: 11\nweapon: sword",
+                    True,
+                ),
+                ("age: 10\n armor: plate\nweapon: sword", True),
+                ("name: Kahlhanbeh\narmor: plate\nweapon: sword", False),
+            ],
+        ),
+        # All properties are optional
+        (
+            {
+                "properties": {
+                    "name": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "age": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                    "strength": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                },
+                "title": "Character",
+                "type": "object",
+            },
+            rf"({WHITESPACE}name:{WHITESPACE}({STRING}|{NULL})(\n{WHITESPACE}age:{WHITESPACE}({INTEGER}|{NULL}))?(\n{WHITESPACE}strength:{WHITESPACE}({INTEGER}|{NULL}))?|({WHITESPACE}name:{WHITESPACE}({STRING}|{NULL})\n)?{WHITESPACE}age:{WHITESPACE}({INTEGER}|{NULL})(\n{WHITESPACE}strength:{WHITESPACE}({INTEGER}|{NULL}))?|({WHITESPACE}name:{WHITESPACE}({STRING}|{NULL})\n)?({WHITESPACE}age:{WHITESPACE}({INTEGER}|{NULL})\n)?{WHITESPACE}strength:{WHITESPACE}({INTEGER}|{NULL}))?{WHITESPACE}",
+            [
+                ("name: Player", True),
+                ("name: Player\nage: 10\nstrength: 10", True),
+                ("age: 10\nstrength: 10", True),
+            ],
+        ),
+    ],
+)
+def test_match(schema, regex, examples):
+    interegular.parse_pattern(regex)
+    schema = json.dumps(schema, sort_keys=False)
+    test_regex = build_regex_from_schema(schema)
+    assert test_regex == regex
+
+    print(test_regex)
+
+    for string, does_match in examples:
+        print(string)
+        match = re.fullmatch(test_regex, string)
+        if does_match:
+            if match is None:
+                raise ValueError(f"Expected match for '{string}'")
+            assert match[0] == string
+            assert match.span() == (0, len(string))
+        else:
+            assert match is None


### PR DESCRIPTION
This is a tentative implementation of a regex generator for arbitrary YAML given a JSON Schema. This PR relates to #923 .

There are still some issues:
* the NUMBER regex can be revisited. I have taken it from the official pyyaml repo [link](https://github.com/yaml/pyyaml/blob/main/lib/yaml/resolver.py). The INTEGER regex can also be changed.
* I don't address the refactoring suggested in #923. This results in some code deduplication between both files.
* The regex generator is not very strict regarding the indentation levels, which might make it impractical in some use cases.

@rlouf 