### PR TITLE
fix(types): map JSON Schema const to a Literal

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -35,6 +35,13 @@ def schema_type_to_python(
         values = schema["enum"]
         return Literal[tuple(values)]
 
+    if "const" in schema:
+        # ``const`` pins the field to a single value (the singular sibling of
+        # ``enum``). Pydantic emits it for a one-element ``Literal``, often
+        # alongside ``type``, so it must be handled before ``type`` to avoid
+        # widening the value back to its bare type.
+        return Literal[schema["const"]]
+
     t = schema.get("type")
 
     if isinstance(t, list):

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -120,6 +120,24 @@ def test_schema_type_to_python_single_element_type_array():
     assert schema_type_to_python({"type": ["string"]}, "pydantic") is str
 
 
+def test_schema_type_to_python_const():
+    # ``const`` pins a field to a single value; it is the singular sibling of
+    # ``enum`` and must map to a ``Literal`` rather than collapsing to ``Any``.
+    assert schema_type_to_python({"const": "admin"}, "pydantic") == Literal["admin"]
+    assert schema_type_to_python({"const": 3}, "pydantic") == Literal[3]
+    assert schema_type_to_python({"const": True}, "pydantic") == Literal[True]
+
+
+def test_schema_type_to_python_const_with_type():
+    # Pydantic emits ``{"const": <value>, "type": <name>}`` for a single-value
+    # ``Literal``; the ``const`` must win so the fixed value is preserved
+    # instead of widening to the bare type.
+    assert (
+        schema_type_to_python({"const": "admin", "type": "string"}, "pydantic")
+        == Literal["admin"]
+    )
+
+
 def test_json_schema_dict_to_typeddict_basic():
     schema = {
         "type": "object",
@@ -228,6 +246,24 @@ def test_json_schema_dict_to_pydantic_nullable_type_array():
 
     result = json_schema_dict_to_pydantic(schema, "Record")
     assert result.model_fields["age"].annotation == Optional[int]
+
+
+def test_json_schema_dict_to_pydantic_const():
+    # A required ``const`` property must keep its fixed value as a ``Literal``.
+    # Pydantic serialises ``Literal["created"]`` to ``{"const": ..., "type": ...}``,
+    # so a schema round-trip through a non-pydantic target used to lose it.
+    schema = {
+        "type": "object",
+        "properties": {
+            "kind": {"const": "created", "type": "string"},
+            "id": {"type": "integer"},
+        },
+        "required": ["kind", "id"],
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Event")
+    assert result.model_fields["kind"].annotation == Literal["created"]
+    assert result.model_fields["id"].annotation is int
 
 
 def test_json_schema_dict_to_pydantic_array_enum():


### PR DESCRIPTION
`schema_type_to_python` maps `enum` to a `Literal`, but its singular sibling `const` isn't handled at all, so a `const` field silently falls through to `Any` — or, when a `type` keyword is present too, widens to that bare type.

This bites the schema round-trip. Pydantic serialises a one-element `Literal` as `{"const": <value>, "type": <name>}`, so converting such a model to a typeddict/dataclass drops the fixed value:

```python
from typing import Literal
from pydantic import BaseModel
from outlines.types.dsl import JsonSchema

class Event(BaseModel):
    kind: Literal["created"]
    id: int

JsonSchema.convert_to(Event, ["typeddict"]).__annotations__["kind"]
# str  -- expected Literal["created"]
```

I map `const` to `Literal[value]`, placed before the `type` handling so `const` wins when both are present (which is the shape Pydantic emits). Added unit + end-to-end tests.

`pre-commit` (mypy, ruff) clean and `pytest tests/types` passes.
