### PR TITLE
Add semver and MAC address custom types

### DIFF
--- a/outlines/types/__init__.py
+++ b/outlines/types/__init__.py
@@ -119,6 +119,11 @@ ipv4 = Regex(
     r"((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})\.){3}"
     r"(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})"
 )
+
+# SemVer 2.0.0: https://semver.org/
+# This enforces the MAJOR.MINOR.PATCH numeric components and their leading-zero
+# rules. Prerelease and build metadata are intentionally matched more broadly
+# than the full spec's dot-separated identifier rules to keep the regex compact.
 semver = Regex(
     r"(0|[1-9]\d*)\."
     r"(0|[1-9]\d*)\."
@@ -126,6 +131,11 @@ semver = Regex(
     r"(?:-[0-9A-Za-z.-]+)?"
     r"(?:\+[0-9A-Za-z.-]+)?"
 )
+
+# IEEE RA EUI-48 identifiers: https://standards.ieee.org/faqs/regauth/
+# This validates only the common colon-separated six-octet text form for MAC
+# addresses. It does not validate assignment, OUI ownership, or local/multicast
+# bits, and excludes other textual forms such as hyphen-separated addresses.
 mac_address = Regex(r"[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}")
 
 # Document-specific types

--- a/outlines/types/__init__.py
+++ b/outlines/types/__init__.py
@@ -83,6 +83,8 @@ __all__ = [
     "hex_str",
     "uuid4",
     "ipv4",
+    "semver",
+    "mac_address",
     # Document-specific types
     "sentence",
     "paragraph",
@@ -117,6 +119,14 @@ ipv4 = Regex(
     r"((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})\.){3}"
     r"(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})"
 )
+semver = Regex(
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?"
+    r"(?:\+[0-9A-Za-z.-]+)?"
+)
+mac_address = Regex(r"[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}")
 
 # Document-specific types
 sentence = Regex(r"[A-Z].*\s*[.!?]")

--- a/tests/types/test_custom_types.py
+++ b/tests/types/test_custom_types.py
@@ -93,6 +93,13 @@ from outlines.types.dsl import to_regex
         (types.ipv4, "1.2.3.4.", False),
         (types.ipv4, ".1.2.3.4", False),
         (types.ipv4, "1..2.3.4", False),
+        (types.semver, "1.2.3", True),
+        (types.semver, "1.2", False),
+        (types.semver, "01.2.3", False),
+        (types.semver, "1.2.3-alpha+001", True),
+        (types.mac_address, "00:1A:2B:3C:4D:5E", True),
+        (types.mac_address, "00-1A-2B-3C-4D-5E", False),
+        (types.mac_address, "00:1A:2B:3C:4D", False),
     ],
 )
 def test_type_regex(custom_type, test_string, should_match):


### PR DESCRIPTION
## Summary

- Add `semver` as a regex-based custom type for semantic version strings
- Add `mac_address` as a regex-based custom type for colon-separated MAC addresses
- Add tests for valid and invalid examples of both custom types

Refs #1303

## Tests

- `uv run --extra airports --extra countries --with pytest python -m pytest tests/types/test_custom_types.py`