### PR TITLE
Docs: remove stale content

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -102,47 +102,6 @@ And run the code style checks:
 pre-commit run --all-files
 ```
 
-### Benchmarking
-
-Outlines uses [asv](https://asv.readthedocs.io) for automated benchmark testing. Benchmarks are run automatically before pull requests are merged to prevent performance degradation.
-
-You can run the benchmark test suite locally with the following command:
-
-```shell
-asv run --config benchmarks/asv.conf.json
-```
-
-Caveats:
-
-- If you're on a device with CUDA, you must add the argument `--launch-method spawn`
-- Uncommitted code will not be benchmarked, you must first commit your changes.
-
-#### Run a specific test:
-
-```shell
-asv run --config benchmarks/asv.conf.json -b bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm
-```
-
-#### Profile a specific test:
-
-```shell
-asv run --config benchmarks/asv.conf.json --profile -b bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm
-```
-
-#### Compare to `origin/main`
-
-```shell
-get fetch origin
-asv continuous origin/main HEAD --config benchmarks/asv.conf.json
-```
-
-#### ASV PR Behavior
-
-- **View ASV Benchmark Results:** Open the workflow, view `BENCHMARK RESULTS` section.
-- Merging is blocked unless benchmarks are run for the latest commit.
-- Benchmarks fail if performance degrades by more than 10% for any individual benchmark.
-- The "Benchmark PR" workflow runs when it is manually dispatched, or if the `run_benchmarks` label is added to the PR they run for every commit.
-
 ### Contribute to the documentation
 
 To work on the *documentation* you will need to install the related dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ countries = ["iso3166"]
 test = [
     "pre-commit",
     "pytest",
-    "pytest-benchmark",
     "pytest-cov",
     "pytest-mock",
     "pytest-asyncio",

--- a/uv.lock
+++ b/uv.lock
@@ -2519,7 +2519,6 @@ test = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
-    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "requests" },
@@ -2612,7 +2611,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-asyncio", marker = "extra == 'test'" },
-    { name = "pytest-benchmark", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pytest-mock", marker = "extra == 'test'" },
     { name = "requests", marker = "extra == 'test'" },
@@ -2976,15 +2974,6 @@ wheels = [
 ]
 
 [[package]]
-name = "py-cpuinfo"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
-]
-
-[[package]]
 name = "pyarrow"
 version = "22.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3192,19 +3181,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
-name = "pytest-benchmark"
-version = "5.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "py-cpuinfo" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Remove stale benchmark contribution notes/artifacts

The contributor guide still described the old ASV benchmark suite and Benchmark PR workflow.

But both were removed from the repo, I assume due to factored out backends: the benchmark files were deleted in 4e66c52c and the GitHub Actions workflow was removed in 1804c67d.

