### PR TITLE
fix: make json-schema-derived dataclasses kw_only so optional-before-required fields don't crash

### DIFF
--- a/outlines/types/json_schema_utils.py
+++ b/outlines/types/json_schema_utils.py
@@ -174,4 +174,4 @@ def json_schema_dict_to_dataclass(
         class_dict[property] = field(default=default_val)
 
     cls = type(name or "AnonymousDataclass", (), class_dict)
-    return dataclass(cls, kw_only=True)
+    return dataclass(kw_only=True)(cls)

--- a/outlines/types/json_schema_utils.py
+++ b/outlines/types/json_schema_utils.py
@@ -174,4 +174,4 @@ def json_schema_dict_to_dataclass(
         class_dict[property] = field(default=default_val)
 
     cls = type(name or "AnonymousDataclass", (), class_dict)
-    return dataclass(cls)
+    return dataclass(cls, kw_only=True)

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -323,3 +323,21 @@ def test_json_schema_dict_to_dataclass_nested_object():
     assert field.__annotations__["age"] is int
     assert not hasattr(field, "name")
     assert field.age is None
+
+
+def test_json_schema_dict_to_dataclass_optional_before_required():
+    schema = {
+        "type": "object",
+        "properties": {
+            "nickname": {"type": "string"},
+            "user_id": {"type": "integer"},
+        },
+        "required": ["user_id"],
+    }
+
+    result = json_schema_dict_to_dataclass(schema, "User")
+    assert is_dataclass(result)
+
+    instance = result(user_id=5)
+    assert instance.user_id == 5
+    assert instance.nickname is None


### PR DESCRIPTION
## Summary

  `json_schema_dict_to_dataclass` raised `TypeError: non-default argument follows default argument` whenever an optional field was declared before a required field in the input schema. That ordering is common and valid;
  `pydantic.BaseModel.model_json_schema()` preserves field-declaration order in `properties`, so any model with an optional field before a required one hit it. The public `JsonSchema` -> dataclass conversion swallowed the same error into a misleading
  `ValueError: Cannot convert schema ... to dataclass`.

  ## Reproduction

  ```python
  from pydantic import BaseModel
  from typing import Optional
  from outlines.types.json_schema_utils import json_schema_dict_to_dataclass

  class User(BaseModel):
      nickname: Optional[str] = None   # optional, declared first
      user_id: int                     # required, declared after

  schema = User.model_json_schema()
  json_schema_dict_to_dataclass(schema, schema["title"])
  # TypeError: non-default argument 'user_id' follows default argument 'nickname'
```


### Fix

  Build the dataclass with kw_only=True. Keyword-only fields are exempt from the "non-default argument cannot follow default argument" rule, so declaration order no longer matters. Defaults and annotations are unchanged, so existing behavior and tests hold. Safe given the project's >=3.10 floor (kw_only landed in 3.10). The sibling `json_schema_dict_to_typeddict` / `json_schema_dict_to_pydantic` paths were already unaffected.

### Tests

Added `test_json_schema_dict_to_dataclass_optional_before_required`, which builds and instantiates a dataclass from a schema with an optional field before a required one. It fails on main (TypeError) and passes with this change. The existing dataclass tests are unaffected.

```pytest tests/types/test_json_schema_utils.py```  15 passed