### PR TITLE
Add `apply_chat_template` to Tokenizer

### DIFF
--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -52,14 +52,6 @@ class LlamaCppTokenizer(Tokenizer):
 
         self._hash = None
 
-        # set to None if no system message
-        self.SYSTEM_MESSAGE = {
-            "role": "system",
-            "content": "You are a helpful assistant.",
-        }
-        self.USER_MESSAGE_TEMPLATE = lambda x: {"role": "user", "content": x}
-        self.ASSISTANT_MESSAGE_TEMPLATE = lambda x: {"role": "assistant", "content": x}
-
     def decode(self, token_ids: List[int]) -> List[str]:
         decoded_bytes = self.tokenizer.detokenize(token_ids)
         return [decoded_bytes.decode("utf-8", errors="ignore")]
@@ -91,28 +83,11 @@ class LlamaCppTokenizer(Tokenizer):
         else:
             return token
 
-    def format_prompt_into_conversation(self, prompt: str) -> List[Dict[str, str]]:
-        """
-        Template for one-turn chat.
-        """
-        return (
-            [self.SYSTEM_MESSAGE.copy(), self.USER_MESSAGE_TEMPLATE(prompt)]
-            if self.SYSTEM_MESSAGE is not None
-            else [self.USER_MESSAGE_TEMPLATE(prompt)]
-        )
-
     def apply_chat_template(
         self,
         prompt_or_conversation: Union[str, List[Dict[str, str]]],
     ) -> str:
-        if isinstance(prompt_or_conversation, str):
-            prompt_or_conversation = self.format_prompt_into_conversation(
-                prompt_or_conversation
-            )
-
-        return self.tokenizer.apply_chat_template(
-            prompt_or_conversation, tokenize=False, add_generation_prompt=True
-        )
+        raise NotImplementedError("Chat templates are not yet supported by llama-cpp")
 
     def __eq__(self, other):
         if not isinstance(other, LlamaCppTokenizer):

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -52,6 +52,14 @@ class LlamaCppTokenizer(Tokenizer):
 
         self._hash = None
 
+        # set to None if no system message
+        self.SYSTEM_MESSAGE = {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        }
+        self.USER_MESSAGE_TEMPLATE = lambda x: {"role": "user", "content": x}
+        self.ASSISTANT_MESSAGE_TEMPLATE = lambda x: {"role": "assistant", "content": x}
+
     def decode(self, token_ids: List[int]) -> List[str]:
         decoded_bytes = self.tokenizer.detokenize(token_ids)
         return [decoded_bytes.decode("utf-8", errors="ignore")]
@@ -82,6 +90,29 @@ class LlamaCppTokenizer(Tokenizer):
             return token_str
         else:
             return token
+
+    def format_prompt_into_conversation(self, prompt: str) -> List[Dict[str, str]]:
+        """
+        Template for one-turn chat.
+        """
+        return (
+            [self.SYSTEM_MESSAGE.copy(), self.USER_MESSAGE_TEMPLATE(prompt)]
+            if self.SYSTEM_MESSAGE is not None
+            else [self.USER_MESSAGE_TEMPLATE(prompt)]
+        )
+
+    def apply_chat_template(
+        self,
+        prompt_or_conversation: Union[str, List[Dict[str, str]]],
+    ) -> str:
+        if isinstance(prompt_or_conversation, str):
+            prompt_or_conversation = self.format_prompt_into_conversation(
+                prompt_or_conversation
+            )
+
+        return self.tokenizer.apply_chat_template(
+            prompt_or_conversation, tokenize=False, add_generation_prompt=True
+        )
 
     def __eq__(self, other):
         if not isinstance(other, LlamaCppTokenizer):

--- a/outlines/models/tokenizer.py
+++ b/outlines/models/tokenizer.py
@@ -29,3 +29,10 @@ class Tokenizer(Hashable, Protocol):
         token that includes `Ġ` with a string.
         """
         ...
+
+    def apply_chat_template(
+        self,
+        prompt_or_conversation: Union[str, List[Dict[str, str]]],
+    ) -> str:
+        """Apply a chat template to a prompt or conversation."""
+        ...

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from outlines.generate.api import GenerationParameters, SamplingParameters
 from outlines.integrations.utils import adapt_tokenizer
 
-from .transformers import TransformerTokenizer
-
 if TYPE_CHECKING:
     from vllm import LLM
     from vllm.sampling_params import SamplingParams
@@ -23,7 +21,6 @@ class VLLM:
 
     def __init__(self, model: "LLM"):
         self.model = model
-        self.tokenizer = TransformerTokenizer(self.model.get_tokenizer())
         self.lora_request = None
 
         self.tokenizer = self._get_tokenizer()

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from outlines.generate.api import GenerationParameters, SamplingParameters
 from outlines.integrations.utils import adapt_tokenizer
 
+from .transformers import TransformerTokenizer
+
 if TYPE_CHECKING:
     from vllm import LLM
     from vllm.sampling_params import SamplingParams
@@ -21,6 +23,7 @@ class VLLM:
 
     def __init__(self, model: "LLM"):
         self.model = model
+        self.tokenizer = TransformerTokenizer(self.model.get_tokenizer())
         self.lora_request = None
 
         self.tokenizer = self._get_tokenizer()


### PR DESCRIPTION
This PR adds `apply_chat_template` to Outline's `Tokenizer`. This replaces https://github.com/outlines-dev/outlines/pull/1019

## Usage:

###

Unlike Huggingface's tokenizers, we can directly pass the text prompt to `tokenizer.apply_chat_template`. This will first convert the prompt into conversation format with a predefined system message, then applies the chat template to the result.

```python
answer = generator(
    tokenizer.apply_chat_template(prompt)
)
```

To use a different system message, either (1) modify `tokenizer.SYSTEM_MESSAGE["content"]` or (2) build the conversation yourself then pass it to the `apply_chat_template` here:

```
conversation = [
    {
        "role": "system",
        "content": "You are a helpful assistant. Please do not say swear words.",
    },
    {
        "role": "user",
        "content": [insert prompt here],
    },
]
```

```python
answer = generator(
    tokenizer.apply_chat_template(conversation)
)
```

## Interface changes:

Default behavior is kept as is.

-----------

@rlouf @lapp0 imo adding it to the tokenizer instead of the model makes more sense.

* in chatml format
