### PR TITLE
fix(vllm): send structured_outputs instead of removed guided_* keys

### DIFF
--- a/docs/features/models/vllm.md
+++ b/docs/features/models/vllm.md
@@ -18,6 +18,10 @@ vllm serve microsoft/Phi-3-mini-4k-instruct \
 
 Follow the [Installation instructions](https://docs.vllm.ai/en/latest/getting_started/installation/index.html) for more information on how to set up a vLLM server for your particular setup.
 
+!!! warning "vLLM server version"
+
+    Structured output requires a vLLM server **>= 0.12**. Older servers will silently ignore the constrained generation arguments and return **unconstrained** output.
+
 As the vLLM client relies on the `openai` python sdk, you need to have the `openai` package installed. Install all optional dependencies for the `VLLM` model with: `pip install openai`.
 
 If you want to use the vllm offline inference mode instead of the server mode, please refer to the [VLLMOffline](./vllm_offline.md) model documentation.

--- a/src/outlines/models/vllm.py
+++ b/src/outlines/models/vllm.py
@@ -56,6 +56,10 @@ class VLLMTypeAdapter(ModelTypeAdapter):
         if output_type is None:
             return {}
 
+        # The ``structured_outputs`` request field requires a vLLM server
+        # >= 0.12, which replaced the older ``guided_json``/``guided_regex``/
+        # ``guided_grammar`` keys. Older servers silently ignore it and return
+        # unconstrained output.
         term = python_types_to_terms(output_type)
         if isinstance(term, CFG):
             return {"structured_outputs": {"grammar": term.definition}}
@@ -358,6 +362,9 @@ def from_vllm(
 ) -> Union[VLLM, AsyncVLLM]:
     """Create an Outlines `VLLM` or `AsyncVLLM` model instance from an
     `openai.OpenAI` or `openai.AsyncOpenAI` instance.
+
+    Structured output requires a vLLM server >= 0.12; earlier servers use a
+    different interface and will silently return unconstrained responses
 
     Parameters
     ----------

--- a/src/outlines/models/vllm.py
+++ b/src/outlines/models/vllm.py
@@ -58,14 +58,14 @@ class VLLMTypeAdapter(ModelTypeAdapter):
 
         term = python_types_to_terms(output_type)
         if isinstance(term, CFG):
-            return {"guided_grammar": term.definition}
+            return {"structured_outputs": {"grammar": term.definition}}
         elif isinstance(term, JsonSchema):
-            extra_body = {"guided_json": json.loads(term.schema)}
+            structured_outputs = {"json": json.loads(term.schema)}
             if term.whitespace_pattern:
-                extra_body["whitespace_pattern"] = term.whitespace_pattern
-            return extra_body
+                structured_outputs["whitespace_pattern"] = term.whitespace_pattern
+            return {"structured_outputs": structured_outputs}
         else:
-            return {"guided_regex": to_regex(term)}
+            return {"structured_outputs": {"regex": to_regex(term)}}
 
 
 class VLLM(Model):

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -83,12 +83,14 @@ mock_responses = [
             'model': vllm_model_name,
             'max_tokens': 10,
             'extra_body': {
-            'guided_json': {
-                'type': 'object',
-                'properties': {
-                    'bar': {'type': 'string'}
-                }
-            },
+                'structured_outputs': {
+                    'json': {
+                        'type': 'object',
+                        'properties': {
+                            'bar': {'type': 'string'}
+                        }
+                    },
+                },
             }
         },
         '{"foo": "bar"}'
@@ -99,7 +101,7 @@ mock_responses = [
             'model': vllm_model_name,
             'max_tokens': 10,
             'extra_body': {
-                'guided_regex': '([0-9]{3})',
+                'structured_outputs': {'regex': '([0-9]{3})'},
             },
         },
         "123"
@@ -110,7 +112,7 @@ mock_responses = [
             'model': vllm_model_name,
             'max_tokens': 10,
             'extra_body': {
-                'guided_grammar': YES_NO_GRAMMAR,
+                'structured_outputs': {'grammar': YES_NO_GRAMMAR},
             },
         },
         "yes"

--- a/tests/models/test_vllm_type_adapter.py
+++ b/tests/models/test_vllm_type_adapter.py
@@ -131,15 +131,17 @@ def test_vllm_type_adapter_output_type(
 ):
     assert type_adapter.format_output_type(None) == {}
     assert type_adapter.format_output_type(cfg_instance) == {
-        "guided_grammar": CFG_STRING
+        "structured_outputs": {"grammar": CFG_STRING}
     }
     assert type_adapter.format_output_type(json_schema_instance) == {
-        "guided_json": json.loads(JSON_SCHEMA_STRING)
+        "structured_outputs": {"json": json.loads(JSON_SCHEMA_STRING)}
     }
     assert type_adapter.format_output_type(json_schema_whitespace_instance) == {
-        "guided_json": json.loads(JSON_SCHEMA_STRING),
-        "whitespace_pattern": "\n"
+        "structured_outputs": {
+            "json": json.loads(JSON_SCHEMA_STRING),
+            "whitespace_pattern": "\n"
+        }
     }
     assert type_adapter.format_output_type(int) == {
-        "guided_regex": "([+-]?(0|[1-9][0-9]*))"
+        "structured_outputs": {"regex": "([+-]?(0|[1-9][0-9]*))"}
     }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -37,7 +37,7 @@ mock_responses = [
             ],
             'model': MODEL_NAME,
             'max_tokens': 10,
-            'extra_body': {'guided_regex': '("[^"]*")'},
+            'extra_body': {'structured_outputs': {'regex': '("[^"]*")'}},
         },
         "Mock response"
     ),
@@ -48,7 +48,7 @@ mock_responses = [
             ],
             'model': MODEL_NAME,
             'max_tokens': 10,
-            'extra_body': {'guided_regex': '("[^"]*")'},
+            'extra_body': {'structured_outputs': {'regex': '("[^"]*")'}},
             'stream': True,
         },
         ["Mock", "response"]


### PR DESCRIPTION
`from_vllm` still sends `guided_json` / `guided_regex` / `guided_grammar` in `extra_body`, but vLLM dropped those keys in v0.12 and silently ignores unknown fields, so on a 0.23 server the constraint just gets dropped and the output comes back unconstrained.

This swaps them for `extra_body={"structured_outputs": {...}}` with the `json` / `regex` / `grammar` keys (`whitespace_pattern` lives inside that dict now), which is what the offline path has done since #1779. Tests and the mock requests are updated to match, and pre-commit plus the vLLM tests pass locally.

The docs still point at the removed `guided_decoding_backend` as well, happy to fix that in a separate PR.

Fixes #1887
