### PR TITLE
Introduce `outlines.models.transformers_vision`

### DIFF
--- a/docs/reference/models/transformers_vision.md
+++ b/docs/reference/models/transformers_vision.md
@@ -1,0 +1,112 @@
+# Transformers Vision
+
+Outlines allows seamless use of [vision models](https://huggingface.co/learn/computer-vision-course/en/unit4/multimodal-models/tasks-models-part1).
+
+`outlines.models.transformers_vision` has shares interfaces with, and is based on [`outlines.models.transformers`](./transformers.md).
+
+Tasks supported include
+- image + text -> text
+- video + text -> text
+
+
+
+## Example: Using [Llava-Next](https://huggingface.co/docs/transformers/en/model_doc/llava_next) Vision Models
+
+Install dependencies
+`pip install torchvision pillow flash-attn`
+
+Create the model
+```python
+import outlines
+
+model = outlines.models.transformers_vision(
+    "llava-hf/llava-v1.6-mistral-7b-hf",
+	device="cuda",
+)
+```
+
+Create convenience function to load a `PIL.Image` from URL
+```python
+from PIL import Image
+from io import BytesIO
+from urllib.request import urlopen
+
+def img_from_url(url):
+    img_byte_stream = BytesIO(urlopen(url).read())
+    return Image.open(img_byte_stream).convert("RGB")
+```
+
+### Describing an image
+
+```python
+description_generator = outlines.generate.text(model)
+description_generator(
+    "<image> detailed description:",
+    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg")]
+)
+```
+
+> This is a color photograph featuring a Siamese cat with striking blue eyes. The cat has a creamy coat and a light eye color, which is typical for the Siamese breed. Its features include elongated ears, a long, thin tail, and a striking coat pattern. The cat is sitting in an indoor setting, possibly on a cat tower or a similar raised platform, which is covered with a beige fabric, providing a comfortable and soft surface for the cat to rest or perch. The surface of the wall behind the cat appears to be a light-colored stucco or plaster.
+
+#### Multiple Images
+
+To include multiple images in your prompt you simply add more `<image>` tokens to the prompt
+
+```python
+image_urls = [
+	"https://cdn1.byjus.com/wp-content/uploads/2020/08/ShapeArtboard-1-copy-3.png",  # triangle
+	"https://cdn1.byjus.com/wp-content/uploads/2020/08/ShapeArtboard-1-copy-11.png",  # hexagon
+]
+description_generator = outlines.generate.text(model)
+description_generator(
+    "<image><image><image>What shapes are present?",
+    list(map(img_from_url, image_urls)),
+)
+```
+
+> There are two shapes present. One shape is a hexagon and the other shape is an triangle. '
+
+
+### Classifying an Image
+
+```python
+pattern = "Mercury|Venus|Earth|Mars|Saturn|Jupiter|Neptune|Uranus|Pluto"
+planet_generator = outlines.generate.regex(model, pattern)
+
+planet_generator(
+    "What planet is this: <image>",
+    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/e/e3/Saturn_from_Cassini_Orbiter_%282004-10-06%29.jpg")]
+)
+```
+
+> Saturn
+
+
+### Extracting Structured Image data
+
+```python
+from pydantic import BaseModel
+from typing import List, Optional
+
+class ImageData(BaseModel):
+    caption: str
+    tags_list: List[str]
+    object_list: List[str]
+    is_photo: bool
+
+image_data_generator = outlines.generate.json(model, ImageData)
+
+image_data_generator(
+    "<image> detailed JSON metadata:",
+    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/9/98/Aldrin_Apollo_11_original.jpg")]
+)
+```
+
+> `ImageData(caption='An astronaut on the moon', tags_list=['moon', 'space', 'nasa', 'americanflag'], object_list=['moon', 'moon_surface', 'space_suit', 'americanflag'], is_photo=True)`
+
+
+## Resources
+
+### Chosing a model
+- https://mmbench.opencompass.org.cn/leaderboard
+- https://huggingface.co/spaces/WildVision/vision-arena

--- a/outlines/generate/fsm.py
+++ b/outlines/generate/fsm.py
@@ -3,8 +3,12 @@ from functools import singledispatch
 import interegular
 
 from outlines.fsm.guide import RegexGuide
-from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
-from outlines.models import MLXLM, LlamaCpp, Transformers
+from outlines.generate.api import (
+    SequenceGenerator,
+    SequenceGeneratorAdapter,
+    VisionSequenceGeneratorAdapter,
+)
+from outlines.models import MLXLM, LlamaCpp, Transformers, TransformersVision
 from outlines.samplers import Sampler, multinomial
 
 
@@ -29,3 +33,12 @@ def fsm_unified(
     fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
     logits_processor = FSMLogitsProcessor(tokenizer=model.tokenizer, fsm=fsm)
     return SequenceGeneratorAdapter(model, logits_processor, sampler)
+
+
+@fsm.register(TransformersVision)
+def fsm_vision(model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()):
+    from outlines.processors import FSMLogitsProcessor
+
+    fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
+    logits_processor = FSMLogitsProcessor(tokenizer=model.tokenizer, fsm=fsm)
+    return VisionSequenceGeneratorAdapter(model, logits_processor, sampler)

--- a/outlines/generate/regex.py
+++ b/outlines/generate/regex.py
@@ -1,12 +1,19 @@
 from functools import singledispatch
 
 from outlines.fsm.guide import RegexGuide
-from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
-from outlines.models import OpenAI
-from outlines.models.llamacpp import LlamaCpp
-from outlines.models.mlxlm import MLXLM
-from outlines.models.transformers import Transformers
-from outlines.models.vllm import VLLM
+from outlines.generate.api import (
+    SequenceGenerator,
+    SequenceGeneratorAdapter,
+    VisionSequenceGeneratorAdapter,
+)
+from outlines.models import (
+    MLXLM,
+    VLLM,
+    LlamaCpp,
+    OpenAI,
+    Transformers,
+    TransformersVision,
+)
 from outlines.samplers import Sampler, multinomial
 
 
@@ -51,6 +58,18 @@ def regex_unified(
 
     logits_processor = RegexLogitsProcessor(regex_str, tokenizer=model.tokenizer)
     return SequenceGeneratorAdapter(model, logits_processor, sampler)
+
+
+@regex.register(TransformersVision)
+def regex_vision(
+    model,
+    regex_str: str,
+    sampler: Sampler = multinomial(),
+):
+    from outlines.processors import RegexLogitsProcessor
+
+    logits_processor = RegexLogitsProcessor(regex_str, tokenizer=model.tokenizer)
+    return VisionSequenceGeneratorAdapter(model, logits_processor, sampler)
 
 
 @regex.register(VLLM)

--- a/outlines/generate/text.py
+++ b/outlines/generate/text.py
@@ -1,8 +1,19 @@
 from functools import singledispatch
 
 from outlines.fsm.guide import StopAtEOSGuide
-from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
-from outlines.models import MLXLM, VLLM, LlamaCpp, OpenAI, Transformers
+from outlines.generate.api import (
+    SequenceGenerator,
+    SequenceGeneratorAdapter,
+    VisionSequenceGeneratorAdapter,
+)
+from outlines.models import (
+    MLXLM,
+    VLLM,
+    LlamaCpp,
+    OpenAI,
+    Transformers,
+    TransformersVision,
+)
 from outlines.samplers import Sampler, multinomial
 
 
@@ -41,6 +52,11 @@ def text(model, sampler: Sampler = multinomial()) -> SequenceGenerator:
 @text.register(LlamaCpp)
 def text_unified(model, sampler: Sampler = multinomial()):
     return SequenceGeneratorAdapter(model, None, sampler)
+
+
+@text.register(TransformersVision)
+def text_vision(model, sampler: Sampler = multinomial()):
+    return VisionSequenceGeneratorAdapter(model, None, sampler)
 
 
 @text.register(VLLM)

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -5,6 +5,7 @@ completion, diffusers, etc.) and use routing functions everywhere else in the
 codebase.
 
 """
+
 from typing import Union
 
 from .exllamav2 import ExLlamaV2Model, exl2
@@ -12,6 +13,7 @@ from .llamacpp import LlamaCpp, llamacpp
 from .mlxlm import MLXLM, mlxlm
 from .openai import OpenAI, azure_openai, openai
 from .transformers import Transformers, TransformerTokenizer, mamba, transformers
+from .transformers_vision import TransformersVision, transformers_vision
 from .vllm import VLLM, vllm
 
 LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, MLXLM, VLLM]

--- a/outlines/models/transformers_vision.py
+++ b/outlines/models/transformers_vision.py
@@ -1,0 +1,139 @@
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
+
+from outlines.generate.api import GenerationParameters, SamplingParameters
+from outlines.models import Transformers
+
+if TYPE_CHECKING:
+    from outlines.processors import OutlinesLogitsProcessor
+
+
+class TransformersVision(Transformers):
+    def __init__(self, model, tokenizer, processor):
+        super().__init__(model, tokenizer)
+        self.processor = processor
+
+    def generate(  # type: ignore
+        self,
+        prompts: Union[str, List[str]],
+        media: Union[List[Any], List[List[Any]]],
+        generation_parameters: GenerationParameters,
+        logits_processor: Optional["OutlinesLogitsProcessor"],
+        sampling_parameters: SamplingParameters,
+    ) -> Union[str, List[str], List[List[str]]]:
+        """Generate text using `transformers`.
+
+        Arguments
+        ---------
+        prompts
+            A prompt or list of prompts.
+        media
+            A List[PIL.Image] or List[List[PIL.Image]]
+        generation_parameters
+            An instance of `GenerationParameters` that contains the prompt,
+            the maximum number of tokens, stop sequences and seed. All the
+            arguments to `SequenceGeneratorAdapter`'s `__cal__` method.
+        logits_processor
+            The logits processor to use when generating text.
+        sampling_parameters
+            An instance of `SamplingParameters`, a dataclass that contains
+            the name of the sampler to use and related parameters as available
+            in Outlines.
+
+        Returns
+        -------
+        The generated text
+        """
+        inputs = self.processor(prompts, media, padding=True, return_tensors="pt").to(
+            self.model.device
+        )
+
+        generation_kwargs = self._get_generation_kwargs(
+            prompts,
+            generation_parameters,
+            logits_processor,
+            sampling_parameters,
+        )
+        generated_ids = self._generate_output_seq(prompts, inputs, **generation_kwargs)
+
+        # if single str input and single sample per input, convert to a 1D output
+        if isinstance(prompts, str):
+            # Should always be true until NotImplementedError above is fixed
+            generated_ids = generated_ids.squeeze(0)
+
+        return self._decode_generation(generated_ids)
+
+    def stream(  # type: ignore
+        self,
+        prompts: Union[str, List[str]],
+        media: Union[Any, List[Any]],  # TODO: docstring
+        generation_parameters: GenerationParameters,
+        logits_processor: Optional["OutlinesLogitsProcessor"],
+        sampling_parameters: SamplingParameters,
+    ) -> Iterator[Union[str, List[str]]]:
+        raise NotImplementedError
+
+
+def transformers_vision(
+    model_name: str,
+    device: Optional[str] = None,
+    model_kwargs: dict = {},
+    processor_kwargs: dict = {},
+    model_class=None,
+    tokenizer_class=None,
+    processor_class=None,
+):
+    """Instantiate a model from the `transformers` library and its tokenizer.
+
+    Parameters
+    ----------
+    model_name
+        The name of the model as listed on Hugging Face's model page.
+    device
+        The device(s) on which the model should be loaded. This overrides
+        the `device_map` entry in `model_kwargs` when provided.
+    model_kwargs
+        A dictionary that contains the keyword arguments to pass to the
+        `from_pretrained` method when loading the model.
+    processor_kwargs
+        A dictionary that contains the keyword arguments to pass to the
+        `from_pretrained` method when loading the processor.
+
+    Returns
+    -------
+    A `TransformersModel` model instance.
+
+    """
+    if model_class is None or tokenizer_class is None:
+        try:
+            from transformers import (
+                AutoTokenizer,
+                LlavaNextForConditionalGeneration,
+                LlavaNextProcessor,
+            )
+        except ImportError:
+            raise ImportError(
+                "The `transformers` library needs to be installed in order to use `transformers` models."
+            )
+    if model_class is None:
+        model_class = LlavaNextForConditionalGeneration
+    if processor_class is None:
+        processor_class = LlavaNextProcessor
+
+    if device is not None:
+        model_kwargs["device_map"] = device
+
+    model = model_class.from_pretrained(model_name, **model_kwargs)
+
+    processor_kwargs.setdefault("padding_side", "left")
+    processor_kwargs.setdefault("pad_token", "[PAD]")
+    processor = processor_class.from_pretrained(model_name, **processor_kwargs)
+
+    if tokenizer_class is None:
+        if getattr(processor, "tokenizer", None):
+            tokenizer = processor.tokenizer
+        else:
+            tokenizer = AutoTokenizer.from_pretrained(model_name, **processor_kwargs)
+    else:
+        tokenizer = tokenizer_class.from_pretrained(model_name, **processor_kwargs)
+
+    return TransformersVision(model, tokenizer, processor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test = [
     "vllm; sys_platform != 'darwin'",
     "torch",
     "transformers",
+    "pillow",
 ]
 serve = [
     "vllm>=0.3.0",

--- a/tests/generate/test_api.py
+++ b/tests/generate/test_api.py
@@ -1,0 +1,33 @@
+from io import BytesIO
+from urllib.request import urlopen
+
+import pytest
+from PIL import Image  # type: ignore
+
+from outlines.generate.api import VisionSequenceGeneratorAdapter
+
+IMG_URI = "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg"
+PIL_IMG = Image.open(BytesIO(urlopen(IMG_URI).read())).convert("RGB")
+
+
+@pytest.mark.parametrize(
+    "prompts,media,type_error",
+    [
+        ("single prompt", [PIL_IMG], False),
+        (["prompt0", "prompt1"], [[PIL_IMG], [PIL_IMG]], False),
+        ("single prompt", [PIL_IMG, PIL_IMG], False),
+        (["prompt0", "prompt1"], [[PIL_IMG, PIL_IMG], [PIL_IMG]], False),
+        ("single prompt", "this isn't an image, it's a string", True),
+        ("single prompt", PIL_IMG, True),
+        (["prompt0", "prompt1"], [PIL_IMG], True),
+        (["prompt0", "prompt1"], [[PIL_IMG]], True),
+        (["prompt0", "prompt1"], [[[PIL_IMG]], [[PIL_IMG]]], True),
+    ],
+)
+def test_vision_sequence_generator_validate_types(prompts, media, type_error):
+    """Ensure inputs are validated correctly"""
+    if type_error:
+        with pytest.raises(TypeError):
+            VisionSequenceGeneratorAdapter._validate_prompt_media_types(prompts, media)
+    else:
+        VisionSequenceGeneratorAdapter._validate_prompt_media_types(prompts, media)


### PR DESCRIPTION
Rendered Docs: https://github.com/lapp0/outlines/blob/multimodal-models/docs/reference/models/transformers_vision.md

- Fixes https://github.com/outlines-dev/outlines/issues/787
- Fixes https://github.com/outlines-dev/outlines/issues/662

# Changes

- Introduce `models.transformers_vision` which subclasses `models.transformers` and overrides its behavior so it applies, instead of `AutoTokenizer`, `AutoProcessor` to handle the text AND `PIL.Images` media
- Introduce `VisionSequenceGeneratorAdapter`, handling and validating the `media` argument.
- Update `outlines.generate` to dispatch `TransformersVision` models to `VisionSequenceGeneratorAdapter`

# Tests

- `tests/generate/test_api.py`: Test `prompt` / `media` validation
- `tests/generate/test_generate.py`: 
  - Add `model_transformers_vision` fixture. **tests pass locally, but disabled because a model small enough for CI isn't available**
  - Test all `outlines.generate` generators to ensure dispatchers for this new sequence generator is handled correctly.