### PR TITLE
Fix the bug regarding unquoted strings in collection types in the DSL

### DIFF
--- a/outlines/types/__init__.py
+++ b/outlines/types/__init__.py
@@ -96,37 +96,40 @@ string = Regex(r'"[^"]*"')
 integer = Regex(r"[+-]?(0|[1-9][0-9]*)")
 boolean = Regex("(True|False)")
 number = Regex(rf"{integer.pattern}(\.[0-9]+)?([eE][+-][0-9]+)?")
-date = Regex(r"(\d{4})-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])")
-time = Regex(r"([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])")
-datetime = Regex(rf"({date.pattern})(\s)({time.pattern})")
+date = Regex(r"(\d{4})-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])", requires_quoting=True)
+time = Regex(r"([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])", requires_quoting=True)
+datetime = Regex(rf"({date.pattern})(\s)({time.pattern})", requires_quoting=True)
 
 # Basic regex types
 digit = Regex(r"\d")
-char = Regex(r"\w")
-newline = Regex(r"(\r\n|\r|\n)")  # Matched new lines on Linux, Windows & MacOS
-whitespace = Regex(r"\s")
-hex_str = Regex(r"(0x)?[a-fA-F0-9]+")
+char = Regex(r"\w", requires_quoting=True)
+newline = Regex(r"(\r\n|\r|\n)", requires_quoting=True)  # Matched new lines on Linux, Windows & MacOS
+whitespace = Regex(r"\s", requires_quoting=True)
+hex_str = Regex(r"(0x)?[a-fA-F0-9]+", requires_quoting=True)
 uuid4 = Regex(
     r"[a-fA-F0-9]{8}-"
     r"[a-fA-F0-9]{4}-"
     r"4[a-fA-F0-9]{3}-"
     r"[89abAB][a-fA-F0-9]{3}-"
-    r"[a-fA-F0-9]{12}"
+    r"[a-fA-F0-9]{12}",
+    requires_quoting=True
 )
 ipv4 = Regex(
     r"((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})\.){3}"
-    r"(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})"
+    r"(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})",
+    requires_quoting=True
 )
 
 # Document-specific types
-sentence = Regex(r"[A-Z].*\s*[.!?]")
-paragraph = Regex(rf"{sentence.pattern}(?:\s+{sentence.pattern})*\n+")
+sentence = Regex(r"[A-Z].*\s*[.!?]", requires_quoting=True)
+paragraph = Regex(rf"{sentence.pattern}(?:\s+{sentence.pattern})*\n+", requires_quoting=True)
 
 
 # The following regex is FRC 5322 compliant and was found at:
 # https://emailregex.com/
 email = Regex(
-    r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])"""
+    r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""",
+    requires_quoting=True
 )
 
 # Matches any ISBN number. Note that this is not completely correct as not all
@@ -136,5 +139,6 @@ email = Regex(
 #
 # TODO: The check digit can only be computed by calling a function to compute it dynamically
 isbn = Regex(
-    r"(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]"
+    r"(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]",
+    requires_quoting=True
 )


### PR DESCRIPTION
Explores a solution to #1630 

As shown in the issue above, we have a problem in our regex DSL regarding the quotation of text elements in Python collection types. Quite simply, we must put between quotations marks everything that ends up being a string if it's used in a collection type to respect Python grammar. The issue is that if those same elements are not used in a collection type, then there is no need to add those quotations marks (and we should not add them as the user never asked for it).

We need to have a system that allows us to add these quotes when handling collection types within our DSL. We need to:

- Automatically assess whether some elements require to be quoted (for instance basic Python types)
- Let the user specify whether they should be for others (for instances for the `Regex` class)
- Do both of those above for all terms and python types beyond the basic elements containing a single element. This is required as a collection type could contain for instance a `Sequence`, a `Literal`, a `QuantifyMinimum`... and we want to quote the whole containing term, not the items is contains

The solution envisioned uses 2 properties possessed by each term, knowing that all Python types are eventually turned into terms (the naming of those properties will be improved):

- `requires_quoting`: tells whether this term should be quoted if it where in a collection type. The value of the property can either be set by the user or is deduced from the type of term or the other terms it contains.
- `apply_quotation`: whether the term is in a collection type such that it should be quoted (if applicable). The value of the property default to `False`, but is then turned to `True` in the `python_types_to_terms` function depending on whether the term is contained in a collection type.

In the `to_regex` function, we wrap the content of the term in `repr` if both properties above are `True`