### PR TITLE
fix: cache key as string

### DIFF
--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -126,7 +126,8 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
 
         def __cache_key__(*args, **kwargs):
             """Make key for cache given function arguments."""
-            return args_to_key(base, args, kwargs, typed, ignore)
+            # return args_to_key(base, args, kwargs, typed, ignore)
+            return str(args_to_key(base, args, kwargs, typed, ignore))
 
         wrapper.__cache_key__ = __cache_key__  # type: ignore
         wrapper.__memory__ = memory  # type: ignore


### PR DESCRIPTION
When using vllm and outlines, in our use cases, it seems that the diskcache functionality is not working. Everytime the server is startup, it doesn't seem to be able to reuse the previously computed FSM cache.

One way that can fix this issue is to serialize the cache key object as a string.
The changes can be found in this PR.