### PR TITLE
Pass `text` and `images` as kwargs to VLM processor

### DIFF
--- a/outlines/models/transformers_vision.py
+++ b/outlines/models/transformers_vision.py
@@ -43,9 +43,9 @@ class TransformersVision(Transformers):
         -------
         The generated text
         """
-        inputs = self.processor(prompts, media, padding=True, return_tensors="pt").to(
-            self.model.device
-        )
+        inputs = self.processor(
+            text=prompts, images=media, padding=True, return_tensors="pt"
+        ).to(self.model.device)
 
         generation_kwargs = self._get_generation_kwargs(
             prompts,


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/1123

# Problem

In a new VLM processor, the text and image arguments are reversed (https://github.com/huggingface/transformers/pull/32473/files#r1734779753). This results in `outlines.models.transformers_vision` passing the arguments to the processor incorrectly.

# Solution

Pass by kwarg

# Testing

- CI doesn't run `transformers_vision` tests because they require GPU. Tests for `transformers_vision` pass locally, however.
- CI was run while huggingface.co was experiencing instability, 3.8 passed, 3.10 failed due to a failure to retrieve a tokenizer.