### PR TITLE
Include SPDX license info in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "outlines"
 authors= [{name = "Outlines Developers"}]
 description = "Probabilistic Generative Model Programming"
 requires-python = ">=3.8"
+license = {text = "Apache-2.0"}
 keywords=[
     "machine learning",
     "deep learning",


### PR DESCRIPTION
A license entry in the project metadata makes it easier to detect the license of a project.

Before:
```shell
$ pip install pip-licenses outlines
$ pip-licenses  | grep outlines
 outlines                   0.0.46       UNKNOWN
```

After:
```shell
$ pip install .
$ pip-licenses  | grep outlines
 outlines                   0.0.47.dev43+g8b78f5d  Apache-2.0
```