### PR TITLE
Fix crash on a union of >=2 non-None members plus None

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -835,21 +835,22 @@ def _ensure_json_quoted(term: Term) -> Term:
 
 
 def _handle_union(args: tuple, recursion_depth: int) -> Alternatives:
-    # Handle the Optional[T] type
-    if len(args) == 2 and (type(None) in args or None in args):
-        other_ptype = next(arg for arg in args if arg not in (type(None), None))
-        return Alternatives(
-            [
-                python_types_to_terms(other_ptype, recursion_depth + 1),
-                # ``None`` is a keyword, not a string value: keep it a ``Regex``
-                # (like ``True``/``False``) so it is not JSON-quoted when the
-                # ``Optional`` ends up nested inside a container type.
-                Regex("None"),
-            ]
-        )
-    return Alternatives(
-        [python_types_to_terms(arg, recursion_depth + 1) for arg in args]
-    )
+    # Peel off the None member(s) for any arity (not just the 2-arg Optional[T]
+    # case): a union such as `Union[int, str, None]` / `Optional[Union[int, str]]`
+    # must map None instead of recursing into NoneType (which has no handler and
+    # raised "Type NoneType is currently not supported").
+    has_none = type(None) in args or None in args
+    terms = [
+        python_types_to_terms(arg, recursion_depth + 1)
+        for arg in args
+        if arg not in (type(None), None)
+    ]
+    if has_none:
+        # `None` is a keyword, not a string value: keep it a `Regex` (like
+        # `True`/`False`) so it is not JSON-quoted when the union ends up
+        # nested inside a container type.
+        terms.append(Regex("None"))
+    return Alternatives(terms)
 
 
 def _handle_list(args: tuple, recursion_depth: int) -> Sequence:

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -725,6 +725,22 @@ def test_dsl_handle_union():
     assert result.terms[1].terms[1] == String("b")
 
 
+def test_dsl_handle_union_multiple_members_with_none():
+    # Regression: only the 2-arg Optional[T] case handled None; a union with >=2
+    # non-None members plus None fell into the general branch and crashed with
+    # "Type NoneType is currently not supported".
+    result = _handle_union(get_args(Union[int, str, None]), recursion_depth=0)
+    assert isinstance(result, Alternatives)
+    assert types.integer in result.terms
+    assert types.string in result.terms
+    assert Regex("None") in result.terms
+
+    # Optional[Union[...]] (same args after flattening) must also not crash.
+    nested = _handle_union(get_args(PyOptional[Union[int, str]]), recursion_depth=0)
+    assert isinstance(nested, Alternatives)
+    assert Regex("None") in nested.terms
+
+
 def test_dsl_handle_list():
     with pytest.raises(TypeError):
         _handle_list(None, recursion_depth=0)


### PR DESCRIPTION
## What

`python_types_to_terms` (via `_handle_union`) only special-cases the **2-arg** `Optional[T]` form
(one non-None member + `None`). Any union with **two or more non-None members plus `None`** falls into
the general branch, which recurses into `NoneType` — which has no handler — and crashes:

```python
from typing import Union, Optional
from outlines.types.dsl import python_types_to_terms

python_types_to_terms(Optional[int])              # OK
python_types_to_terms(Union[int, str, None])      # TypeError: Type NoneType is currently not supported
python_types_to_terms(Optional[Union[int, str]])  # TypeError
# also Dict[str, Union[int, str, None]], List[Optional[Union[int, str]]], ...
```

These are common annotations and the path is reachable from the public `Generator` entry point
(`generator.py` calls `python_types_to_terms(output_type)` on the user's type).

## Fix

Generalize `_handle_union` to peel off the `None` member(s) for **any** arity and map them to
`String("None")`, preserving the existing 2-arg `Optional[T]` semantics:

```python
has_none = type(None) in args or None in args
terms = [python_types_to_terms(a, d+1) for a in args if a not in (type(None), None)]
if has_none:
    terms.append(String("None"))
return Alternatives(terms)
```

So `Union[int, str, None]` → `Alternatives([integer, string, String("None")])`.

> Note: PR #1880 separately changes the 2-arg `None` token from `String("None")` to `Regex("None")`
> (container-quoting fix). It doesn't touch this >=2-member case, so there's no overlap; if it lands
> first, the `None` token here should be switched to match.

## Tests

`tests/types/test_dsl.py::test_dsl_handle_union_multiple_members_with_none` — `Union[int, str, None]`
and `Optional[Union[int, str]]` no longer crash and include the `None` arm. Existing union/dsl/to_regex
tests still pass.
