### PR TITLE
Add AsyncOllama to __all__ exports

### DIFF
--- a/outlines/models/ollama.py
+++ b/outlines/models/ollama.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ollama import Client
     from ollama import AsyncClient
 
-__all__ = ["Ollama", "from_ollama"]
+__all__ = ["AsyncOllama", "Ollama", "from_ollama"]
 
 
 class OllamaTypeAdapter(ModelTypeAdapter):


### PR DESCRIPTION
The AsyncOllama class was missing from the module's __all__ list. Spotted this while working on lmstudio integration.