### PR TITLE
fix(dsl): keep None unquoted for Optional nested in containers

### DIFF
--- a/outlines/types/dsl.py
+++ b/outlines/types/dsl.py
@@ -837,7 +837,10 @@ def _handle_union(args: tuple, recursion_depth: int) -> Alternatives:
         return Alternatives(
             [
                 python_types_to_terms(other_ptype, recursion_depth + 1),
-                String("None"),
+                # ``None`` is a keyword, not a string value: keep it a ``Regex``
+                # (like ``True``/``False``) so it is not JSON-quoted when the
+                # ``Optional`` ends up nested inside a container type.
+                Regex("None"),
             ]
         )
     return Alternatives(

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -682,7 +682,7 @@ def test_dsl_handle_union():
     assert isinstance(result, Alternatives)
     assert len(result.terms) == 2
     assert result.terms[0] == types.integer
-    assert result.terms[1] == String("None")
+    assert result.terms[1] == Regex("None")
 
     # test with more complex types
     class TestModel(BaseModel):
@@ -1081,6 +1081,34 @@ def test_e2e_dict_literal_key_and_enum_value():
     assert _re.fullmatch(pattern, '{"switch":"on"}')
     assert _re.fullmatch(pattern, '{"switch":"off"}')
     assert not _re.fullmatch(pattern, "{switch:on}")
+
+
+def test_e2e_optional_none_not_quoted_in_containers():
+    """The ``None`` from ``Optional``/``Union`` must stay a bare keyword inside
+    containers, exactly as it is standalone, and must not be JSON-quoted like a
+    string literal."""
+    # Standalone Optional already matches the bare ``None`` keyword.
+    standalone = to_regex(python_types_to_terms(PyOptional[int]))
+    assert _re.fullmatch(standalone, "None")
+    assert not _re.fullmatch(standalone, '"None"')
+
+    list_pattern = to_regex(python_types_to_terms(list[PyOptional[int]]))
+    assert _re.fullmatch(list_pattern, "[None]")
+    assert _re.fullmatch(list_pattern, "[1, None]")
+    assert not _re.fullmatch(list_pattern, '["None"]')
+
+    dict_pattern = to_regex(python_types_to_terms(dict[str, PyOptional[int]]))
+    assert _re.fullmatch(dict_pattern, '{"a":None}')
+    assert not _re.fullmatch(dict_pattern, '{"a":"None"}')
+
+    tuple_pattern = to_regex(python_types_to_terms(Tuple[PyOptional[int], int]))
+    assert _re.fullmatch(tuple_pattern, "(None, 5)")
+    assert not _re.fullmatch(tuple_pattern, '("None", 5)')
+
+    # A genuine ``Literal["None"]`` string is still quoted inside containers.
+    literal_pattern = to_regex(python_types_to_terms(list[Literal["None"]]))
+    assert _re.fullmatch(literal_pattern, '["None"]')
+    assert not _re.fullmatch(literal_pattern, "[None]")
 
 
 def test_to_regex():


### PR DESCRIPTION
While using `list[Optional[int]]` as an output type I noticed the generated regex matched `[5, "None"]` but rejected `[5, None]`. A standalone `Optional[int]` matches the bare `None` keyword, so the two disagree on how the absent value is written, and the quoted `"None"` parses back to the 4-character string rather than `None`.

The cause is in `_handle_union`: the `None` arm of an `Optional`/`Union` is emitted as `String("None")`. The JSON-quoting helper added for string literals inside container types (`_ensure_json_quoted`) then wraps every `String` in double quotes, this one included. `True`/`False` escape it because they're already `Regex` terms, which the helper leaves untouched.

I made `None` a `Regex("None")` keyword token like the booleans, so it stays unquoted inside `List`/`Dict`/`Tuple` while a genuine `Literal["None"]` string is still quoted. Added e2e regex tests for `Optional` nested in each container and updated the one structural assertion in `test_dsl_handle_union`.

`pytest tests/types` and `pre-commit run` pass locally.