### PR TITLE
fix: use PreTrainedTokenizerFast wrapper for MLXLM in xgrammar and llguidance backends

### DIFF
--- a/outlines/backends/llguidance.py
+++ b/outlines/backends/llguidance.py
@@ -224,7 +224,7 @@ class LLGuidanceBackend(BaseBackend):
             import llguidance.hf
 
             return llguidance.hf.from_tokenizer(
-                model.mlx_tokenizer._tokenizer
+                model.mlx_tokenizer
             )
 
         else: # pragma: no cover

--- a/outlines/backends/xgrammar.py
+++ b/outlines/backends/xgrammar.py
@@ -126,7 +126,7 @@ class XGrammarBackend(BaseBackend):
         if isinstance(model, Transformers):
             tokenizer = model.hf_tokenizer
         elif isinstance(model, MLXLM): # pragma: no cover
-            tokenizer = model.mlx_tokenizer._tokenizer
+            tokenizer = model.mlx_tokenizer
         else: # pragma: no cover
             raise ValueError(
                 "The xgrammar backend only supports Transformers and "


### PR DESCRIPTION
Fixes the same class of bug reported in #1847, which noted that code in \`mlxlm.py\` was passing the raw \`tokenizers.Tokenizer\` backend instead of the \`PreTrainedTokenizerFast\` wrapper to downstream APIs.

## Problem

Two backends had the same incorrect pattern when handling MLXLM models:

**\`xgrammar.py\`** (line 129):
```python
# Before (wrong):
tokenizer = model.mlx_tokenizer._tokenizer  # raw tokenizers.Tokenizer
xgr.TokenizerInfo.from_huggingface(tokenizer, ...)
```

**\`llguidance.py\`** (line 226-227):
```python
# Before (wrong):
llguidance.hf.from_tokenizer(model.mlx_tokenizer._tokenizer)  # raw backend
```

Both \`xgr.TokenizerInfo.from_huggingface\` and \`llguidance.hf.from_tokenizer\` expect a \`PreTrainedTokenizerFast\` wrapper (which has \`eos_token_id\`, \`eos_token\`, \`all_special_tokens\`, etc.), not the raw \`tokenizers.Tokenizer\` backend.

With modern \`transformers\` / \`tokenizers\` >= 0.25, the raw backend no longer exposes these attributes, causing \`AttributeError\` when MLXLM is used with the xgrammar or llguidance backends.

## Solution

Replace \`model.mlx_tokenizer._tokenizer\` with \`model.mlx_tokenizer\` in both backends. This is consistent with:
- The **outlines_core backend**, which already correctly uses \`model.mlx_tokenizer\` (line 200 of \`outlines_core.py\`)
- The **Transformers model path** in both backends, which uses \`model.hf_tokenizer\` (the \`PreTrainedTokenizerFast\` wrapper)

## Testing

Existing MLX integration tests in \`tests/backends/test_xgrammar.py\` and \`tests/backends/test_llguidance.py\` cover these code paths when run on Apple Silicon (\`HAS_MLX=True\`). The backends MLXLM branches are marked \`# pragma: no cover\` as they require Apple Silicon to execute.