### PR TITLE
Fix typo in vision argument of Ollama

### DIFF
--- a/outlines/models/ollama.py
+++ b/outlines/models/ollama.py
@@ -96,7 +96,7 @@ class OllamaTypeAdapter(ModelTypeAdapter):
             return {
                 "role": role,
                 "content": prompt,
-                "image": [image.image_str for image in images],
+                "images": [image.image_str for image in images],
             }
 
         else:
@@ -192,6 +192,8 @@ class Ollama(Model):
         """
         if "model" not in kwargs and self.model_name is not None:
             kwargs["model"] = self.model_name
+
+        print(self.type_adapter.format_input(model_input))
 
         response = self.client.chat(
             messages=self.type_adapter.format_input(model_input),

--- a/tests/models/test_ollama_type_adapter.py
+++ b/tests/models/test_ollama_type_adapter.py
@@ -68,7 +68,7 @@ def test_ollama_type_adapter_input_vision(adapter, image):
     assert result[0] == {
         "role": "user",
         "content": text_input,
-        "image": [image_input.image_str],
+        "images": [image_input.image_str],
     }
 
 
@@ -86,7 +86,7 @@ def test_ollama_type_adapter_input_chat(adapter, image):
     assert isinstance(result, list)
     assert len(result) == 3
     assert result[0] == {"role": "system", "content": "prompt"}
-    assert result[1] == {"role": "user", "content": "hello", "image": [image_input.image_str]}
+    assert result[1] == {"role": "user", "content": "hello", "images": [image_input.image_str]}
     assert result[2] == {"role": "assistant", "content": "response"}
 
 


### PR DESCRIPTION
Closes #1809 

The keyword used to be provide image arguments to the generation functions of Ollama was wrong (`image` instead of `images`).