### PR TITLE
fix(exceptions): don't require a provider's optional SDK to normalize errors

### DIFF
--- a/src/outlines/exceptions.py
+++ b/src/outlines/exceptions.py
@@ -231,7 +231,20 @@ def _build_exception_map(provider: str) -> dict[type, type[APIError]]:
 
     Imports are lazy so no SDK is loaded until an exception actually occurs.
     vLLM and SGLang reuse the OpenAI map because they use the OpenAI SDK client.
+
+    If the provider's optional SDK is not installed the mapping is empty: the
+    callers (:func:`is_provider_exception`, :func:`normalize_provider_exception`)
+    then fall back to SDK-free HTTP status-code inspection. This keeps error
+    handling from raising a spurious ``ImportError`` that would mask the original
+    exception when a *different* provider's SDK is the one installed.
     """
+    try:
+        return _provider_exception_map(provider)
+    except ImportError:
+        return {}
+
+
+def _provider_exception_map(provider: str) -> dict[type, type[APIError]]:
     if provider in ("openai", "vllm", "sglang"):  # vLLM and SGLang use the OpenAI SDK client
         import openai
         return {

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -327,6 +327,71 @@ class TestIsProviderException:
         assert not is_provider_exception(ValueError("oops"), "unknown-provider")
 
 
+class TestProviderSDKNotInstalled:
+    """Exception normalization must not require the provider's optional SDK.
+
+    ``is_provider_exception`` / ``normalize_provider_exception`` are public API
+    and their contract is to let non-provider errors pass through and to fall
+    back to HTTP status-code inspection. Building the SDK-exception map must
+    therefore degrade gracefully to an empty map when the provider package is
+    absent, instead of raising ``ImportError`` (which would mask the original
+    exception when a *different* provider's SDK is the one installed).
+
+    Each provider's optional import is blocked via ``sys.modules[name] = None``,
+    which forces ``import name`` to raise ``ImportError`` even if the package is
+    installed, so these tests are deterministic regardless of the test env.
+    """
+
+    # provider -> the top-level module(s) its exception map imports
+    _PROVIDER_SDK_MODULES = {
+        "openai": ["openai"],
+        "vllm": ["openai"],
+        "sglang": ["openai"],
+        "anthropic": ["anthropic"],
+        "gemini": ["google", "httpx"],
+        "ollama": ["ollama", "httpx"],
+        "tgi": ["huggingface_hub"],
+        "dottxt": ["urllib3"],
+    }
+
+    @pytest.fixture
+    def block_sdk(self, monkeypatch):
+        def _block(*module_names):
+            _build_exception_map.cache_clear()
+            for name in module_names:
+                monkeypatch.setitem(sys.modules, name, None)
+        yield _block
+        _build_exception_map.cache_clear()
+
+    @pytest.mark.parametrize("provider", sorted(_PROVIDER_SDK_MODULES))
+    def test_build_exception_map_returns_empty_when_sdk_missing(self, provider, block_sdk):
+        block_sdk(*self._PROVIDER_SDK_MODULES[provider])
+        assert _build_exception_map(provider) == {}
+
+    @pytest.mark.parametrize("provider", sorted(_PROVIDER_SDK_MODULES))
+    def test_is_provider_exception_passes_through_when_sdk_missing(self, provider, block_sdk):
+        block_sdk(*self._PROVIDER_SDK_MODULES[provider])
+        # A programmer error must not be misreported as a provider error, and
+        # building the (unavailable) SDK map must not raise ImportError.
+        assert is_provider_exception(TypeError("programmer bug"), provider) is False
+
+    @pytest.mark.parametrize("provider", sorted(_PROVIDER_SDK_MODULES))
+    def test_status_code_fallback_survives_missing_sdk(self, provider, block_sdk):
+        block_sdk(*self._PROVIDER_SDK_MODULES[provider])
+        # Even without the SDK, a status-carrying error still normalizes via the
+        # SDK-free status-code fallback.
+        result = normalize_provider_exception(fake_provider_error(429), provider)
+        assert isinstance(result, RateLimitError)
+
+    def test_normalize_context_manager_reraises_programmer_error_without_sdk(self, block_sdk):
+        block_sdk("openai")
+        original = TypeError("programmer bug")
+        with pytest.raises(TypeError) as exc_info:
+            with normalize_provider_errors("openai"):
+                raise original
+        assert exc_info.value is original
+
+
 class TestExceptionMapOpenAI:
     @pytest.fixture(autouse=True)
     def _require_openai(self):


### PR DESCRIPTION
## Summary

`is_provider_exception` and `normalize_provider_exception` are public API (both in `exceptions.__all__`). Their documented contract is to let non-provider errors pass through untouched and otherwise fall back to HTTP status-code inspection.

`_build_exception_map` broke that contract. For every provider **except `mistral`** it performed a bare optional-SDK import (`import openai`, `import anthropic`, `from google.genai import errors`, `import ollama`, `import huggingface_hub.errors`, `import urllib3.exceptions`). When the named provider's optional SDK is **not installed**, building the map raises `ModuleNotFoundError` instead of degrading gracefully — so error-handling code introduces a *new* failure that masks the user's original exception.

```python
# outlines installed, openai SDK not installed:
from outlines.exceptions import is_provider_exception
is_provider_exception(TypeError("a bug in my code"), "openai")
# ModuleNotFoundError: No module named 'openai'   <- should return False
```

This also fires inside the `normalize_provider_errors(provider)` context manager (used throughout `outlines/models/*.py`): a plain `TypeError` raised in that block surfaces as `ModuleNotFoundError` rather than propagating unchanged.

The `mistral` branch already guards its optional import with `try/except ImportError`. This PR makes the other six providers consistent with that existing pattern.

## Fix

Split the SDK-dependent body into `_provider_exception_map` and wrap the single call site in `try/except ImportError`, returning an empty map when the SDK is absent. Callers then fall through to the **SDK-free** status-code inspection, which is unchanged. Behavior when the SDK *is* installed is byte-for-byte identical (same dict, same lookups).

```python
@lru_cache(maxsize=16)
def _build_exception_map(provider: str) -> dict[type, type[APIError]]:
    try:
        return _provider_exception_map(provider)
    except ImportError:
        return {}
```

## Evidence

**13 existing tests already fail without this fix** when `openai` is not installed — `TestIsProviderException` and `TestNormalizeProviderErrors` deliberately test with synthetic errors and do **not** `importorskip`, unlike the sibling `TestExceptionMap*` classes which correctly guard on the SDK. That asymmetry encodes the intended contract; the bug violates it.

```
# openai not installed, before fix:
13 failed, 59 passed, 67 skipped
# openai not installed, after fix:
72 passed, 67 skipped
```

**New regression test** `TestProviderSDKNotInstalled` blocks each provider's optional import via `sys.modules[name] = None`, so the missing-SDK path is exercised **deterministically even in CI where every SDK is installed**. Parametrized across all providers, it asserts:

- `_build_exception_map(provider)` returns `{}` instead of raising
- `is_provider_exception(TypeError(...), provider)` returns `False` (contract: pass programmer errors through)
- status-code fallback still maps `429 -> RateLimitError` with the SDK absent
- `normalize_provider_errors(provider)` re-raises a `TypeError` unchanged

Proven to guard the bug (stash the source change, tests fail; restore, tests pass):

```
# new tests, source fix stashed:  25 failed
# new tests, source fix applied:  25 passed
```

Full `tests/test_exceptions.py` with all SDKs present: **117 passed, 47 skipped**. Broader pure-Python suites (`tests/types`, `tests/test_utils`, `tests/test_templates.py`, `tests/test_inputs.py`): **249 passed**, no regressions. `ruff check --config=pyproject.toml` clean on both files; `mypy` introduces no new errors (the two pre-existing `urllib3` stub warnings are unrelated and identical on `main`).

## Changes

- `src/outlines/exceptions.py` — guard the optional-SDK import once; add `_provider_exception_map` helper (+13/−0)
- `tests/test_exceptions.py` — add `TestProviderSDKNotInstalled` regression coverage (+65/−0)
