### PR TITLE
Fix TransformerTokenizer pad_token_id reset

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -69,7 +69,7 @@ class TransformerTokenizer(Tokenizer):
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token
 
-        if not self.tokenizer.pad_token_id:
+        if self.tokenizer.pad_token_id is None:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
             self.pad_token_id = self.eos_token_id
         else:


### PR DESCRIPTION
For some LLM models (such as [chatglm3-6b](https://huggingface.co/THUDM/chatglm3-6b)), the `pad_token_id` is defined as 0 and immutable. We only need to reset for undefined cases.