### PR TITLE
Fix the broken links in the home page of the documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ hide:
 #
 
 <figure markdown>
-![](/assets/images/logo-light-mode.svg#only-light){ width="500" }
-![](/assets/images/logo-dark-mode.svg#only-dark){ width="500" }
+![](assets/images/logo-light-mode.svg#only-light){ width="500" }
+![](assets/images/logo-dark-mode.svg#only-dark){ width="500" }
 </figure>
 
 LLMs are powerful but their outputs are unpredictable. Most solutions attempt to fix bad outputs after generation using parsing, regex, or fragile code that breaks easily.
@@ -71,16 +71,18 @@ pip install outlines
 
 ## Supported inference APIs, libraries & servers
 
-- [vLLM](reference/models/vllm.md)
-- [Transformers](reference/models/transformers.md)
-- [llama.cpp](reference/models/llamacpp.md)
-- [Ollama](reference/models/ollama.md)
-- [MLX-LM](reference/models/mlxlm.md)
-- [SgLang](reference/models/sglang.md)
-- [TGI](reference/models/tgi.md)
-- [OpenAI](reference/models/openai.md)
-- [Anthropic](reference/models/anthropic.md)
-- [Gemini](reference/models/gemini.md)
+- [vLLM](features/models/vllm.md)
+- [vLLM offline](features/models/vllm_offline.md)
+- [Transformers](features/models/transformers.md)
+- [llama.cpp](features/models/llamacpp.md)
+- [Ollama](features/models/ollama.md)
+- [MLX-LM](features/models/mlxlm.md)
+- [SgLang](features/models/sglang.md)
+- [TGI](features/models/tgi.md)
+- [OpenAI](features/models/openai.md)
+- [Anthropic](features/models/anthropic.md)
+- [Gemini](features/models/gemini.md)
+- [Dottxt](features/models/dottxt.md)
 
 ## Who is using Outlines?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,46 +98,6 @@ plugins:
     - redirects:
           redirect_maps:
               "welcome.md": "index.md"
-              "reference/chat_templating.md": "guide/chat_templating.md"
-              "blog.md": "https://blog.dottxt.co"
-              "cookbook/index.md": "examples/index.md"
-              "cookbook/classification.md": "examples/classification.md"
-              "cookbook/extraction.md": "examples/extraction.md"
-              "cookbook/dating_profiles.md": "examples/dating_profiles.md"
-              "cookbook/chain_of_density.md": "examples/chain_of_density.md"
-              "cookbook/models_playing_chess.md": "examples/models_playing_chess.md"
-              "cookbook/simtom.md": "examples/simtom.md"
-              "cookbook/qa-with-citations.md": "examples/qa-with-citations.md"
-              "cookbook/knowledge_graph_extraction.md": "examples/knowledge_graph_extraction.md"
-              "cookbook/structured_generation_workflow.md": "examples/structured_generation_workflow.md"
-              "cookbook/chain_of_thought.md": "examples/chain_of_thought.md"
-              "cookbook/react_agent.md": "examples/react_agent.md"
-              "cookbook/atomic_caption.md": "examples/atomic_caption.md"
-              "cookbook/read-pdfs.md": "examples/read-pdfs.md"
-              "cookbook/earnings-reports.md": "examples/earnings-reports.md"
-              "cookbook/receipt-digitization.md": "examples/receipt-digitization.md"
-              "cookbook/extract_event_details.md": "examples/extract_event_details.md"
-              "cookbook/deploy-using-bentoml.md": "examples/deploy-using-bentoml.md"
-              "cookbook/deploy-using-cerebrium.md": "examples/deploy-using-cerebrium.md"
-              "cookbook/deploy-using-modal.md": "examples/deploy-using-modal.md"
-
-              # Root files
-              "quickstart.md": "getting_started/index.md"
-
-              # API to features redirects
-              "api/index.md": "features/index.md"
-              "api/json_schema.md": "features/types/json_schema.md"
-              "api/regex.md": "features/types/regex.md"
-              "api/applications.md": "features/utility/application.md"
-              "api/templates.md": "features/utility/template.md"
-              "api/guide.md": "features/advanced/guide.md"
-              "api/parsing.md": "features/advanced/parsing.md"
-              "api/models.md": "features/available_models.md"
-
-              # API subdirectories to features
-              "api/types/": "features/types/index.md"
-              "api/core/": "features/index.md"
-              "api/advanced/": "features/index.md"
 
     - git-committers:
         repository: dottxt-ai/outlines


### PR DESCRIPTION
Addresses #1623

2 additional things:
- The Outlines logo at the home page is not found when deployed while it's fine in local. As the other images with relative paths work fine, I changed the link to a relative path
- I removed many outdated redirects in the `mkdocs.yml` that were adding noise in the build process of the documentation