### PR TITLE
Use `outlines.processors` and `SequenceGeneratorAdapter` for `outlines.models.vllm`

### DIFF
--- a/outlines/generate/choice.py
+++ b/outlines/generate/choice.py
@@ -1,7 +1,7 @@
 from functools import singledispatch
 from typing import Callable, List
 
-from outlines.generate.api import SequenceGenerator
+from outlines.generate.api import SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.samplers import Sampler, multinomial
 
@@ -11,7 +11,7 @@ from .regex import regex
 @singledispatch
 def choice(
     model, choices: List[str], sampler: Sampler = multinomial()
-) -> SequenceGenerator:
+) -> SequenceGeneratorAdapter:
     regex_str = r"(" + r"|".join(choices) + r")"
 
     generator = regex(model, regex_str, sampler)

--- a/outlines/generate/format.py
+++ b/outlines/generate/format.py
@@ -1,7 +1,7 @@
 from functools import singledispatch
 
 from outlines.fsm.types import python_types_to_regex
-from outlines.generate.api import SequenceGenerator
+from outlines.generate.api import SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.samplers import Sampler, multinomial
 
@@ -9,7 +9,9 @@ from .regex import regex
 
 
 @singledispatch
-def format(model, python_type, sampler: Sampler = multinomial()) -> SequenceGenerator:
+def format(
+    model, python_type, sampler: Sampler = multinomial()
+) -> SequenceGeneratorAdapter:
     """Generate structured data that can be parsed as a Python type.
 
     Parameters

--- a/outlines/generate/fsm.py
+++ b/outlines/generate/fsm.py
@@ -8,24 +8,12 @@ from outlines.generate.api import (
     SequenceGeneratorAdapter,
     VisionSequenceGeneratorAdapter,
 )
-from outlines.models import MLXLM, LlamaCpp, Transformers, TransformersVision
+from outlines.models import ExLlamaV2Model, TransformersVision
 from outlines.samplers import Sampler, multinomial
 
 
 @singledispatch
 def fsm(
-    model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()
-) -> SequenceGenerator:
-    fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
-    device = model.device
-    generator = SequenceGenerator(fsm, model, sampler, device)
-    return generator
-
-
-@fsm.register(MLXLM)
-@fsm.register(Transformers)
-@fsm.register(LlamaCpp)
-def fsm_unified(
     model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()
 ) -> SequenceGeneratorAdapter:
     from outlines.processors import FSMLogitsProcessor
@@ -42,3 +30,13 @@ def fsm_vision(model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()
     fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
     logits_processor = FSMLogitsProcessor(tokenizer=model.tokenizer, fsm=fsm)
     return VisionSequenceGeneratorAdapter(model, logits_processor, sampler)
+
+
+@fsm.register(ExLlamaV2Model)
+def fsm_exllamav2(
+    model, fsm: interegular.fsm.FSM, sampler: Sampler = multinomial()
+) -> SequenceGenerator:
+    fsm = RegexGuide.from_interegular_fsm(fsm, model.tokenizer)
+    device = model.device
+    generator = SequenceGenerator(fsm, model, sampler, device)
+    return generator

--- a/outlines/generate/json.py
+++ b/outlines/generate/json.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional, Union
 from pydantic import BaseModel
 
 from outlines.fsm.json_schema import build_regex_from_schema, get_schema_from_signature
-from outlines.generate.api import SequenceGenerator
+from outlines.generate.api import SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.samplers import Sampler, multinomial
 
@@ -18,7 +18,7 @@ def json(
     schema_object: Union[str, object, Callable],
     sampler: Sampler = multinomial(),
     whitespace_pattern: Optional[str] = None,
-) -> SequenceGenerator:
+) -> SequenceGeneratorAdapter:
     """
     Generate structured JSON data with a `Transformer` model based on a specified JSON Schema.
 

--- a/tests/generate/conftest.py
+++ b/tests/generate/conftest.py
@@ -1,16 +1,38 @@
 from importlib import reload
 
 import pytest
+import torch
 
 
-def pytest_collection_modifyitems(config, items):
-    """If mlxlm and Metal aren't available, skip mlxlm tests"""
+def is_metal_available():
     try:
         import mlx.core as mx
         import mlx_lm  # noqa: F401
 
         assert mx.metal.is_available()
     except (ImportError, AssertionError):
+        return False
+    return True
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    If mlxlm and Metal aren't available, skip mlxlm tests
+    If CUDA isn't available, skip vllm and transformers_vision
+    """
+    if not torch.cuda.is_available():
+        skip_marker = pytest.mark.skip(
+            reason="Skipping test because CUDA is not available"
+        )
+        for item in items:
+            if "model_fixture" in item.fixturenames:
+                model_param = item.callspec.params.get("model_fixture", None)
+                if model_param.startswith(
+                    "model_transformers_vision"
+                ) or model_param.startswith("model_vllm"):
+                    item.add_marker(skip_marker)
+
+    if not is_metal_available():
         skip_marker = pytest.mark.skip(
             reason="Skipping test because mlx-lm or Metal are not available"
         )

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -61,8 +61,17 @@ def model_transformers_vision(tmp_path_factory):
     return models.transformers_vision(
         "llava-hf/llava-v1.6-mistral-7b-hf",
         device="cuda",
-        model_kwargs=dict(torch_dtype=torch.bfloat16),
+        model_kwargs=dict(
+            torch_dtype=torch.bfloat16,
+            load_in_4bit=True,
+            low_cpu_mem_usage=True,
+        ),
     )
+
+
+@pytest.fixture(scope="session")
+def model_vllm(tmp_path_factory):
+    return models.vllm("facebook/opt-125m", gpu_memory_utilization=0.1)
 
 
 # TODO: exllamav2 failing in main, address in https://github.com/outlines-dev/outlines/issues/808
@@ -93,7 +102,8 @@ ALL_MODEL_FIXTURES = (
     "model_transformers_opt125m",
     "model_mamba",
     "model_bart",
-    # "model_transformers_vision",  # tests pass, but awaiting a tiny model for CI
+    "model_transformers_vision",
+    "model_vllm",
 )
 
 
@@ -137,7 +147,7 @@ def enforce_not_implemented(model_fixture, *task_names):
     assert an NotImplementedError is raised. Otherwise, run normally
     """
     NOT_IMPLEMENTED = {
-        "stream": ["model_transformers_vision"],
+        "stream": ["model_transformers_vision", "model_vllm"],
         "batch": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],
         "beam_search": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],
         "multiple_samples": ["model_llamacpp", "model_mlxlm", "model_mlxlm_phi3"],


### PR DESCRIPTION
Fixes: `models.vllm` being the only model (other than `models.exllamav2`) using `SequenceGenerator`

# Changes
- Update `outlines.generate` handlers, default to `SequenceGeneratorAdapter` for all models except `ExLlamaV2Model`
- Update `OutlinesLogitsProcessors` to allow vLLM `input_ids` which are of type `tuple`
- Fix `FSMLogitsProcessor` bug: unable to handle batch sequences where prompt ids are part of `input_ids`. Wasn't caught previously because `model_llamacpp` cannot perform batch generation.

# Tests
- in `tests/generate/test_generate.py`
  - test `model_vllm`
  - enable `model_vllm` and `model_transformers_vision` only if cuda is available

# Benchmarks

Regex logits processing performance has changed in an acceptable manner
- Structured generation with `torch`: `268±7μs` -> `225±1μs`
- Noop with `numpy`: `160±0.9μs` -> `185±3μs`


<details>
Benchmarks that have improved:

| Change   | Before [a7e3381a]    | After [b2c28a74]    |   Ratio | Benchmark (Parameter)                                                                         |
|----------|----------------------|---------------------|---------|-----------------------------------------------------------------------------------------------|
| -        | 268±7μs              | 225±1μs             |    0.84 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('torch', 'Z*') |

Benchmarks that have stayed the same:

| Change   | Before [a7e3381a]    | After [b2c28a74]    |   Ratio | Benchmark (Parameter)                                                                                              |
|----------|----------------------|---------------------|---------|--------------------------------------------------------------------------------------------------------------------|
|          | 5.21±0.01s           | 5.18±0.02s          |    0.99 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('complex_schema')                                    |
|          | 3.67±0.02s           | 3.62±0.03s          |    0.99 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('simple_schema')                                     |
|          | 90.4±1μs             | 87.3±0.3μs          |    0.97 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('complex_schema')                                  |
|          | 49.4±0.04μs          | 50.0±0.9μs          |    1.01 | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('simple_schema')                                   |
|          | 5.69±0.02s           | 5.71±0.02s          |    1    | bench_numba_compile.NumbaCompileBenchmark.time_compile_numba                                                       |
|          | 180±10μs             | 173±1μs             |    0.96 | bench_processors.LogitsProcessorPassthroughBenchmark.time_passthrough('torch')                                     |
|          | 256±3μs              | 243±2μs             |    0.95 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('numpy', 'Z*')                      |
|          | 1.03±0.01ms          | 1.02±0.01ms         |    0.99 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('numpy', '[^Z]*')                   |
|          | 1.03±0.01ms          | 1.02±0.02ms         |    0.99 | bench_processors.LogitsProcessorStructuredBenchmark.time_structured_generation('torch', '[^Z]*')                   |
|          | 592M                 | 592M                |    1    | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('complex_span_constrained_relation_extraction') |
|          | 493M                 | 494M                |    1    | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('simple_phone')                                 |
|          | 2.72±0.05s           | 2.72±0.02s          |    1    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_phone')                                         |
|          | 6.36±0.01s           | 6.35±0.02s          |    1    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_span_constrained_relation_extraction')          |
|          | 2.58±0.01s           | 2.54±0.02s          |    0.99 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('date')                                                  |
|          | 2.53±0.02s           | 2.58±0.02s          |    1.02 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('email')                                                 |
|          | 2.52±0.06s           | 2.48±0.02s          |    0.98 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ip')                                                    |
|          | 2.47±0.03s           | 2.43±0.02s          |    0.98 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('simple_phone')                                          |
|          | 2.43±0.02s           | 2.41±0.02s          |    0.99 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ssn')                                                   |
|          | 2.46±0.06s           | 2.38±0.01s          |    0.97 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('time')                                                  |
|          | 2.64±0.04s           | 2.62±0.03s          |    0.99 | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('url')                                                   |
Benchmarks that have got worse:
| Change   | Before [a7e3381a]    | After [b2c28a74]    |   Ratio | Benchmark (Parameter)                                                          |
|----------|----------------------|---------------------|---------|--------------------------------------------------------------------------------|
| +        | 160±0.9μs            | 185±3μs             |    1.16 | bench_processors.LogitsProcessorPassthroughBenchmark.time_passthrough('numpy') |

Performance degradation detected!

</details>