### PR TITLE
Fix the documentation preview workflow

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   build:
-    name: Build and Deploy Documentation Preview
+    name: Build Documentation Preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -23,7 +22,9 @@ jobs:
 
       - name: Install dependencies
         if: github.event.action != 'closed'
-        run: pip install -r requirements-doc.txt
+        run: |
+          pip install .
+          pip install -r requirements-doc.txt
 
       - name: Build the documentation
         if: github.event.action != 'closed'
@@ -34,51 +35,21 @@ jobs:
           sed -i "1i site_url: https://dottxt-ai.github.io/outlines/pr-preview/pr-${PR_NUMBER}/" mkdocs.yml
           mkdocs build
 
-      - name: Deploy to PR preview
-        if: github.event_name == 'pull_request'
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+      - name: Save PR metadata
+        run: |
+          mkdir -p pr-meta
+          echo "${{ github.event.pull_request.number }}" > pr-meta/pr_number
+          echo "${{ github.event.action }}" > pr-meta/event_action
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          source-dir: site/
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          comment: false
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          name: pr-preview-meta
+          path: pr-meta/
 
-      - name: Comment PR with preview link
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - name: Upload built site
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          script: |
-            const prNumber = context.issue.number;
-            const previewUrl = `https://dottxt-ai.github.io/outlines/pr-preview/pr-${prNumber}/`;
-
-            // Find existing preview comment
-            const comments = await github.rest.issues.listComments({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const botComment = comments.data.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Documentation preview')
-            );
-
-            const commentBody = `📚 **Documentation preview**: ${previewUrl}\n\n*Preview updates automatically with each commit.*`;
-
-            // Update existing comment or create new one
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                comment_id: botComment.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: prNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
-              });
-            }
+          name: pr-preview-site
+          path: site/

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -1,0 +1,95 @@
+name: Deploy the documentation preview
+
+on:
+  workflow_run:
+    workflows: ["Build the documentation"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    name: Deploy Documentation Preview
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pr-preview-meta
+          path: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          pr_number=$(grep -oE '^[0-9]+' pr-meta/pr_number | head -1)
+          event_action=$(grep -oE '^[a-z_]+' pr-meta/event_action | head -1)
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "event_action=${event_action}" >> "$GITHUB_OUTPUT"
+
+      - name: Download built site
+        if: steps.meta.outputs.event_action != 'closed'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pr-preview-site
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy or remove PR preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pr-number: ${{ steps.meta.outputs.pr_number }}
+          action: ${{ steps.meta.outputs.event_action == 'closed' && 'remove' || 'deploy' }}
+          comment: false
+          token: ${{ secrets.DEPLOY_TOKEN }}
+
+      - name: Comment PR with preview link
+        if: steps.meta.outputs.event_action != 'closed'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const previewUrl = `https://dottxt-ai.github.io/outlines/pr-preview/pr-${prNumber}/`;
+
+            const comments = await github.rest.issues.listComments({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Documentation preview')
+            );
+
+            const commentBody = `📚 **Documentation preview**: ${previewUrl}\n\n*Preview updates automatically with each commit.*`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            }

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -29,6 +29,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
+      - run: pip install .
       - run: pip install -r requirements-doc.txt
       - run: mkdocs build
 


### PR DESCRIPTION
The documentation preview was not working for PRs opened from forks because they are lacking access to the deploy token found in the main repo. The solution is to break the process in two: the workflow to build the documentation preview runs in the fork context and uploads the relevant documents, then it triggers the deployment workflow that runs in the base repo (has access to the token). It downloads the docs and deploys.