### PR TITLE
Handle both HF tokenizer and mlx tokenizer wrapper for the MLXLM model

### DIFF
--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -3,6 +3,11 @@
 from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Iterator, List, Optional
 
+try:
+    from transformers import PreTrainedTokenizerBase
+except ImportError:  # pragma: no cover
+    PreTrainedTokenizerBase = None  # type: ignore
+
 from outlines.inputs import Chat
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import _check_hf_chat_template
@@ -10,8 +15,11 @@ from outlines.models.transformers import TransformerTokenizer
 from outlines.processors import OutlinesLogitsProcessor
 
 if TYPE_CHECKING:
+    from typing import Union
     import mlx.nn as nn
+    from mlx_lm.tokenizer_utils import TokenizerWrapper
     from transformers import PreTrainedTokenizer
+    MLXTokenizer = Union["TokenizerWrapper", "PreTrainedTokenizer"]
 
 __all__ = ["MLXLM", "from_mlxlm"]
 
@@ -100,7 +108,7 @@ class MLXLM(Model):
     def __init__(
         self,
         model: "nn.Module",
-        tokenizer: "PreTrainedTokenizer",
+        tokenizer: "MLXTokenizer",
     ):
         """
         Parameters
@@ -116,7 +124,11 @@ class MLXLM(Model):
         # self.mlx_tokenizer is used by the mlx-lm in its generate function
         self.mlx_tokenizer = tokenizer
         # self.tokenizer is used by the logits processor
-        self.tokenizer = TransformerTokenizer(tokenizer._tokenizer)
+        # tokenizer may be a mlx_lm.TokenizerWrapper (whose ._tokenizer is a
+        # PreTrainedTokenizerFast) or a PreTrainedTokenizerFast passed directly
+        inner = getattr(tokenizer, "_tokenizer", tokenizer)
+        hf_tokenizer = inner if isinstance(inner, PreTrainedTokenizerBase) else tokenizer
+        self.tokenizer = TransformerTokenizer(hf_tokenizer)
         self.type_adapter = MLXLMTypeAdapter(
             tokenizer=tokenizer,
             has_chat_template=_check_hf_chat_template(tokenizer)
@@ -251,7 +263,7 @@ class MLXLM(Model):
             yield gen_response.text
 
 
-def from_mlxlm(model: "nn.Module", tokenizer: "PreTrainedTokenizer") -> MLXLM:
+def from_mlxlm(model: "nn.Module", tokenizer: "MLXTokenizer") -> MLXLM:
     """Create an Outlines `MLXLM` model instance from an `mlx_lm` model and a
     tokenizer.
 

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -3,15 +3,17 @@ import re
 from enum import Enum
 from typing import Generator
 
+from pydantic import BaseModel
+import transformers
+
 import outlines
-from outlines.types import Regex
 from outlines.models.mlxlm import (
     MLXLM,
     MLXLMTypeAdapter,
     from_mlxlm
 )
 from outlines.models.transformers import TransformerTokenizer
-from pydantic import BaseModel
+from outlines.types import Regex
 
 try:
     import mlx_lm
@@ -36,6 +38,19 @@ def test_mlxlm_model_initialization():
     assert isinstance(model.tokenizer, TransformerTokenizer)
     assert isinstance(model.type_adapter, MLXLMTypeAdapter)
     assert model.tensor_library_name == "mlx"
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
+def test_mlxlm_model_initialization_with_hf_tokenizer():
+    """from_mlxlm must work when a raw HF tokenizer is passed instead of a
+    mlx_lm.TokenizerWrapper."""
+    mlx_model, _ = mlx_lm.load(TEST_MODEL)
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(TEST_MODEL)
+    model = from_mlxlm(mlx_model, hf_tokenizer)
+    assert isinstance(model, MLXLM)
+    assert isinstance(model.tokenizer, TransformerTokenizer)
+    assert model.tokenizer.eos_token_id is not None
+    assert model.tokenizer.eos_token is not None
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Closes #1847 

We want to allow users to either provide a `mlx_lm.tokenizer_utils.TokenizerWrapper` tokenizer they got from using `mlx_lm.load` or a `PreTrainedTokenizer` tokenizer from `transformers` when initializing the `MLXLM` model. We currently only supports the former. This PR updates the MLXLM's `__init__` method to support both uses and improves the type hinting