### PR TITLE
Fix error message for model type determination

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -730,7 +730,7 @@ def from_transformers(
         return TransformersMultiModal(model, processor, device_dtype=device_dtype)
     else:
         raise ValueError(
-            "We could determine whether the model passed to `from_transformers`"
+            "We couldn't determine whether the model passed to `from_transformers`"
             + " is a text-2-text or a multi-modal model. Please provide a "
             + "a transformers tokenizer or processor."
         )


### PR DESCRIPTION
The `from_transformers` method check the type of the passed `tokenizer_or_processor`, and based on this type, it returns either a `Transformers` or `TransformersMultiModal`.

The code implementation is correct, but in the final else statement, there's a missing negation in the error message presented to the user.

Could be confusing.