### PR TITLE
Ignore PydanticDeprecatedSince212 warnings in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore::pydantic.warnings.PydanticDeprecatedSince20",
+    "ignore::pydantic.warnings.PydanticDeprecatedSince212",
     "ignore::FutureWarning:transformers.*",
     "ignore::FutureWarning:huggingface_hub.*",
     "ignore::UserWarning",


### PR DESCRIPTION
Closes #1780 

As the warning is related to the `google-genai` package instead of `outlines` itself and will most likely disappear as the former gets updated, we simply ignore the warning in `pytest`.