### PR TITLE
fix(types): handle bool instances in python_types_to_terms for Literal[True/False]

### DIFF
--- a/outlines/types/dsl.py
+++ b/outlines/types/dsl.py
@@ -746,7 +746,9 @@ def python_types_to_terms(ptype: Any, recursion_depth: int = 0) -> Term:
         return types.datetime
 
     # Basic type instances
-    if is_str_instance(ptype):
+    if isinstance(ptype, bool):
+        return Regex(str(ptype))
+    elif is_str_instance(ptype):
         return String(ptype)
     elif is_int_instance(ptype) or is_float_instance(ptype):
         return Regex(str(ptype))

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -656,6 +656,17 @@ def test_dsl_handle_literal():
     assert result.terms[1] == Regex(r"1")
 
 
+def test_dsl_literal_bool():
+    # Literal[True] and Literal[False] previously raised TypeError; ensure they resolve.
+    result_true = python_types_to_terms(Literal[True])
+    assert isinstance(result_true, Alternatives)
+    assert result_true.terms == [Regex("True")]
+    result_false = python_types_to_terms(Literal[False])
+    assert result_false.terms == [Regex("False")]
+    result_both = python_types_to_terms(Literal[True, False])
+    assert result_both == Alternatives([Regex("True"), Regex("False")])
+
+
 def test_dsl_handle_union():
     # test simple Union
     simple_union = Union[int, str]


### PR DESCRIPTION
## What's broken

Calling `python_types_to_terms` with `Literal[True]`, `Literal[False]`, or `Literal[True, False]` raises `TypeError: Type True is currently not supported`. The literal args are unpacked one-by-one and each bool value is passed back into `python_types_to_terms`, where every branch fails: `is_int_instance` explicitly excludes bool via `not isinstance(value, bool)`, and there is no `isinstance(ptype, bool)` branch.

## Why it happens

`is_int_instance` guards against bool (since `bool` is a subclass of `int` in Python), but no corresponding bool-instance path was added, leaving `True` and `False` with no matching branch.

## Fix

One line added before the `is_int_instance` check in the "Basic type instances" section of `python_types_to_terms`: `if isinstance(ptype, bool): return Regex(str(ptype))`. This resolves `True` to `Regex("True")` and `False` to `Regex("False")`, consistent with the existing `types.boolean = Regex("(True |False)")` definition.

## Test

Added `test_dsl_literal_bool` in `tests/types/test_dsl.py` that asserts `Literal[True]`, `Literal[False]`, and `Literal[True, False]` all resolve without error and produce the expected `Regex` terms.

Fixes #1868