### PR TITLE
Remove dead is_llama detection code in TransformerTokenizer

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -28,48 +28,6 @@ __all__ = ["Transformers", "TransformersMultiModal", "from_transformers"]
 SPIECE_UNDERLINE = "\u2581"
 
 
-def get_llama_tokenizer_types():
-    """Get all the Llama tokenizer types/classes that need work-arounds.
-
-    When they can't be imported, a dummy class is created.
-
-    """
-    try:
-        from transformers.models.llama import LlamaTokenizer
-    except ImportError:  # pragma: no cover
-
-        class LlamaTokenizer:  # type: ignore
-            pass
-
-    try:
-        from transformers.models.llama import LlamaTokenizerFast
-    except ImportError:  # pragma: no cover
-
-        class LlamaTokenizerFast:  # type: ignore
-            pass
-
-    try:
-        from transformers.models.code_llama import CodeLlamaTokenizer
-    except ImportError:  # pragma: no cover
-
-        class CodeLlamaTokenizer:  # type: ignore
-            pass
-
-    try:
-        from transformers.models.code_llama import CodeLlamaTokenizerFast
-    except ImportError:  # pragma: no cover
-
-        class CodeLlamaTokenizerFast:  # type: ignore
-            pass
-
-    return (
-        LlamaTokenizer,
-        LlamaTokenizerFast,
-        CodeLlamaTokenizer,
-        CodeLlamaTokenizerFast,
-    )
-
-
 class TransformerTokenizer(Tokenizer):
     """Represents a tokenizer for models in the `transformers` library."""
 
@@ -89,7 +47,6 @@ class TransformerTokenizer(Tokenizer):
         self.special_tokens = set(self.tokenizer.all_special_tokens)
 
         self.vocabulary = self.tokenizer.get_vocab()
-        self.is_llama = isinstance(self.tokenizer, get_llama_tokenizer_types())
 
     def encode(
         self, prompt: Union[str, List[str]], **kwargs

--- a/tests/models/test_transformers_tokenizer.py
+++ b/tests/models/test_transformers_tokenizer.py
@@ -5,7 +5,6 @@ import transformers
 
 from outlines.models.transformers import (
     SPIECE_UNDERLINE,
-    get_llama_tokenizer_types,
     TransformerTokenizer,
 )
 
@@ -45,14 +44,6 @@ def transformer_tokenizer_seq2seq(tokenizer_seq2seq):
     return TransformerTokenizer(tokenizer_seq2seq)
 
 
-def test_get_llama_tokenizer_types():
-    tokenizer_types = get_llama_tokenizer_types()
-    assert tokenizer_types[0] is transformers.models.llama.LlamaTokenizer
-    assert tokenizer_types[1] is transformers.models.llama.LlamaTokenizerFast
-    assert tokenizer_types[2] is transformers.models.code_llama.CodeLlamaTokenizer
-    assert tokenizer_types[3] is transformers.models.code_llama.CodeLlamaTokenizerFast
-
-
 def test_transformer_tokenizer_init(
     tokenizer,
     tokenizer_no_pad_token_id
@@ -90,14 +81,12 @@ def test_transformer_tokenizer_decode(transformer_tokenizer):
 
 def test_transformer_tokenizer_convert_token_to_string(transformer_tokenizer):
     # regular
-    transformer_tokenizer.is_llama = False
     token = transformer_tokenizer.tokenizer.tokenize("Hello")[0]
     string = transformer_tokenizer.convert_token_to_string(token)
     assert isinstance(string, str)
     assert "Hello" in string
 
-    # is_llama + <0x20>
-    transformer_tokenizer.is_llama = True
+    # <0x20> byte token is converted to a space
     string = transformer_tokenizer.convert_token_to_string("<0x20>")
     assert isinstance(string, str)
     assert " " in string


### PR DESCRIPTION
`convert_token_to_string` applies the `SPIECE_UNDERLINE` / `<0x20>` space workaround unconditionally, so the `is_llama` flag and the `get_llama_tokenizer_types()` helper that computed it are no longer read anywhere. This removes both, deletes the test that exercised the helper, and drops the now-meaningless `is_llama` assignments in `test_transformer_tokenizer_convert_token_to_string` (which still passes). Fixes #1874.