### PR TITLE
Mark non-required JSON-schema properties NotRequired in TypedDict conversion

### DIFF
--- a/outlines/types/json_schema_utils.py
+++ b/outlines/types/json_schema_utils.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, create_model
 
 if sys.version_info >= (3, 12):  # pragma: no cover
-    from typing import _TypedDictMeta, TypedDict  # type: ignore
+    from typing import _TypedDictMeta, NotRequired, TypedDict  # type: ignore
 else:  # pragma: no cover
-    from typing_extensions import _TypedDictMeta, TypedDict  # type: ignore
+    from typing_extensions import _TypedDictMeta, NotRequired, TypedDict  # type: ignore
 
 
 def schema_type_to_python(
@@ -91,7 +91,9 @@ def json_schema_dict_to_typeddict(
     for property, details in properties.items():
         typ = schema_type_to_python(details, "typeddict")
         if property not in required:
-            typ = Optional[typ]
+            # NotRequired (PEP 655) marks the KEY optional; Optional only makes the
+            # value nullable, leaving the key required on a total=True TypedDict.
+            typ = NotRequired[typ]
         annotations[property] = typ
 
     return TypedDict(name or "AnonymousTypedDict", annotations)  # type: ignore

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -13,9 +13,9 @@ from outlines.types.json_schema_utils import (
 )
 
 if sys.version_info >= (3, 12):
-    from typing import _TypedDictMeta  # type: ignore
+    from typing import _TypedDictMeta, NotRequired  # type: ignore
 else:
-    from typing_extensions import _TypedDictMeta  # type: ignore
+    from typing_extensions import _TypedDictMeta, NotRequired  # type: ignore
 
 
 def test_schema_type_to_python_simple_types():
@@ -73,7 +73,7 @@ def test_schema_type_to_python_object():
     assert isinstance(typeddict_result, _TypedDictMeta)
     assert typeddict_result.__name__ == "TestObject"
     assert typeddict_result.__annotations__["name"] is str
-    assert typeddict_result.__annotations__["age"] == Optional[int]
+    assert typeddict_result.__annotations__["age"] == NotRequired[int]
 
     # Dataclass caller
     dataclass_result = schema_type_to_python(schema, "dataclass")
@@ -113,7 +113,12 @@ def test_json_schema_dict_to_typeddict_basic():
 
     annotations = result.__annotations__
     assert annotations["name"] is str
-    assert annotations["age"] == Optional[int]
+    # A non-required property must be an optional KEY (NotRequired), not merely a
+    # nullable value (Optional) — otherwise it round-trips back as required.
+    assert annotations["age"] == NotRequired[int]
+    assert "name" in result.__required_keys__
+    assert "age" in result.__optional_keys__
+    assert "age" not in result.__required_keys__
 
 
 def test_json_schema_dict_to_typeddict_array_enum():
@@ -137,7 +142,7 @@ def test_json_schema_dict_to_typeddict_array_enum():
 
     annotations = result.__annotations__
     assert annotations["tags"] == List[str]
-    assert annotations["preferences"] == Optional[Literal[("light", "dark")]]
+    assert annotations["preferences"] == NotRequired[Literal[("light", "dark")]]
 
 
 def test_json_schema_dict_to_typeddict_nested_object():
@@ -164,7 +169,7 @@ def test_json_schema_dict_to_typeddict_nested_object():
     assert isinstance(annotations["field"], _TypedDictMeta)
     assert annotations["field"].__name__ == "AnonymousTypedDict"
     assert annotations["field"].__annotations__["name"] is str
-    assert annotations["field"].__annotations__["age"] == Optional[int]
+    assert annotations["field"].__annotations__["age"] == NotRequired[int]
 
 
 def test_json_schema_dict_to_pydantic_basic():


### PR DESCRIPTION
## What

`json_schema_dict_to_typeddict` wraps non-`required` properties in `Optional[T]` on a `total=True`
TypedDict. But `Optional` only makes the **value** nullable — the **key** stays required. So a schema
where `age` is optional round-trips back as required, unlike the pydantic/dataclass converters:

```python
schema = {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name"]}
td = json_schema_dict_to_typeddict(schema, "Person")
td.__required_keys__   # {'name', 'age'}   -- age should be optional
# json_schema_dict_to_pydantic / _to_dataclass on the same schema -> required == ['name']
```

## Fix

Use `NotRequired[T]` (PEP 655) for non-required properties so the **key** is optional, matching the
input schema and the sibling converters.

## Tests

`tests/types/test_json_schema_utils.py::test_json_schema_dict_to_typeddict_basic` updated to assert
`age` is `NotRequired[int]` and lands in `__optional_keys__` (it previously codified the buggy
`Optional[int]`/required behavior). Full `test_json_schema_utils.py` passes.
