### PR TITLE
fix(mlxlm): pass PreTrainedTokenizerFast wrapper to TransformerTokenizer, not raw backend

### DIFF
--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -116,7 +116,7 @@ class MLXLM(Model):
         # self.mlx_tokenizer is used by the mlx-lm in its generate function
         self.mlx_tokenizer = tokenizer
         # self.tokenizer is used by the logits processor
-        self.tokenizer = TransformerTokenizer(tokenizer._tokenizer)
+        self.tokenizer = TransformerTokenizer(tokenizer)
         self.type_adapter = MLXLMTypeAdapter(
             tokenizer=tokenizer,
             has_chat_template=_check_hf_chat_template(tokenizer)


### PR DESCRIPTION
## Summary

Fixes #1847

In `MLXLM.__init__`, the tokenizer was initialized as:
```python
self.tokenizer = TransformerTokenizer(tokenizer._tokenizer)
```

`tokenizer._tokenizer` is the raw `tokenizers.Tokenizer` backend. Modern `transformers` (tokenizers 0.25+) no longer exposes `eos_token_id`, `eos_token`, and `all_special_tokens` on the raw backend — those attributes live only on the `PreTrainedTokenizerFast` wrapper.

This caused:
```
AttributeError: 'tokenizers.Tokenizer' object has no attribute 'eos_token_id'
```

### Fix

Pass the `PreTrainedTokenizerFast` wrapper directly:
```python
self.tokenizer = TransformerTokenizer(tokenizer)
```

`TransformerTokenizer` is already designed to work with `PreTrainedTokenizer`/`PreTrainedTokenizerFast` wrappers — that's exactly how the `Transformers` model class uses it.

## Reproduction

```python
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-32B", trust_remote_code=True)
# tok._tokenizer has no eos_token_id attribute in tokenizers 0.25+
print(hasattr(tok, "eos_token_id"))         # True
print(hasattr(tok._tokenizer, "eos_token_id"))  # False
```