### PR TITLE
Fix link to `mamba` model reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,7 @@ nav:
           - TGI: reference/models/tgi.md
           - ExllamaV2: reference/models/exllamav2.md
           - MLX: reference/models/mlxlm.md
-          - Mamba: reference/models/mamba.md
+          - Mamba: reference/models/transformers.md
         - API:
             - OpenAI: reference/models/openai.md
   - API Reference:


### PR DESCRIPTION
The previous refactor of the `mamba` integration deleted the Mamba documentation file to add the related information to the `transformers` page. This PR redirects the link to the `transformers` page. Fixes #1071. 