### PR TITLE
Major bug & fix: Fix bug in batched multi sample generation

### DIFF
--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -231,8 +231,8 @@ class SequenceGenerator:
 
         # We reshape the output to (batch_size, sample_size)
         output: List[List[FormattedOutput]] = list()
-        for i in range(batch_size):
-            output.append(formatted[i : i + num_samples])
+        for i in range(0, batch_size * num_samples, num_samples):
+            output.append(formatted[i : i + num_samples]
 
         # We remove leading dimensions for the output
         if batch_size == 1 and num_samples == 1:

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -232,7 +232,7 @@ class SequenceGenerator:
         # We reshape the output to (batch_size, sample_size)
         output: List[List[FormattedOutput]] = list()
         for i in range(0, batch_size * num_samples, num_samples):
-            output.append(formatted[i : i + num_samples]
+            output.append(formatted[i : i + num_samples])
 
         # We remove leading dimensions for the output
         if batch_size == 1 and num_samples == 1:

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -372,7 +372,7 @@ class SequenceGenerator:
                 previously_generated_sequences = generated_sequences
                 # We reshape the output to (batch_size, sample_size)
                 output: List[List[str]] = list()
-                for i in range(batch_size):
+                for i in range(0, batch_size * num_samples, num_samples):
                     output.append(next_tokens[i : i + num_samples])
 
                 # We remove leading dimensions for the output


### PR DESCRIPTION
The following lines break in batched generation.
There is a single list that is 

`[b_0_s_0, b_0_s_1, b_0_s_2, b_0_s_3, b_1_s_0, b_1_s_1, ...]`

with `b_0_s_0` being the example generated for batch 0 and sample 0 of multi-sample batch generation.

At the end of the generation code, the following tries to separate the generated samples in a `batch_size` quantity of sub lists. The problematic code is as follows:

```python
for i in range(batch_size):
            output.append(formatted[i : i + num_samples])
```

We indeed get a list of batch size, but not the expected ones. Instead it should be:

```python
for i in range(0, batch_size * num_samples, num_samples):
                    output.append(next_tokens[i : i + num_samples])
```

As an example, using the prompts: 

`'1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 =`  

and 

`'2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 =`

which gives a batch size of 2, with the `\d( \d)+` regex, and with multinomial generation with a number of samples of 10, the current wrong output is (if you remove excluding the prompt from the output, which I did because the outputs looked fishy):

```python
[[
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 9 9 9',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 6 6',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 1 2',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 5 5 5',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 0 0 0',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 4 5',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 3 3 3'
], [
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 9 9 9',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 6 6',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 1 2',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 5 5 5',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 0 0 0',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 4 5',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 3 3 3',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 8 0 8 8'
]]
```

We can see the problem, it returned `next_tokens[0 : num_samples]` and `next_tokens[1 : num_samples + 1]` which is not what we want.

The new code returns

```python
[[
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 6 8 1',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 2 4',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 7 7',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 9 3 3',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 4 9',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 6 6 6',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 4 4 4',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 7 3 2',
    '1 1 1 + 3 3 3 =? Solution: 1 1 1 + 3 3 3 = 1 1 0'
], [
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 4 4 4 4',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 2 4 4 4',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 8 2 2 2',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 8 4 4 4',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 4 4 4 4',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 2 2 2 2',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 5 5 5 5',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 2 2 2 2',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 2 2 2 2',
    '2 2 2 2 + 4 4 4 4 =? Solution: 2 2 2 2 + 4 4 4 4 = 8 8 8 8'
]]
```

Which corresponds to the index ranges `[0 : num_samples]` and `[num_samples : 2 * num_samples]`, which is what we want.

A more simple complete example is
```python
#!/usr/bin/env python
# coding: utf-8

import outlines
import outlines.models.transformers
import outlines.samplers
from outlines.generate.generator import sequence_generator
import transformers
import more_itertools as mit
import rich
import rich.panel
from typing import *


MODEL          = "susnato/phi-2"
hf_model       = transformers .AutoModelForCausalLM .from_pretrained (MODEL).cuda()
hf_tokenizer   = transformers .AutoTokenizer        .from_pretrained (
    MODEL, padding_side="right")
outlines_model = outlines     .models               .Transformers    (hf_model, hf_tokenizer)

generator = outlines.generate.regex(outlines_model, "\d+", sampler=outlines.samplers.MultinomialSampler(10))
output = generator.stream(prompts=["What is 11 + 33 ? Solution: 11 + 33 = ", "What is 2222 + 4444 ? Solution: 2222 + 4444 = "], max_tokens=100)

for o in output:
    rich.print(o)
```
gives
```python
[
    ['21', '11', '41', '14', '55', '10', '11', '09', '31', '10'],
    [ '11', '41', '14', '55', '10', '11', '09', '31', '10', '6666']
]
```

when not fixed (see how the second list is just the first list with one item at the start fewer, and one reasonable-looking generation at the end),

and, when fixed:

```python
[
    ['21', '11', '41', '14', '55', '10', '11', '09', '31', '10'],
    ['6666', '66666666', '6666', '0000000000000000', '6666', '6666', '6666', '6666', '6666', '6666']
]
```