### PR TITLE
Fix error tokenizer arg for transformers models' generate method

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -220,7 +220,6 @@ class Transformers(Model):
 
         tokenizer.padding_side = "left"
         self.model = model
-        self.transformer_tokenizer = tokenizer
         self.tokenizer = TransformerTokenizer(tokenizer)
         self.type_adapter = TransformersTypeAdapter()
 
@@ -332,9 +331,9 @@ class Transformers(Model):
 
     def _generate_output_seq(self, prompts, inputs, **inference_kwargs):
         input_ids = inputs["input_ids"]
+
         output_ids = self.model.generate(
             **inputs,
-            tokenizer=self.transformer_tokenizer,
             **inference_kwargs,
         )
 

--- a/tests/v0_legacy/models/test_transformers_legacy.py
+++ b/tests/v0_legacy/models/test_transformers_legacy.py
@@ -168,5 +168,6 @@ def test_transformers_legacy_call_generation():
         "foo",
         2,
         length_penalty=0.5,
+        tokenizer=model.tokenizer.tokenizer,
     )
     assert isinstance(result, str)

--- a/tests/v0_legacy/models/test_transformers_vision_legacy.py
+++ b/tests/v0_legacy/models/test_transformers_vision_legacy.py
@@ -106,5 +106,6 @@ def test_transformers_vision_legacy_call_generation():
         "foo",
         2,
         length_penalty=0.5,
+        tokenizer=model.tokenizer.tokenizer,
     )
     assert isinstance(result, str)


### PR DESCRIPTION
Closes #1678 

The `tokenizer` keyword argument that we were providing to the `generate` method of `transformers` model makes some of them raise an error. This error had not been noticed yet and was not caught by our unit tests because behavior differs from a model to another, and most models do not raise an error (they just ignore the argument).

The reason for which we added this argument in the first place is that models that support the `stop_strings` argument require to also provide a `tokenizer` argument.

The solution proposed is to add only the `tokenizer` argument if `stop_strings` is present in the `kwargs`. An alternative would be to never include `tokenizer` and instead require users to provide it themselves in the inference arguments, but it would be more work for them.