### PR TITLE
Handle enum refs in prompt schema rendering

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -306,16 +306,27 @@ def parse_pydantic_schema(raw_schema, definitions):
     key in the schema of the top-level model.
 
     """
+    if "properties" not in raw_schema:
+        return parse_pydantic_schema_value(
+            raw_schema.get("title", "value"), raw_schema, definitions
+        )
+
     simple_schema = {}
     for name, value in raw_schema["properties"].items():
-        if "description" in value:
-            simple_schema[name] = value["description"]
-        elif "$ref" in value: # pragma: no cover
-            refs = value["$ref"].split("/")
-            simple_schema[name] = parse_pydantic_schema(
-                definitions[refs[2]], definitions
-            )
-        else:
-            simple_schema[name] = f"<{name}>"
+        simple_schema[name] = parse_pydantic_schema_value(name, value, definitions)
 
     return simple_schema
+
+
+def parse_pydantic_schema_value(name, schema, definitions):
+    """Render a single Pydantic schema property for prompt examples."""
+    if "description" in schema:
+        return schema["description"]
+    elif "$ref" in schema:
+        refs = schema["$ref"].split("/")
+        return parse_pydantic_schema(definitions[refs[2]], definitions)
+    elif "enum" in schema:
+        values = " | ".join(str(value) for value in schema["enum"])
+        return f"<{values}>"
+    else:
+        return f"<{name}>"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,5 @@
 import base64
+from enum import Enum
 import os
 import tempfile
 from typing import Optional
@@ -39,6 +40,17 @@ class CallableClass:
 
 class PydanticClass(BaseModel):
     foo: str
+
+
+class Armor(str, Enum):
+    leather = "leather"
+    chainmail = "chainmail"
+    plate = "plate"
+
+
+class PydanticClassWithEnum(BaseModel):
+    name: str
+    armor: Armor
 
 
 def test_vision_initialization():
@@ -370,3 +382,8 @@ def test_get_schema():
 
     pydantic_schema_output = get_schema(PydanticClass)
     assert pydantic_schema_output == '{\n  "foo": "<foo>"\n}'
+
+    pydantic_enum_schema_output = get_schema(PydanticClassWithEnum)
+    assert pydantic_enum_schema_output == (
+        '{\n  "name": "<name>",\n  "armor": "<leather | chainmail | plate>"\n}'
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -53,6 +53,11 @@ class PydanticClassWithEnum(BaseModel):
     armor: Armor
 
 
+class PydanticNestedClass(BaseModel):
+    name: str
+    inner: PydanticClass
+
+
 def test_vision_initialization():
     # Create a simple image for testing
     image = PILImage.new("RGB", (10, 10), color="red")
@@ -386,4 +391,9 @@ def test_get_schema():
     pydantic_enum_schema_output = get_schema(PydanticClassWithEnum)
     assert pydantic_enum_schema_output == (
         '{\n  "name": "<name>",\n  "armor": "<leather | chainmail | plate>"\n}'
+    )
+
+    pydantic_nested_schema_output = get_schema(PydanticNestedClass)
+    assert pydantic_nested_schema_output == (
+        '{\n  "name": "<name>",\n  "inner": {\n    "foo": "<foo>"\n  }\n}'
     )


### PR DESCRIPTION
## Summary

- Render referenced enum schemas in the `schema` template filter instead of recursing into non-object schemas.
- Keep the existing prompt-example rendering for descriptions, nested models, and regular fields.
- Add regression coverage for Pydantic models with Enum fields.

Closes #229

## Tests

- `python -m pytest tests/test_templates.py -q`
- `python -m ruff check outlines/templates.py tests/test_templates.py --config=pyproject.toml`
- `git diff --check`

Note: `pre-commit run --files outlines/templates.py tests/test_templates.py` could not complete locally because fetching `pre-commit/pre-commit-hooks` failed with a TLS handshake error.