### PR TITLE
Modal documentation: fix deprecated memory= parameter

### DIFF
--- a/docs/cookbook/deploy-using-modal.md
+++ b/docs/cookbook/deploy-using-modal.md
@@ -73,7 +73,7 @@ schema = """{
 To make the inference work on Modal we need to wrap the corresponding function in a `@app.function` decorator. We pass to this decorator the image and GPU on which we want this function to run (here an A100 with 80GB memory):
 
 ```python
-@app.function(image=outlines_image, gpu=gpu.A100(memory=80))
+@app.function(image=outlines_image, gpu=gpu.A100(size='80GB'))
 def generate(
     prompt: str = "Amiri, a 53 year old warrior woman with a sword and leather armor.",
 ):


### PR DESCRIPTION
memory= parameter is deprecated in favor of size=
See https://modal.com/docs/reference/changelog#062174-2024-05-17

Current doc example produces the following error:
```
/path/test_modal.py:56: DeprecationError: 2024-05-16: The `memory` parameter is deprecated. Use the `size='80GB'` parameter instead.
  @app.function(image=outlines_image, gpu=gpu.A100(memory=80))
```