### PR TITLE
Change cookbook examples: Download model weights in the hub cache folder

### DIFF
--- a/docs/cookbook/chain_of_thought.md
+++ b/docs/cookbook/chain_of_thought.md
@@ -11,30 +11,48 @@ We use [llama.cpp](https://github.com/ggerganov/llama.cpp) using the [llama-cpp-
 pip install llama-cpp-python
 ```
 
-We pull a quantized GGUF model, in this guide we pull [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-
-```bash
-wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
-```
-
-We initialize the model:
-
+We download the model weights by passing the name of the repository on the HuggingFace Hub, and the filenames (or glob pattern):
 ```python
-from llama_cpp import Llama
+import llama_cpp
 from outlines import generate, models
 
-llm = Llama(
-    "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
-    tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
-        "NousResearch/Hermes-2-Pro-Llama-3-8B"
-    ),
-    n_gpu_layers=-1,
-    flash_attn=True,
-    n_ctx=8192,
-    verbose=False
-)
-model = models.LlamaCpp(llm)
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+            "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+            tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+            ),
+            n_gpu_layers=-1,
+            flash_attn=True,
+            n_ctx=8192,
+            verbose=False)
 ```
+
+??? note "(Optional) Store the model weights in a custom folder"
+
+    By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
+    
+    ```bash
+    wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
+    ```
+    
+    We initialize the model:
+    
+    ```python
+    import llama_cpp
+    from llama_cpp import Llama
+    from outlines import generate, models
+    
+    llm = Llama(
+        "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+        ),
+        n_gpu_layers=-1,
+        flash_attn=True,
+        n_ctx=8192,
+        verbose=False
+    )
+    ```
 
 ## Chain of thought
 

--- a/docs/cookbook/chain_of_thought.md
+++ b/docs/cookbook/chain_of_thought.md
@@ -16,7 +16,7 @@ We download the model weights by passing the name of the repository on the Huggi
 import llama_cpp
 from outlines import generate, models
 
-model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
             "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
             tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
             "NousResearch/Hermes-2-Pro-Llama-3-8B"
@@ -30,18 +30,18 @@ model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
 ??? note "(Optional) Store the model weights in a custom folder"
 
     By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-    
+
     ```bash
     wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
     ```
-    
+
     We initialize the model:
-    
+
     ```python
     import llama_cpp
     from llama_cpp import Llama
     from outlines import generate, models
-    
+
     llm = Llama(
         "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
         tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(

--- a/docs/cookbook/knowledge_graph_extraction.md
+++ b/docs/cookbook/knowledge_graph_extraction.md
@@ -8,30 +8,48 @@ We will use [llama.cpp](https://github.com/ggerganov/llama.cpp) using the [llama
 pip install llama-cpp-python
 ```
 
-We pull a quantized GGUF model, in this guide we pull [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-
-```bash
-wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
-```
-
-We initialize the model:
-
+We download the model weights by passing the name of the repository on the HuggingFace Hub, and the filenames (or glob pattern):
 ```python
-from llama_cpp import Llama
+import llama_cpp
 from outlines import generate, models
 
-llm = Llama(
-    "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
-    tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
-        "NousResearch/Hermes-2-Pro-Llama-3-8B"
-    ),
-    n_gpu_layers=-1,
-    flash_attn=True,
-    n_ctx=8192,
-    verbose=False
-)
-model = models.LlamaCpp(llm)
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+            "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+            tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+            ),
+            n_gpu_layers=-1,
+            flash_attn=True,
+            n_ctx=8192,
+            verbose=False)
 ```
+
+??? note "(Optional) Store the model weights in a custom folder"
+
+    By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
+    
+    ```bash
+    wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
+    ```
+    
+    We initialize the model:
+    
+    ```python
+    import llama_cpp
+    from llama_cpp import Llama
+    from outlines import generate, models
+    
+    llm = Llama(
+        "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+        ),
+        n_gpu_layers=-1,
+        flash_attn=True,
+        n_ctx=8192,
+        verbose=False
+    )
+    ```
 
 ## Knowledge Graph Extraction
 

--- a/docs/cookbook/knowledge_graph_extraction.md
+++ b/docs/cookbook/knowledge_graph_extraction.md
@@ -13,7 +13,7 @@ We download the model weights by passing the name of the repository on the Huggi
 import llama_cpp
 from outlines import generate, models
 
-model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
             "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
             tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
             "NousResearch/Hermes-2-Pro-Llama-3-8B"
@@ -27,18 +27,18 @@ model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
 ??? note "(Optional) Store the model weights in a custom folder"
 
     By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-    
+
     ```bash
     wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
     ```
-    
+
     We initialize the model:
-    
+
     ```python
     import llama_cpp
     from llama_cpp import Llama
     from outlines import generate, models
-    
+
     llm = Llama(
         "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
         tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(

--- a/docs/cookbook/qa-with-citations.md
+++ b/docs/cookbook/qa-with-citations.md
@@ -8,29 +8,48 @@ We will use [llama.cpp](https://github.com/ggerganov/llama.cpp) using the [llama
 pip install llama-cpp-python
 ```
 
-We pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-
-```bash
-wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
-```
-
-We initialize the model:
-
+We download the model weights by passing the name of the repository on the HuggingFace Hub, and the filenames (or glob pattern):
 ```python
-from llama_cpp import Llama
+import llama_cpp
 from outlines import generate, models
 
-llm = Llama(
-    "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
-    tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
-        "NousResearch/Hermes-2-Pro-Llama-3-8B"
-    ),
-    n_gpu_layers=-1,
-    flash_attn=True,
-    n_ctx=8192,
-    verbose=False
-)
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+            "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+            tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+            ),
+            n_gpu_layers=-1,
+            flash_attn=True,
+            n_ctx=8192,
+            verbose=False)
 ```
+
+??? note "(Optional) Store the model weights in a custom folder"
+
+    By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
+    
+    ```bash
+    wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
+    ```
+    
+    We initialize the model:
+    
+    ```python
+    import llama_cpp
+    from llama_cpp import Llama
+    from outlines import generate, models
+    
+    llm = Llama(
+        "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+        ),
+        n_gpu_layers=-1,
+        flash_attn=True,
+        n_ctx=8192,
+        verbose=False
+    )
+    ```
 
 ## Generate Synthetic Data
 

--- a/docs/cookbook/qa-with-citations.md
+++ b/docs/cookbook/qa-with-citations.md
@@ -13,7 +13,7 @@ We download the model weights by passing the name of the repository on the Huggi
 import llama_cpp
 from outlines import generate, models
 
-model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
             "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
             tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
             "NousResearch/Hermes-2-Pro-Llama-3-8B"
@@ -27,18 +27,18 @@ model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
 ??? note "(Optional) Store the model weights in a custom folder"
 
     By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-    
+
     ```bash
     wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
     ```
-    
+
     We initialize the model:
-    
+
     ```python
     import llama_cpp
     from llama_cpp import Llama
     from outlines import generate, models
-    
+
     llm = Llama(
         "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
         tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(

--- a/docs/cookbook/react_agent.md
+++ b/docs/cookbook/react_agent.md
@@ -17,7 +17,7 @@ We download the model weights by passing the name of the repository on the Huggi
 import llama_cpp
 from outlines import generate, models
 
-model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
             "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
             tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
             "NousResearch/Hermes-2-Pro-Llama-3-8B"
@@ -31,18 +31,18 @@ model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF",
 ??? note "(Optional) Store the model weights in a custom folder"
 
     By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-    
+
     ```bash
     wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
     ```
-    
+
     We initialize the model:
-    
+
     ```python
     import llama_cpp
     from llama_cpp import Llama
     from outlines import generate, models
-    
+
     llm = Llama(
         "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
         tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(

--- a/docs/cookbook/react_agent.md
+++ b/docs/cookbook/react_agent.md
@@ -12,31 +12,48 @@ We use [llama.cpp](https://github.com/ggerganov/llama.cpp) using the [llama-cpp-
 pip install llama-cpp-python
 ```
 
-We pull a quantized GGUF model, in this guide we pull [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
-
-```bash
-wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
-```
-
-We initialize the model:
-
+We download the model weights by passing the name of the repository on the HuggingFace Hub, and the filenames (or glob pattern):
 ```python
 import llama_cpp
-from llama_cpp import Llama
 from outlines import generate, models
 
-llm = Llama(
-    "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
-    tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
-        "NousResearch/Hermes-2-Pro-Llama-3-8B"
-    ),
-    n_gpu_layers=-1,
-    flash_attn=True,
-    n_ctx=8192,
-    verbose=False
-)
-model = models.LlamaCpp(llm)
+model = models.llamacpp("NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF", 
+            "Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+            tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+            ),
+            n_gpu_layers=-1,
+            flash_attn=True,
+            n_ctx=8192,
+            verbose=False)
 ```
+
+??? note "(Optional) Store the model weights in a custom folder"
+
+    By default the model weights are downloaded to the hub cache but if we want so store the weights in a custom folder, we pull a quantized GGUF model [Hermes-2-Pro-Llama-3-8B](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B-GGUF) by [NousResearch](https://nousresearch.com/) from [HuggingFace](https://huggingface.co/):
+    
+    ```bash
+    wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
+    ```
+    
+    We initialize the model:
+    
+    ```python
+    import llama_cpp
+    from llama_cpp import Llama
+    from outlines import generate, models
+    
+    llm = Llama(
+        "/path/to/model/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf",
+        tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(
+            "NousResearch/Hermes-2-Pro-Llama-3-8B"
+        ),
+        n_gpu_layers=-1,
+        flash_attn=True,
+        n_ctx=8192,
+        verbose=False
+    )
+    ```
 
 ## Build a ReAct agent
 


### PR DESCRIPTION
Change cookbook examples: Download model weights in the hub cache folder