### PR TITLE
Standardize the use of the model_name argument

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -16,7 +16,7 @@ from .llamacpp import LlamaCpp, from_llamacpp
 from .mlxlm import MLXLM, from_mlxlm
 from .ollama import Ollama, from_ollama
 from .openai import from_openai, OpenAI
-from .sglang import from_sglang, SgLang, AsyncSgLang
+from .sglang import from_sglang, SGLang, AsyncSgLang
 from .tgi import from_tgi, TGI, AsyncTGI
 from .transformers import (
     Transformers,
@@ -42,6 +42,6 @@ BlackBoxModel = Union[
     Ollama,
     OpenAI,
     TGI,
-    SgLang,
+    SGLang,
     VLLM,
 ]

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -1,6 +1,14 @@
 import warnings
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterator,
+    List,
+    Set,
+    Tuple,
+    Union,
+)
 
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import Tokenizer
@@ -21,7 +29,8 @@ class LlamaCppTokenizer(Tokenizer):
 
         self.tokenizer = model.tokenizer()
 
-        # TODO: Remove when https://github.com/ggerganov/llama.cpp/pull/5613 is resolved
+        # TODO: Remove when https://github.com/ggerganov/llama.cpp/pull/5613
+        # is resolved
         self._hf_tokenizer = None
         try:
             self.vocabulary = model.tokenizer_.hf_tokenizer.get_vocab()
@@ -35,7 +44,8 @@ class LlamaCppTokenizer(Tokenizer):
         # ensure stable ordering of vocabulary
         self.vocabulary = {
             tok: tok_id
-            for tok, tok_id in sorted(self.vocabulary.items(), key=lambda x: x[1])
+            for tok, tok_id
+            in sorted(self.vocabulary.items(), key=lambda x: x[1])
         }
 
         self._hash = None
@@ -45,14 +55,19 @@ class LlamaCppTokenizer(Tokenizer):
         return [decoded_bytes.decode("utf-8", errors="ignore")]
 
     def encode(
-        self, prompt: Union[str, List[str]], add_bos: bool = True, special: bool = True
+        self,
+        prompt: Union[str, List[str]],
+        add_bos: bool = True,
+        special: bool = True,
     ) -> Tuple[List[int], List[int]]:
         if isinstance(prompt, list):
             raise NotImplementedError(
                 "llama-cpp-python tokenizer doesn't support batch tokenization"
             )
         token_ids = self.tokenizer.tokenize(
-            prompt.encode("utf-8", errors="ignore"), add_bos=add_bos, special=special
+            prompt.encode("utf-8", errors="ignore"),
+            add_bos=add_bos,
+            special=special,
         )
         # generate attention mask, missing from llama-cpp-python
         attention_mask = [
@@ -65,7 +80,10 @@ class LlamaCppTokenizer(Tokenizer):
             from transformers.file_utils import SPIECE_UNDERLINE
 
             token_str = self._hf_tokenizer.convert_tokens_to_string([token])
-            if token.startswith(SPIECE_UNDERLINE) or token == "<0x20>": # pragma: no cover
+            if (
+                token.startswith(SPIECE_UNDERLINE)
+                or token == "<0x20>"
+            ):  # pragma: no cover
                 token_str = " " + token_str
             return token_str
         else:
@@ -163,8 +181,8 @@ class LlamaCpp(Model):
         output_type
             The logits processor to use when generating text.
         inference_kwargs
-            The inference kwargs that can be passed to the `Llama.__call__` method
-            in the `llama-cpp-python` library.
+            The inference kwargs that can be passed to the `Llama.__call__`
+            method in the `llama-cpp-python` library.
 
         Returns
         -------
@@ -173,7 +191,8 @@ class LlamaCpp(Model):
         """
         if isinstance(output_type, CFGLogitsProcessor):
             raise NotImplementedError(
-                "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
+                "CFG generation is not supported for LlamaCpp due to bug in "
+                "the llama_cpp tokenizer"
             )
 
         completion = self.model(
@@ -199,8 +218,8 @@ class LlamaCpp(Model):
         output_type
             The logits processor to use when generating text.
         inference_kwargs
-            The inference kwargs that can be passed to the `Llama.__call__` method
-            in the `llama-cpp-python` library.
+            The inference kwargs that can be passed to the `Llama.__call__`
+            method in the `llama-cpp-python` library.
 
         Returns
         -------
@@ -209,7 +228,8 @@ class LlamaCpp(Model):
         """
         if isinstance(output_type, CFGLogitsProcessor):
             raise NotImplementedError(
-                "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
+                "CFG generation is not supported for LlamaCpp due to bug in "
+                "the llama_cpp tokenizer"
             )
 
         generator = self.model(

--- a/outlines/models/sglang.py
+++ b/outlines/models/sglang.py
@@ -42,7 +42,7 @@ class SgLangTypeAdapter(ModelTypeAdapter):
         term = python_types_to_terms(output_type)
         if isinstance(term, CFG):
             warnings.warn(
-                "SgLang grammar-based structured outputs expects an EBNF "
+                "SGLang grammar-based structured outputs expects an EBNF "
                 "grammar instead of a Lark grammar as is generally used in "
                 "Outlines. The grammar cannot be used as a structured output "
                 "type with an outlines backend, it is only compatible with "
@@ -57,11 +57,11 @@ class SgLangTypeAdapter(ModelTypeAdapter):
             return {"extra_body": {"regex": to_regex(term)}}
 
 
-class SgLang(Model):
+class SGLang(Model):
     """Represents a client to a `sglang` server."""
 
     def __init__(self, client, model_name: Optional[str] = None):
-        """Create a `SgLang` model instance.
+        """Create a `SGLang` model instance.
 
         Parameters
         ----------
@@ -102,7 +102,7 @@ class SgLang(Model):
         for message in messages:
             if message.refusal is not None:  # pragma: no cover
                 raise ValueError(
-                    f"The SgLang server refused to answer the request: "
+                    f"The SGLang server refused to answer the request: "
                     f"{message.refusal}"
                 )
 
@@ -140,18 +140,16 @@ class SgLang(Model):
                 yield chunk.choices[0].delta.content
 
     def _build_client_args(self, model_input, output_type, **inference_kwargs):
-        """Build the arguments to pass to the SgLang client."""
+        """Build the arguments to pass to the SGLang client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
         inference_kwargs.update(output_type_args)
-        model_name = (
-            inference_kwargs.pop("model", self.model_name)
-            or self.model_name
-        )
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
 
         client_args = {
             **messages,
-            "model": model_name,
             **inference_kwargs,
         }
 
@@ -242,18 +240,16 @@ class AsyncSgLang(AsyncModel):
                 yield chunk.choices[0].delta.content
 
     def _build_client_args(self, model_input, output_type, **inference_kwargs):
-        """Build the arguments to pass to the SgLang client."""
+        """Build the arguments to pass to the SGLang client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
         inference_kwargs.update(output_type_args)
-        model_name = (
-            inference_kwargs.pop("model", self.model_name)
-            or self.model_name
-        )
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
 
         client_args = {
             **messages,
-            "model": model_name,
             **inference_kwargs,
         }
 
@@ -263,11 +259,11 @@ class AsyncSgLang(AsyncModel):
 def from_sglang(
     client: Union["OpenAI", "AsyncOpenAI"],
     model_name: Optional[str] = None,
-) -> Union[SgLang, AsyncSgLang]:
+) -> Union[SGLang, AsyncSgLang]:
     from openai import AsyncOpenAI, OpenAI
 
     if isinstance(client, OpenAI):
-        return SgLang(client, model_name)
+        return SGLang(client, model_name)
     elif isinstance(client, AsyncOpenAI):
         return AsyncSgLang(client, model_name)
     else:

--- a/outlines/models/tgi.py
+++ b/outlines/models/tgi.py
@@ -141,7 +141,6 @@ class TGI(Model):
         output_type_args = self.type_adapter.format_output_type(output_type)
         inference_kwargs.update(output_type_args)
 
-
         client_args = {
             "prompt": prompt,
             **inference_kwargs,

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -138,14 +138,12 @@ class VLLM(Model):
         output_type_args = self.type_adapter.format_output_type(output_type)
         extra_body = inference_kwargs.pop("extra_body", {})
         extra_body.update(output_type_args)
-        model_name = (
-            inference_kwargs.pop("model", self.model_name)
-            or self.model_name
-        )
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
 
         client_args = {
             **messages,
-            "model": model_name,
             **inference_kwargs,
         }
         if extra_body:
@@ -244,21 +242,18 @@ class AsyncVLLM(AsyncModel):
         output_type_args = self.type_adapter.format_output_type(output_type)
         extra_body = inference_kwargs.pop("extra_body", {})
         extra_body.update(output_type_args)
-        model_name = (
-            inference_kwargs.pop("model", self.model_name)
-            or self.model_name
-        )
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
 
         client_args = {
             **messages,
-            "model": model_name,
             **inference_kwargs,
         }
         if extra_body:
             client_args["extra_body"] = extra_body
 
         return client_args
-
 
 
 def from_vllm(

--- a/tests/models/test_dottxt.py
+++ b/tests/models/test_dottxt.py
@@ -10,15 +10,20 @@ from outlines import Generator
 from outlines.models.dottxt import Dottxt
 
 
+MODEL_NAME = "dottxt/dottxt-v1-alpha"
+MODEL_REVISION = "d06c86726aadd8dadb92c5b9b9e3ce8ef246c471"
+
+
 class User(BaseModel):
     first_name: str
     last_name: str
     user_id: int
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def api_key():
-    """Get the Dottxt API key from the environment, providing a default value if not found.
+    """Get the Dottxt API key from the environment, providing a default value
+    if not found.
 
     This fixture should be used for tests that do not make actual api calls,
     but still require to initialize the Dottxt client.
@@ -30,70 +35,97 @@ def api_key():
     return api_key
 
 
-def test_dottxt_wrong_init_parameters(api_key):
-    with pytest.raises(TypeError, match="got an unexpected"):
-        client = DottxtClient(api_key=api_key)
-        Dottxt(client, foo=10)
-
-
-def test_dottxt_wrong_output_type(api_key):
-    with pytest.raises(TypeError, match="You must provide an output type"):
-        client = DottxtClient(api_key=api_key)
-        model = Dottxt(client)
-        model("prompt")
-
-
-def test_dottxt_init_from_client(api_key):
+@pytest.fixture(scope="session")
+def model_name_and_revision(api_key):
     client = DottxtClient(api_key=api_key)
+    model_list = client.list_models()
+    return (model_list[0].name, model_list[0].revision)
+
+
+@pytest.fixture(scope="session")
+def model(api_key, model_name_and_revision):
+    client = DottxtClient(api_key=api_key)
+    return Dottxt(
+        client,
+        model_name_and_revision[0],
+        model_name_and_revision[1],
+    )
+
+
+@pytest.fixture(scope="session")
+def model_no_model_name(api_key):
+    client = DottxtClient(api_key=api_key)
+    return Dottxt(client)
+
+
+@pytest.mark.api_call
+def test_dottxt_init_from_client(api_key, model_name_and_revision):
+    client = DottxtClient(api_key=api_key)
+
+    # Without model name
     model = outlines.from_dottxt(client)
     assert isinstance(model, Dottxt)
     assert model.client == client
+    assert model.model_name is None
+
+    # With model name
+    model = outlines.from_dottxt(
+        client,
+        model_name_and_revision[0],
+        model_name_and_revision[1],
+    )
+    assert isinstance(model, Dottxt)
+    assert model.client == client
+    assert model.model_name == model_name_and_revision[0]
+    assert model.model_revision == model_name_and_revision[1]
 
 
-@pytest.mark.api_call
-def test_dottxt_wrong_input_type(api_key):
+def test_dottxt_wrong_output_type(model_no_model_name):
+    with pytest.raises(TypeError, match="You must provide an output type"):
+        model_no_model_name("prompt")
+
+
+def test_dottxt_wrong_input_type(model_no_model_name):
     with pytest.raises(TypeError, match="is not available"):
-        client = DottxtClient(api_key=api_key)
-        model = Dottxt(client)
-        model(["prompt"], User)
+        model_no_model_name(["prompt"], User)
 
 
 @pytest.mark.api_call
-def test_dottxt_wrong_inference_parameters(api_key):
+def test_dottxt_wrong_inference_parameters(model_no_model_name):
     with pytest.raises(TypeError, match="got an unexpected"):
-        client = DottxtClient(api_key=api_key)
-        model = Dottxt(client)
-        model("prompt", User, foo=10)
+        model_no_model_name("prompt", User, foo=10)
 
 
 @pytest.mark.api_call
-def test_dottxt_direct_pydantic_call(api_key):
-    client = DottxtClient(api_key=api_key)
-    model = Dottxt(client)
-    result = model("Create a user", User)
+def test_dottxt_direct_pydantic_call(model_no_model_name):
+    result = model_no_model_name("Create a user", User)
     assert "first_name" in json.loads(result)
 
 
 @pytest.mark.api_call
-def test_dottxt_direct_jsonschema_call(api_key):
-    client = DottxtClient(api_key=api_key)
-    model = Dottxt(client)
-    result = model("Create a user", User)
+def test_dottxt_direct_jsonschema_call(
+    model_no_model_name, model_name_and_revision
+):
+    result = model_no_model_name(
+        "Create a user",
+        User,
+        model_name=model_name_and_revision[0],
+        model_revision=model_name_and_revision[1],
+    )
     assert "first_name" in json.loads(result)
 
 
 @pytest.mark.api_call
-def test_dottxt_generator_pydantic_call(api_key):
-    client = DottxtClient(api_key=api_key)
-    model = Dottxt(client)
+def test_dottxt_generator_pydantic_call(model):
     generator = Generator(model, User)
     result = generator("Create a user")
     assert "first_name" in json.loads(result)
 
 
 @pytest.mark.api_call
-def test_dottxt_streaming(api_key):
-    client = DottxtClient(api_key=api_key)
-    model = Dottxt(client)
-    with pytest.raises(NotImplementedError, match="Dottxt does not support streaming"):
+def test_dottxt_streaming(model):
+    with pytest.raises(
+        NotImplementedError,
+        match="Dottxt does not support streaming"
+    ):
         model.stream("Create a user", User)

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -27,6 +27,11 @@ def model():
     return Gemini(Client(), MODEL_NAME)
 
 
+@pytest.fixture(scope="session")
+def model_no_model_name():
+    return Gemini(Client())
+
+
 @pytest.fixture
 def image():
     width, height = 1, 1
@@ -72,8 +77,11 @@ def test_gemini_simple_call(model):
 
 
 @pytest.mark.api_call
-def test_gemini_direct_call(model):
-    result = model("Respond with one word. Not more.")
+def test_gemini_direct_call(model_no_model_name):
+    result = model_no_model_name(
+        "Respond with one word. Not more.",
+        model=MODEL_NAME
+    )
     assert isinstance(result, str)
 
 

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -11,69 +11,90 @@ from outlines.models import Ollama
 
 
 MODEL_NAME = "tinyllama"
-CLIENT = OllamaClient()
 
 
-def test_wrong_inference_parameters():
+@pytest.fixture
+def model():
+    return Ollama(OllamaClient(), MODEL_NAME)
+
+
+@pytest.fixture
+def model_no_model_name():
+    return Ollama(OllamaClient())
+
+
+def test_init_from_client():
+    client = OllamaClient()
+
+    # With model name
+    model = outlines.from_ollama(client, MODEL_NAME)
+    assert isinstance(model, Ollama)
+    assert model.client == client
+    assert model.model_name == MODEL_NAME
+
+    # Without model name
+    model = outlines.from_ollama(client)
+    assert isinstance(model, Ollama)
+    assert model.client == client
+    assert model.model_name is None
+
+
+def test_wrong_inference_parameters(model):
     with pytest.raises(TypeError, match="got an unexpected"):
-        Ollama(CLIENT, MODEL_NAME).generate(
+        model.generate(
             "Respond with one word. Not more.", None, foo=10
         )
 
 
-def test_init_from_client():
-    model = outlines.from_ollama(CLIENT, MODEL_NAME)
-    assert isinstance(model, Ollama)
-    assert model.client == CLIENT
-
-
-def test_ollama_simple():
-    result = Ollama(CLIENT, MODEL_NAME).generate(
+def test_ollama_simple(model):
+    result = model.generate(
         "Respond with one word. Not more.", None
     )
     assert isinstance(result, str)
 
 
-def test_ollama_direct():
-    result = Ollama(CLIENT, MODEL_NAME)("Respond with one word. Not more.", None)
+def test_ollama_direct(model_no_model_name):
+    result = model_no_model_name(
+        "Respond with one word. Not more.",
+        None,
+        model=MODEL_NAME,
+    )
     assert isinstance(result, str)
 
 
-def test_ollama_json():
+def test_ollama_json(model):
     class Foo(BaseModel):
         foo: Annotated[str, Field(max_length=1)]
 
-    result = Ollama(CLIENT, MODEL_NAME)("Respond with one word. Not more.", Foo)
+    result = model("Respond with one word. Not more.", Foo)
     assert isinstance(result, str)
     assert "foo" in json.loads(result)
 
 
-def test_ollama_wrong_output_type():
+def test_ollama_wrong_output_type(model):
     class Foo(Enum):
         bar = "Bar"
         foor = "Foo"
 
     with pytest.raises(TypeError, match="is not supported"):
-        Ollama(CLIENT, MODEL_NAME).generate("foo?", Foo)
+        model.generate("foo?", Foo)
 
 
-def test_ollama_wrong_input_type():
+def test_ollama_wrong_input_type(model):
     with pytest.raises(TypeError, match="is not available"):
-        Ollama(CLIENT, MODEL_NAME).generate(["foo?", "bar?"], None)
+        model.generate(["foo?", "bar?"], None)
 
 
-def test_ollama_stream():
-    model = Ollama(CLIENT, MODEL_NAME)
+def test_ollama_stream(model):
     generator = model.stream("Write a sentence about a cat.")
     assert isinstance(next(generator), str)
 
 
-def test_ollama_stream_json():
+def test_ollama_stream_json(model_no_model_name):
     class Foo(BaseModel):
         foo: Annotated[str, Field(max_length=2)]
 
-    model = Ollama(CLIENT, MODEL_NAME)
-    generator = model.stream("Create a character.", Foo)
+    generator = model_no_model_name.stream("Create a character.", Foo, model=MODEL_NAME)
     generated_text = []
     for text in generator:
         generated_text.append(text)

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -108,7 +108,7 @@ def test_sglang_type_adapter_output_type(
     assert type_adapter.format_output_type(None) == {}
     with pytest.warns(
         UserWarning,
-        match="SgLang grammar-based structured outputs expects an EBNF"
+        match="SGLang grammar-based structured outputs expects an EBNF"
     ):
         assert type_adapter.format_output_type(cfg_instance) == {
             "extra_body": {"ebnf": CFG_STRING}

--- a/tests/v0_legacy/models/test_openai_legacy.py
+++ b/tests/v0_legacy/models/test_openai_legacy.py
@@ -111,13 +111,6 @@ def test_openai_legacy_init():
     assert not hasattr(model, "model_name")
     assert not hasattr(model, "type_adapter")
 
-    # directly through the OpenAI class without config
-    with pytest.raises(TypeError):
-        models.OpenAI(
-            AsyncOpenAI(),
-            system_prompt="You are a helpful assistant.",
-        )
-
 
 def test_azure_openai_legacy_init():
     with pytest.warns(


### PR DESCRIPTION
Addresses #1583 

We standardize the behavior by including an optional `model_name` argument in the loading function of all models for which a model name can be provided (so all models except those of type `SteerableModel` and `TGI`).

In the text generation methods, we give precedence to the inference keyword argument for the model name, otherwise we fall back to the `model_name` value provided at initialization (if there's one)