### PR TITLE
Update file contributors style for docs

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -9,9 +9,6 @@
   --md-code-fg-color: #FFFFFF;
   --md-text-font-family: "Inter";
   --md-code-font: "Source Code Pro Custom";
-  --md-default-fg-color--light: #D8DEE9;
-  --md-default-fg-color--lighter: #E5E9F0;
-  --md-default-fg-color--lightest: #ECEFF4;
 }
 
 .index-pre-code {
@@ -23,6 +20,19 @@
   text-align: left;
 }
 
+.md-clipboard::after {
+  color: #FFFFFF;
+  transition: color 0.3s ease-in-out;
+}
+
+.md-clipboard:hover::after {
+  color: #D8DEE9;
+}
+
+.md-source-file {
+  text-align: center;
+  padding: 24px 0;
+}
 
 .md-typeset pre>code {
   border-radius: .2rem;


### PR DESCRIPTION
Minor style change for file contributors for accessibility.

| BEFORE | AFTER |
|--------|--------|
| <img width="1512" alt="Frame 1235" src="https://github.com/user-attachments/assets/1e337348-3553-4a36-be8f-550102b76961"> | <img width="1512" alt="Frame 1234" src="https://github.com/user-attachments/assets/02d3dc79-cb58-4a62-baa8-94200d1b5818"> |
| <img width="397" alt="Frame 1236" src="https://github.com/user-attachments/assets/8775cec1-a5e9-4de0-99be-0f8638569e17"> | <img width="397" alt="Frame 1237" src="https://github.com/user-attachments/assets/750cd9c1-3d27-4c09-b979-d38d217bca88"> | 