### PR TITLE
Emit {0,n} for at_most so the regex compiles on the outlines-core backend

### DIFF
--- a/outlines/types/dsl.py
+++ b/outlines/types/dsl.py
@@ -955,7 +955,7 @@ def to_regex(term: Term) -> str:
     elif isinstance(term, QuantifyMinimum):
         return f"({to_regex(term.term)}){{{term.min_count},}}"
     elif isinstance(term, QuantifyMaximum):
-        return f"({to_regex(term.term)}){{,{term.max_count}}}"
+        return f"({to_regex(term.term)}){{0,{term.max_count}}}"
     elif isinstance(term, QuantifyBetween):
         return f"({to_regex(term.term)}){{{term.min_count},{term.max_count}}}"
     else:

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -1118,7 +1118,7 @@ def test_to_regex():
     assert to_regex(min_term) == r"(a){2,}"
 
     max_term = QuantifyMaximum(String("a"), 5)
-    assert to_regex(max_term) == r"(a){,5}"
+    assert to_regex(max_term) == r"(a){0,5}"
 
     between_term = QuantifyBetween(String("a"), 1, 3)
     assert to_regex(between_term) == r"(a){1,3}"

--- a/tests/types/test_to_regex.py
+++ b/tests/types/test_to_regex.py
@@ -73,7 +73,7 @@ def test_to_regex_simple():
     assert a.matches("aaa") is True
 
     a = QuantifyMaximum(String("a"), 2)
-    assert to_regex(a) == "(a){,2}"
+    assert to_regex(a) == "(a){0,2}"
     assert a.matches("aa") is True
     assert a.matches("aaa") is False
 


### PR DESCRIPTION
### Problem

`Term.at_most(n)` / `at_most(n, term)` (the `QuantifyMaximum` DSL term) compiles to a regex of the form `(...){,n}`:

```python
return f"({to_regex(term.term)}){{,{term.max_count}}}"   # -> "(a){,5}"
```

Python's `re` accepts the lower-bound-omitted `{,n}` form, but the **default** generation backend — `outlines-core` (Rust `regex` / regex-automata) — does **not** (it only supports `{n}`, `{n,}`, `{n,m}`). So any structured generation using an `at_most` quantifier raises when the `Index`/`Guide` is built:

```python
>>> from outlines_core import Index, Vocabulary
>>> v = Vocabulary.from_pretrained("gpt2")
>>> Index("(a){,3}", v)
ValueError: Failed to build DFA error building NFA ...
>>> Index("(a){0,3}", v)   # OK
```

The whole `at_most` quantifier is effectively unusable with the default backend.

### Fix

Emit the equivalent `(...){0,n}`. Semantically identical (0 to n repetitions), but valid for both `re` and `outlines-core`. A unit test asserted the old `(a){,5}` output; updated to `(a){0,5}`.

### Verification

```
to_regex(at_most 5)            -> "(a){0,5}"
outlines_core.Index("(a){0,5}") -> builds OK   (previously "(a){,5}" failed)
pytest tests/types/test_dsl.py -k "to_regex or at_most" -> 2 passed
```
