### PR TITLE
fix: return Pydantic model instance from SteerableGenerator for BaseModel output types

### DIFF
--- a/outlines/generator.py
+++ b/outlines/generator.py
@@ -23,6 +23,7 @@ from outlines.backends import (
 from outlines.backends.base import LogitsProcessorType
 from outlines.types import CFG, JsonSchema
 from outlines.types.dsl import python_types_to_terms, to_regex
+from outlines.types.utils import is_pydantic_model
 
 
 class BlackBoxGenerator:
@@ -231,6 +232,7 @@ class SteerableGenerator:
 
         """
         self.model = model
+        self.output_type = output_type
         if output_type is None:
             self.logits_processor = None
         else:
@@ -272,9 +274,34 @@ class SteerableGenerator:
         """
         instance = cls.__new__(cls)
         instance.model = model
+        instance.output_type = None
         instance.logits_processor = processor
 
         return instance
+
+    def _parse_result(self, result: Any) -> Any:
+        """Parse a generated string into a Pydantic model instance if applicable.
+
+        When the output type is a Pydantic ``BaseModel`` subclass, the
+        generated JSON string is automatically validated and converted into a
+        model instance.  For all other output types the result is returned
+        unchanged.
+
+        Parameters
+        ----------
+        result
+            The raw string returned by the model.
+
+        Returns
+        -------
+        Any
+            A Pydantic model instance when ``output_type`` is a Pydantic
+            ``BaseModel`` subclass, otherwise the original string.
+
+        """
+        if is_pydantic_model(self.output_type):
+            return self.output_type.model_validate_json(result)
+        return result
 
     def __call__(self, prompt: Any, **inference_kwargs) -> Any:
         """Generate a response from the model.
@@ -294,9 +321,10 @@ class SteerableGenerator:
         """
         if self.logits_processor is not None:
             self.logits_processor.reset()
-        return self.model.generate(
+        result = self.model.generate(
             prompt, self.logits_processor, **inference_kwargs
         )
+        return self._parse_result(result)
 
     def batch(self, prompts: List[Any], **inference_kwargs) -> List[Any]:
         """Generate a batch of responses from the model.
@@ -316,9 +344,10 @@ class SteerableGenerator:
         """
         if self.logits_processor is not None:
             self.logits_processor.reset()
-        return self.model.generate_batch(
+        results = self.model.generate_batch(
             prompts, self.logits_processor, **inference_kwargs
         )
+        return [self._parse_result(r) for r in results]
 
     def stream(self, prompt: Any, **inference_kwargs) -> Iterator[Any]:
         """Generate a stream of responses from the model.

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ import pytest
 from typing import AsyncGenerator, Generator as TypingGenerator, Literal
 
 import transformers
+from pydantic import BaseModel
 from outlines_core import Index, Vocabulary
 
 import outlines
@@ -91,6 +92,7 @@ def test_steerable_generator_init_valid_processor(steerable_model, sample_proces
     generator = SteerableGenerator.from_processor(steerable_model, sample_processor)
     assert generator.logits_processor == sample_processor
     assert generator.model == steerable_model
+    assert generator.output_type is None
 
 
 def test_steerable_generator_init_cfg_output_type(steerable_model):
@@ -102,6 +104,7 @@ def test_steerable_generator_init_cfg_output_type(steerable_model):
 def test_steerable_generator_init_other_output_type(steerable_model):
     generator = SteerableGenerator(steerable_model, Literal["foo", "bar"])
     assert generator.model == steerable_model
+    assert generator.output_type == Literal["foo", "bar"]
     assert isinstance(generator.logits_processor, OutlinesLogitsProcessor)
 
 
@@ -114,6 +117,33 @@ def test_steerable_generator_call(steerable_model):
     generator = SteerableGenerator(steerable_model, Literal["foo", "bar"])
     result = generator("foo", max_new_tokens=10)
     assert isinstance(result, str)
+
+
+def test_steerable_generator_call_pydantic(steerable_model):
+    class MyModel(BaseModel):
+        value: int
+
+    generator = SteerableGenerator(steerable_model, MyModel)
+    result = generator("Return a JSON object with a single integer field called value", max_new_tokens=50)
+    assert isinstance(result, MyModel)
+
+
+def test_steerable_generator_parse_result_pydantic(steerable_model):
+    class MyModel(BaseModel):
+        name: str
+        count: int
+
+    generator = SteerableGenerator(steerable_model, MyModel)
+    parsed = generator._parse_result('{"name": "test", "count": 42}')
+    assert isinstance(parsed, MyModel)
+    assert parsed.name == "test"
+    assert parsed.count == 42
+
+
+def test_steerable_generator_parse_result_non_pydantic(steerable_model):
+    generator = SteerableGenerator(steerable_model, Literal["foo", "bar"])
+    result = generator._parse_result("foo")
+    assert result == "foo"
 
 
 def test_steerable_generator_stream(steerable_model):


### PR DESCRIPTION
Fixes #1526

## Problem

When a Pydantic `BaseModel` subclass is passed as the `output_type` to a `SteerableGenerator`, the generated text is constrained to be valid JSON matching the model's schema — but the return value is still a raw JSON string. Callers have to manually run `MyModel.model_validate_json(result)` after every call, which is a footgun especially for users migrating from Outlines < 1.0 where the Pydantic object was returned directly.

As noted in the issue, the maintainer consensus is to treat Pydantic `BaseModel` subclasses as a special case and auto-parse the result, while leaving all other output types (regex, `Literal`, `CFG`, raw `JsonSchema`, etc.) unchanged as strings.

## Solution

- Store `output_type` on `SteerableGenerator` instances (was previously discarded after building the logits processor). The `from_processor` class-method sets it to `None`.
- Add a `_parse_result` helper that calls `output_type.model_validate_json(result)` when `output_type` is a Pydantic `BaseModel` subclass, and returns the string unchanged for all other types.
- Apply `_parse_result` in `__call__` and `batch`. Streaming is intentionally left unchanged — partial token sequences are not valid JSON and cannot be validated mid-stream.
- Import the existing `is_pydantic_model` utility from `outlines.types.utils` to keep the check consistent with the rest of the codebase.

## Example (before / after)

```python
from pydantic import BaseModel
from outlines import from_transformers, Generator

class Person(BaseModel):
    name: str
    age: int

model = from_transformers(...)
generator = Generator(model, Person)

# Before this fix:
result = generator("Extract: John, 30")
# result == '{"name": "John", "age": 30}'  (str)
person = Person.model_validate_json(result)  # extra step required

# After this fix:
result = generator("Extract: John, 30")
# result == Person(name='John', age=30)  (Person instance)
```

## Testing

- `test_steerable_generator_parse_result_pydantic` — verifies `_parse_result` converts a JSON string to the expected Pydantic model instance.
- `test_steerable_generator_parse_result_non_pydantic` — verifies non-Pydantic output types are returned unchanged.
- `test_steerable_generator_call_pydantic` — end-to-end: calls the generator with a Pydantic output type and checks the return type.
- `test_steerable_generator_init_valid_processor` — updated to assert `output_type is None` after `from_processor`.
- `test_steerable_generator_init_other_output_type` — updated to assert `output_type` is stored correctly.