### PR TITLE
Honor parameter defaults in get_schema_from_signature

### DIFF
--- a/outlines/types/utils.py
+++ b/outlines/types/utils.py
@@ -177,8 +177,11 @@ def get_schema_from_signature(fn: Callable) -> dict:
     for name, arg in signature.parameters.items():
         if arg.annotation == inspect._empty:
             raise ValueError("Each argument must have a type annotation")
-        else:
+        elif arg.default is inspect._empty:
             arguments[name] = (arg.annotation, ...)
+        else:
+            # Honor the parameter default so it is optional (not required) in the schema.
+            arguments[name] = (arg.annotation, arg.default)
 
     try:
         fn_name = fn.__name__

--- a/tests/types/test_types_utils.py
+++ b/tests/types/test_types_utils.py
@@ -405,6 +405,18 @@ def test_get_schema_from_signature(sample_function, sample_function_missing_type
         get_schema_from_signature(sample_function_missing_type)
 
 
+def test_get_schema_from_signature_respects_defaults():
+    # Parameters with a default must be optional (not required) and carry the default,
+    # so that calling fn(**obj) with only the required keys is valid.
+    def fn(a: int, b: int = 5, c: str = "hi"):
+        ...
+
+    schema = get_schema_from_signature(fn)
+    assert schema["required"] == ["a"]
+    assert schema["properties"]["b"]["default"] == 5
+    assert schema["properties"]["c"]["default"] == "hi"
+
+
 def test_get_schema_from_enum(sample_complex_enum, sample_empty_enum):
     schema = get_schema_from_enum(sample_complex_enum)
     assert JsonSchema(schema)


### PR DESCRIPTION
## What

`get_schema_from_signature` maps every parameter to `(annotation, ...)`, which forces **all**
parameters `required` and drops their defaults:

```python
from outlines.types.utils import get_schema_from_signature
def fn(a: int, b: int = 5, c: str = "hi"): ...
get_schema_from_signature(fn)["required"]   # ['a', 'b', 'c']  -- should be ['a']
```

So a JSON object that omits a defaulted argument — a perfectly valid call, `fn(**{"a": 1})` works —
fails schema validation, and the defaults are lost from the schema.

## Fix

Pass `arg.default` to `create_model` when the parameter has one, so defaulted params become optional
and emit their default; annotation-only params stay required.

## Tests

`tests/types/test_types_utils.py::test_get_schema_from_signature_respects_defaults` — `required == ["a"]`
and the `b`/`c` defaults appear in `properties`. Fails before, passes after; existing
`test_get_schema_from_signature` still passes.
