### PR TITLE
Fix bug in outlines_core for transformers about token-str conversion

### DIFF
--- a/outlines/backends/outlines_core.py
+++ b/outlines/backends/outlines_core.py
@@ -184,23 +184,23 @@ class OutlinesCoreBackend(BaseBackend):
 
         """
         if isinstance(model, Transformers):
-            tokenizer = model.hf_tokenizer
+            tokenizer = model.tokenizer
             vocabulary = tokenizer.get_vocab()
             eos_token_id = tokenizer.eos_token_id
             eos_token = tokenizer.eos_token
-            token_to_str = lambda token: tokenizer.convert_tokens_to_string([token])
+            token_to_str = tokenizer.convert_token_to_string
         elif isinstance(model, LlamaCpp):
-            tokenizer = model.tokenizer
+            tokenizer = model.tokenizer # type: ignore
             vocabulary = tokenizer.vocabulary
             eos_token_id = tokenizer.eos_token_id
             eos_token = tokenizer.eos_token
             token_to_str = tokenizer.convert_token_to_string
         elif isinstance(model, MLXLM):
-            tokenizer = model.mlx_tokenizer
+            tokenizer = model.mlx_tokenizer # type: ignore
             vocabulary = tokenizer.get_vocab()
             eos_token_id = tokenizer.eos_token_id
             eos_token = tokenizer.eos_token
-            token_to_str = lambda token: tokenizer.convert_tokens_to_string([token])
+            token_to_str = lambda token: tokenizer.convert_tokens_to_string([token]) # type: ignore
         else:
             raise ValueError(f"Unsupported model type: {type(model)}")
 

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -72,6 +72,7 @@ class TransformerTokenizer(Tokenizer):
         self.tokenizer = tokenizer
         self.eos_token_id = self.tokenizer.eos_token_id
         self.eos_token = self.tokenizer.eos_token
+        self.get_vocab = self.tokenizer.get_vocab
 
         if self.tokenizer.pad_token_id is None:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id


### PR DESCRIPTION
Closes #1715 

The origin of the bug is that we were using the method `convert_tokens_to_string` of the HF tokenizer in the `outlines-core` backend with a `Transformers` model instead of the method `convert_token_to_string` of our custom `TransformerTokenizer`.

This was causing an issue for HF Llama tokenizers as we need to implement a little hack to go around an issue with missing spaces in the conversion of tokens to strings that was implemented in our `TransformerTokenizer`.