### PR TITLE
fix(types): convert JSON Schema type arrays to a Union

### DIFF
--- a/outlines/types/json_schema_utils.py
+++ b/outlines/types/json_schema_utils.py
@@ -2,7 +2,7 @@
 
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, create_model
 
@@ -37,6 +37,17 @@ def schema_type_to_python(
 
     t = schema.get("type")
 
+    if isinstance(t, list):
+        # JSON Schema allows ``type`` to be a list of type names, e.g. the
+        # common nullable form ``["string", "null"]``. Map each member to a
+        # Python type and combine them into a Union (mirroring the ``anyOf``
+        # the regex backend uses for type arrays).
+        members = tuple(
+            schema_type_to_python({**schema, "type": member}, caller_target_type)
+            for member in t
+        )
+        return Union[members] if members else Any  # type: ignore
+
     if t == "string":
         return str
     elif t == "integer":
@@ -45,6 +56,8 @@ def schema_type_to_python(
         return float
     elif t == "boolean":
         return bool
+    elif t == "null":
+        return type(None)
     elif t == "array":
         items = schema.get("items", {})
         if items:

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import is_dataclass
-from typing import Any, List, Literal, Optional
+from typing import Any, List, Literal, Optional, Union
 
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticUndefined
@@ -97,6 +97,29 @@ def test_schema_type_to_python_unknown_type():
     assert result == Any
 
 
+def test_schema_type_to_python_null():
+    assert schema_type_to_python({"type": "null"}, "pydantic") is type(None)
+
+
+def test_schema_type_to_python_type_array_nullable():
+    # JSON Schema allows ``type`` to be a list of type names; ["string", "null"]
+    # is the canonical way to express a nullable field.
+    assert schema_type_to_python({"type": ["string", "null"]}, "pydantic") == Optional[str]
+    assert schema_type_to_python({"type": ["integer", "null"]}, "pydantic") == Optional[int]
+
+
+def test_schema_type_to_python_type_array_union():
+    assert schema_type_to_python({"type": ["string", "integer"]}, "pydantic") == Union[str, int]
+    assert (
+        schema_type_to_python({"type": ["string", "integer", "null"]}, "pydantic")
+        == Optional[Union[str, int]]
+    )
+
+
+def test_schema_type_to_python_single_element_type_array():
+    assert schema_type_to_python({"type": ["string"]}, "pydantic") is str
+
+
 def test_json_schema_dict_to_typeddict_basic():
     schema = {
         "type": "object",
@@ -190,6 +213,21 @@ def test_json_schema_dict_to_pydantic_basic():
     assert result.model_fields["age"].annotation == Optional[int]
     assert result.model_fields["name"].default == PydanticUndefined
     result.model_fields["age"].default is None
+
+
+def test_json_schema_dict_to_pydantic_nullable_type_array():
+    # A required property typed as ["integer", "null"] should keep its type
+    # constraint rather than collapsing to ``Any``.
+    schema = {
+        "type": "object",
+        "properties": {
+            "age": {"type": ["integer", "null"]},
+        },
+        "required": ["age"],
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Record")
+    assert result.model_fields["age"].annotation == Optional[int]
 
 
 def test_json_schema_dict_to_pydantic_array_enum():


### PR DESCRIPTION
JSON Schema lets `type` be an array of type names — the canonical way to express a nullable field is `{"type": ["string", "null"]}`. `schema_type_to_python` only matched `type` against a single string, so a type array fell through to the `Any` fallback. When a raw JSON schema is converted to a pydantic model / TypedDict / dataclass (the path the API model backends use, e.g. Gemini), this silently dropped the constraint: an `["integer", "null"]` field came out as `Any` instead of `Optional[int]`.

I map each member of a type array to its Python type and combine them with `Union`, and added handling for the `"null"` type so it resolves to `NoneType`. That lines up with the `anyOf` the regex backend already uses for type arrays.

Added tests covering nullable and multi-type arrays, the standalone `null` type, and a single-element array. `pytest tests/types/` and `pre-commit run --all-files` are green.