### PR TITLE
Fix a bug in the Transformers tokenizer

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -103,10 +103,8 @@ class TransformerTokenizer(Tokenizer):
 
         string = self.tokenizer.convert_tokens_to_string([token])
 
-        if self.is_llama:
-            # A hack to handle missing spaces to HF's Llama tokenizers
-            if token.startswith(SPIECE_UNDERLINE) or token == "<0x20>":
-                return " " + string
+        if token.startswith(SPIECE_UNDERLINE) or token == "<0x20>":
+            return " " + string
 
         return string
 

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -236,7 +236,7 @@ def test_transformers_streaming(model):
     "model_name",
     [
         TEST_MODEL,
-        "EleutherAI/pythia-70m-deduped",
+        "HuggingFaceTB/SmolLM2-135M"
     ],
 )
 def test_transformers_parametrized_smoke(model_name):


### PR DESCRIPTION
Closes #1816 

The problem identified in the issue above comes from an incoherent handling of tokens containing a spiece underline. The `TransformerTokenizer` class was adding a white space to their string representation for `LlamaTokenizer,` tokenizers, but some models do not use it but still use `SentencePiece` tokenization that requires this transformation.

We modify the `convert_token_to_string` method of `TransformerTokenizer` to apply the adding of a white space in case of tokens starting with a speice underline for all tokenizers, considering nothing would happen for those that do not need it because they do not use the spiece underline.