### PR TITLE
Add missing CI matrix step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,16 @@ jobs:
     - name: Set up test environment
       run: |
         python -m pip install --upgrade pip
-        pip install .[test]
+        pip install -e .[test]
+    - name: Create matrix id
+      id: matrix-id
+      env:
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      run: |
+        echo $MATRIX_CONTEXT
+        export MATRIX_ID=`echo $MATRIX_CONTEXT | md5sum | cut -c 1-32`
+        echo $MATRIX_ID
+        echo "::set-output name=id::$MATRIX_ID"
     - name: Run tests
       run: |
         pytest --cov=outlines


### PR DESCRIPTION
The matrix ID hash used to produce coverage files isn't being computed.  This PR fixes that.
Also, this changes the tests so that they use development installs, which should help us avoid relative path issues.