### PR TITLE
Update modal example

### DIFF
--- a/docs/cookbook/deploy-using-modal.md
+++ b/docs/cookbook/deploy-using-modal.md
@@ -54,7 +54,7 @@ outlines_image = Image.debian_slim(python_version="3.11").pip_install(
 
 ## Setting the container up
 
-When running longer Modal apps, it's recommended to download your language model when the container starts, rather than when the function is called. This is to reduce latency on the first time you send a request to the container.
+When running longer Modal apps, it's recommended to download your language model when the container starts, rather than when the function is called. This will cache the model for future runs.
 
 **NOTE**: Using `mistralai/Mistral-7B-v0.1` requires you to request access on HuggingFace using the account associated with the token you set in the image definition. Please do so [here](https://huggingface.co/mistralai/Mistral-7B-v0.1).
 

--- a/docs/cookbook/deploy-using-modal.md
+++ b/docs/cookbook/deploy-using-modal.md
@@ -34,6 +34,10 @@ import os
 # See the documentation here: https://modal.com/docs/reference/modal.App
 app = App(name="outlines-app")
 
+# Specify a language model to use.
+# Another good model to use is "NousResearch/Hermes-2-Pro-Mistral-7B"
+language_model = "mistral-community/Mistral-7B-v0.2"
+
 # Please set an environment variable HF_TOKEN with your Hugging Face API token.
 # The code below (the .env({...}) part) will copy the token from your local
 # environment to the container.
@@ -43,6 +47,7 @@ outlines_image = Image.debian_slim(python_version="3.11").pip_install(
     "transformers",
     "datasets",
     "accelerate",
+    "sentencepiece",
 ).env({
     'HF_TOKEN':os.environ['HF_TOKEN']
 
@@ -56,15 +61,13 @@ outlines_image = Image.debian_slim(python_version="3.11").pip_install(
 
 When running longer Modal apps, it's recommended to download your language model when the container starts, rather than when the function is called. This will cache the model for future runs.
 
-**NOTE**: Using `mistralai/Mistral-7B-v0.1` requires you to request access on HuggingFace using the account associated with the token you set in the image definition. Please do so [here](https://huggingface.co/mistralai/Mistral-7B-v0.1).
-
 ```python
 # This function imports the model from Hugging Face. The modal container
 # will call this function when it starts up. This is useful for
 # downloading models, setting up environment variables, etc.
 def import_model():
     import outlines
-    outlines.models.transformers("mistralai/Mistral-7B-v0.1")
+    outlines.models.transformers(language_model)
 
 # This line tells the container to run the import_model function when it starts.
 outlines_image = outlines_image.run_function(import_model)
@@ -135,7 +138,7 @@ def generate(
     # should have already downloaded the model, so this call
     # only loads the model into GPU memory.
     model = outlines.models.transformers(
-        "mistralai/Mistral-7B-v0.1", device="cuda"
+        language_model, device="cuda"
     )
 
     # Generate a character description based on the prompt.

--- a/docs/cookbook/deploy-using-modal.md
+++ b/docs/cookbook/deploy-using-modal.md
@@ -21,7 +21,7 @@ pip install modal outlines
 
 ## Build the image
 
-First we need to define our container image. We download the Mistral-7B-v0.1 model from HuggingFace as part of the definition of the image so it only needs to be done once (you need to provide an [access token](https://huggingface.co/settings/tokens)).
+First we need to define our container image. If you need to access a gated model, you will need to provide an [access token](https://huggingface.co/settings/tokens). See the `.env` call below for how to provide a HuggingFace token.
 
 Setting a token is best done by setting an environment variable `HF_TOKEN` with your token. If you do not wish to do this, we provide a commented-out line in the code to set the token directly in the code.
 
@@ -49,6 +49,7 @@ outlines_image = Image.debian_slim(python_version="3.11").pip_install(
     "accelerate",
     "sentencepiece",
 ).env({
+    # This will pull in your HF_TOKEN environment variable if you have one.
     'HF_TOKEN':os.environ['HF_TOKEN']
 
     # To set the token directly in the code, uncomment the line below and replace

--- a/docs/cookbook/deploy-using-modal.md
+++ b/docs/cookbook/deploy-using-modal.md
@@ -56,6 +56,8 @@ outlines_image = Image.debian_slim(python_version="3.11").pip_install(
 
 When running longer Modal apps, it's recommended to download your language model when the container starts, rather than when the function is called. This is to reduce latency on the first time you send a request to the container.
 
+**NOTE**: Using `mistralai/Mistral-7B-v0.1` requires you to request access on HuggingFace using the account associated with the token you set in the image definition. Please do so [here](https://huggingface.co/mistralai/Mistral-7B-v0.1).
+
 ```python
 # This function imports the model from Hugging Face. The modal container
 # will call this function when it starts up. This is useful for
@@ -113,12 +115,9 @@ schema = """{
 }"""
 ```
 
-To make the inference work on Modal we need to wrap the corresponding function in a `@app.function` decorator. We pass to this decorator the image and GPU on which we want this function to run (here an A100 with 80GB memory):
+To make the inference work on Modal we need to wrap the corresponding function in a `@app.function` decorator. We pass to this decorator the image and GPU on which we want this function to run.
 
-The @app.function decorator tells modal to create a function that can be called.
-The function will run in the container with the image specified above.
-
-We pick an A100 GPU with 80GB. Other valid GPUs can be found [here](https://modal.com/docs/reference/modal.gpu).
+Let's choose an A100 with 80GB memory. Valid GPUs can be found [here](https://modal.com/docs/reference/modal.gpu).
 
 ```python
 # Define a function that uses the image we chose, and specify the GPU


### PR DESCRIPTION
I updated some of the text of the modal example to add more information on what's happening where, since Modal's general structure may be unfamiliar to new users.

List of changes:

- Removed version constraints on the image. I think this is a questionable choice so I'd love input -- in general, this should probably better be addressed by versioning the docs #999. There's an open PR #1059 here that can help with this too -- I'm happy to revert to pinned versions, or at least update to the current version of outlines (0.0.46).
- Added a brief note that the Mistral model is gated and requires you to request access on HuggingFace.
- Moved the environment variable setting from `import_model` to a `.env` call when the image is created. This is more idiomatic Modal code. It was previously addressed in #1058, but this should be more current.
- More comments and prep.