### PR TITLE
Correct mlx-lm example unpacking operator

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -125,7 +125,7 @@ For a quick start, you can find below an example of how to initialize all suppor
     # Create an MLXLM model with the output of mlx_lm.load
     # The model will be downloaded from the HuggingFace hub
     model = outlines.from_mlxlm(
-        **mlx_lm.load("mlx-community/SmolLM-135M-Instruct-4bit")
+        *mlx_lm.load("mlx-community/SmolLM-135M-Instruct-4bit")
     )
     ```
 


### PR DESCRIPTION
## Problem
The mlx-lm example in the Getting Started guide uses `**` (keyword unpacking), but `mlx_lm.load()` returns a tuple, not a dict.

## Fix
Change `**mlx_lm.load(...)` to `*mlx_lm.load(...)`.

## Verification
Tested locally on Apple Silicon - the corrected example successfully creates an MLXLM model.