### PR TITLE
Update docs with OrcaRouter guide

### DIFF
--- a/docs/features/models/orcarouter.md
+++ b/docs/features/models/orcarouter.md
@@ -1,0 +1,45 @@
+# OrcaRouter
+
+!!! Installation
+
+    [OrcaRouter](https://www.orcarouter.ai) uses the same API as OpenAI, so both services are [interoperable](./openai_compatible.md) using the `openai` library. Install all optional dependencies of the `OpenAI` model with: `pip install "outlines[openai]"`.
+
+    You also need to have an OrcaRouter API key. This API key must either be set as an environment variable called `OPENAI_API_KEY` or be provided to the `openai.OpenAI` class when instantiating it.
+
+## Model Initialization
+
+To create a model instance, you can use the `from_openai` function. It takes 2 arguments:
+
+- `client`: an `openai.OpenAI` instance
+- `model_name`: the name of the model you want to use, defined as `provider/model`
+
+For instance:
+
+```python
+import os
+import outlines
+import openai
+
+# Create the client
+client = openai.OpenAI(
+    base_url="https://api.orcarouter.ai/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+# Create the model
+model = outlines.from_openai(
+    client,
+    "openai/gpt-5.5"
+)
+```
+
+You can also pass `"orcarouter/auto"` as the model name to let OrcaRouter pick an upstream for each request according to the routing strategy you configured in the [routing console](https://www.orcarouter.ai/console/routing).
+
+The [OrcaRouter](https://www.orcarouter.ai/models) website lists available models. Keep in mind that some models do not support `json_schema` response formats and may return a 400 error code as a result.
+
+## Related Documentation
+
+For specific implementations that use OpenAI-compatible APIs:
+
+- [OpenAI](./openai.md): The original OpenAI API implementation
+- [OpenAI compatible API](./openai_compatible.md): Details on how to use OpenAI-compatible APIs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
                     - OpenAI: features/models/openai.md
                     - OpenAI compatible API: features/models/openai_compatible.md
                     - OpenRouter: features/models/openrouter.md
+                    - OrcaRouter: features/models/orcarouter.md
                     - SGLang: features/models/sglang.md
                     - TGI: features/models/tgi.md
                     - Transformers: features/models/transformers.md


### PR DESCRIPTION
The goal of this small PR is to add documentation for using OrcaRouter with
Outlines. OrcaRouter is an OpenAI-compatible model router, so it works
seamlessly with the existing `from_openai` loader by simply pointing the
`openai` client at OrcaRouter's base URL — no new model class is required.

This mirrors the existing OpenRouter guide added in #1691: the PR only adds a
`docs/features/models/orcarouter.md` page and a single navigation entry in
`mkdocs.yml`. No code or tests are changed, since OrcaRouter relies entirely on
the already-supported `from_openai` integration.

Disclosure: I'm an engineer on the OrcaRouter team.
