### PR TITLE
Normalize LM Studio exceptions

### DIFF
--- a/src/outlines/exceptions.py
+++ b/src/outlines/exceptions.py
@@ -358,6 +358,12 @@ def _provider_exception_map(provider: str) -> dict[type, type[APIError]]:
             urllib3_exc.MaxRetryError: APIConnectionError,
         }
 
+    if provider == "lmstudio":
+        return {
+            ConnectionError: APIConnectionError,
+            TimeoutError: APITimeoutError,
+        }
+
     # Unknown provider: no SDK-specific mapping available.
     # normalize_provider_exception will fall back to status-code inspection.
     return {}

--- a/src/outlines/models/lmstudio.py
+++ b/src/outlines/models/lmstudio.py
@@ -1,6 +1,6 @@
 """Integration with the `lmstudio` library.
 
-Local runtime calls intentionally bypass
+Provider/runtime calls are normalized via
 outlines.exceptions.normalize_provider_errors().
 """
 
@@ -15,12 +15,15 @@ from typing import (
     cast,
 )
 
+from outlines.exceptions import normalize_provider_errors
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
 from outlines.types import CFG, JsonSchema, Regex
 
 if TYPE_CHECKING:
     from lmstudio import AsyncClient, Chat as LMStudioChat, Client
+
+PROVIDER = "lmstudio"
 
 __all__ = ["LMStudio", "AsyncLMStudio", "from_lmstudio"]
 
@@ -214,7 +217,12 @@ class LMStudio(Model):
             kwargs["model"] = self.model_name
 
         model_key = kwargs.pop("model", None)
-        model = self.client.llm.model(model_key) if model_key else self.client.llm.model()
+        with normalize_provider_errors(PROVIDER):
+            model = (
+                self.client.llm.model(model_key)
+                if model_key
+                else self.client.llm.model()
+            )
 
         formatted_input = self.type_adapter.format_input(model_input)
         response_format = self.type_adapter.format_output_type(output_type)
@@ -222,7 +230,8 @@ class LMStudio(Model):
         if response_format is not None:
             kwargs["response_format"] = response_format
 
-        result = model.respond(formatted_input, **kwargs)
+        with normalize_provider_errors(PROVIDER):
+            result = model.respond(formatted_input, **kwargs)
         return result.content
 
     def generate_batch(
@@ -264,7 +273,12 @@ class LMStudio(Model):
             kwargs["model"] = self.model_name
 
         model_key = kwargs.pop("model", None)
-        model = self.client.llm.model(model_key) if model_key else self.client.llm.model()
+        with normalize_provider_errors(PROVIDER):
+            model = (
+                self.client.llm.model(model_key)
+                if model_key
+                else self.client.llm.model()
+            )
 
         formatted_input = self.type_adapter.format_input(model_input)
         response_format = self.type_adapter.format_output_type(output_type)
@@ -272,9 +286,10 @@ class LMStudio(Model):
         if response_format is not None:
             kwargs["response_format"] = response_format
 
-        stream = model.respond_stream(formatted_input, **kwargs)
-        for fragment in stream:
-            yield fragment.content
+        with normalize_provider_errors(PROVIDER):
+            stream = model.respond_stream(formatted_input, **kwargs)
+            for fragment in stream:
+                yield fragment.content
 
 
 class AsyncLMStudio(AsyncModel):
@@ -342,7 +357,12 @@ class AsyncLMStudio(AsyncModel):
             kwargs["model"] = self.model_name
 
         model_key = kwargs.pop("model", None)
-        model = await self.client.llm.model(model_key) if model_key else await self.client.llm.model()
+        with normalize_provider_errors(PROVIDER):
+            model = (
+                await self.client.llm.model(model_key)
+                if model_key
+                else await self.client.llm.model()
+            )
 
         formatted_input = self.type_adapter.format_input(model_input)
         response_format = self.type_adapter.format_output_type(output_type)
@@ -350,7 +370,8 @@ class AsyncLMStudio(AsyncModel):
         if response_format is not None:
             kwargs["response_format"] = response_format
 
-        result = await model.respond(formatted_input, **kwargs)
+        with normalize_provider_errors(PROVIDER):
+            result = await model.respond(formatted_input, **kwargs)
         return result.content
 
     async def generate_batch(
@@ -396,7 +417,12 @@ class AsyncLMStudio(AsyncModel):
             kwargs["model"] = self.model_name
 
         model_key = kwargs.pop("model", None)
-        model = await self.client.llm.model(model_key) if model_key else await self.client.llm.model()
+        with normalize_provider_errors(PROVIDER):
+            model = (
+                await self.client.llm.model(model_key)
+                if model_key
+                else await self.client.llm.model()
+            )
 
         formatted_input = self.type_adapter.format_input(model_input)
         response_format = self.type_adapter.format_output_type(output_type)
@@ -404,9 +430,10 @@ class AsyncLMStudio(AsyncModel):
         if response_format is not None:
             kwargs["response_format"] = response_format
 
-        stream = await model.respond_stream(formatted_input, **kwargs)
-        async for fragment in stream:
-            yield fragment.content
+        with normalize_provider_errors(PROVIDER):
+            stream = await model.respond_stream(formatted_input, **kwargs)
+            async for fragment in stream:
+                yield fragment.content
 
 
 def from_lmstudio(

--- a/tests/models/test_lmstudio.py
+++ b/tests/models/test_lmstudio.py
@@ -3,7 +3,9 @@ import json
 import os
 import warnings
 from enum import Enum
+from types import SimpleNamespace
 from typing import Annotated, AsyncGenerator, Generator
+from unittest.mock import AsyncMock, Mock
 
 import lmstudio
 import pytest
@@ -11,6 +13,7 @@ from PIL import Image as PILImage
 from pydantic import BaseModel, Field
 
 import outlines
+from outlines.exceptions import APIConnectionError, APITimeoutError
 from outlines.inputs import Chat, Image, Video
 from outlines.models import AsyncLMStudio, LMStudio
 from outlines.models.lmstudio import LMStudioTypeAdapter
@@ -50,6 +53,28 @@ else:
 
 class Foo(BaseModel):
     foo: Annotated[str, Field(max_length=10)]
+
+
+class RaisingIterator:
+    def __init__(self, exc):
+        self.exc = exc
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise self.exc
+
+
+class RaisingAsyncIterator:
+    def __init__(self, exc):
+        self.exc = exc
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise self.exc
 
 
 type_adapter = LMStudioTypeAdapter()
@@ -229,6 +254,44 @@ def test_lmstudio_wrong_input_type(model):
         model.generate(["foo?", image_input, Video("")], None)
 
 
+def test_lmstudio_connection_error_normalizes():
+    original = ConnectionError("LM Studio is unavailable")
+    lmstudio_model = SimpleNamespace(respond=Mock(side_effect=original))
+    client = SimpleNamespace(llm=SimpleNamespace(model=Mock(return_value=lmstudio_model)))
+    model = LMStudio(client)
+
+    with pytest.raises(APIConnectionError) as exc_info:
+        model.generate("hello")
+
+    assert exc_info.value.provider == "lmstudio"
+    assert exc_info.value.original_exception is original
+    assert exc_info.value.__cause__ is original
+
+
+def test_lmstudio_model_lookup_timeout_normalizes():
+    original = TimeoutError("LM Studio timed out")
+    client = SimpleNamespace(llm=SimpleNamespace(model=Mock(side_effect=original)))
+    model = LMStudio(client)
+
+    with pytest.raises(APITimeoutError) as exc_info:
+        model.generate("hello")
+
+    assert exc_info.value.provider == "lmstudio"
+    assert exc_info.value.original_exception is original
+
+
+def test_lmstudio_non_provider_error_passes_through():
+    original = ValueError("bad mock response")
+    lmstudio_model = SimpleNamespace(respond=Mock(side_effect=original))
+    client = SimpleNamespace(llm=SimpleNamespace(model=Mock(return_value=lmstudio_model)))
+    model = LMStudio(client)
+
+    with pytest.raises(ValueError) as exc_info:
+        model.generate("hello")
+
+    assert exc_info.value is original
+
+
 def test_lmstudio_stream(model):
     result = model.stream("Write a sentence about a cat.")
     assert isinstance(result, Generator)
@@ -241,6 +304,40 @@ def test_lmstudio_stream_json(model_no_model_name):
     for text in generator:
         generated_text.append(text)
     assert "foo" in json.loads("".join(generated_text))
+
+
+def test_lmstudio_stream_connection_error_normalizes():
+    original = ConnectionError("LM Studio stream disconnected")
+    lmstudio_model = SimpleNamespace(
+        respond_stream=Mock(return_value=RaisingIterator(original))
+    )
+    client = SimpleNamespace(llm=SimpleNamespace(model=Mock(return_value=lmstudio_model)))
+    model = LMStudio(client)
+
+    with pytest.raises(APIConnectionError) as exc_info:
+        next(model.stream("hello"))
+
+    assert exc_info.value.provider == "lmstudio"
+    assert exc_info.value.original_exception is original
+
+
+def test_lmstudio_stream_can_stop_early():
+    lmstudio_model = SimpleNamespace(
+        respond_stream=Mock(
+            return_value=iter(
+                [
+                    SimpleNamespace(content="first"),
+                    SimpleNamespace(content="second"),
+                ]
+            )
+        )
+    )
+    client = SimpleNamespace(llm=SimpleNamespace(model=Mock(return_value=lmstudio_model)))
+    model = LMStudio(client)
+
+    for chunk in model.stream("hello"):
+        assert chunk == "first"
+        break
 
 
 def test_lmstudio_batch(model):
@@ -348,6 +445,24 @@ async def test_lmstudio_async_wrong_input_type(async_model):
 
 
 @pytest.mark.asyncio
+async def test_lmstudio_async_connection_error_normalizes():
+    original = ConnectionError("LM Studio is unavailable")
+    lmstudio_model = SimpleNamespace(respond=AsyncMock(side_effect=original))
+    client = SimpleNamespace(
+        __aenter__=AsyncMock(),
+        llm=SimpleNamespace(model=AsyncMock(return_value=lmstudio_model)),
+    )
+    model = AsyncLMStudio(client)
+
+    with pytest.raises(APIConnectionError) as exc_info:
+        await model.generate("hello")
+
+    assert exc_info.value.provider == "lmstudio"
+    assert exc_info.value.original_exception is original
+    assert exc_info.value.__cause__ is original
+
+
+@pytest.mark.asyncio
 async def test_lmstudio_async_stream(async_model):
     result = async_model.stream("Write a sentence about a cat.")
     assert isinstance(result, AsyncGenerator)
@@ -361,6 +476,43 @@ async def test_lmstudio_async_stream_json(async_model_no_model_name):
     async for chunk in async_generator:
         generated_text.append(chunk)
     assert "foo" in json.loads("".join(generated_text))
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_async_stream_timeout_normalizes():
+    original = TimeoutError("LM Studio stream timed out")
+    lmstudio_model = SimpleNamespace(
+        respond_stream=AsyncMock(return_value=RaisingAsyncIterator(original))
+    )
+    client = SimpleNamespace(
+        __aenter__=AsyncMock(),
+        llm=SimpleNamespace(model=AsyncMock(return_value=lmstudio_model)),
+    )
+    model = AsyncLMStudio(client)
+
+    with pytest.raises(APITimeoutError) as exc_info:
+        await model.stream("hello").__anext__()
+
+    assert exc_info.value.provider == "lmstudio"
+    assert exc_info.value.original_exception is original
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_async_stream_can_stop_early():
+    async def stream():
+        yield SimpleNamespace(content="first")
+        yield SimpleNamespace(content="second")
+
+    lmstudio_model = SimpleNamespace(respond_stream=AsyncMock(return_value=stream()))
+    client = SimpleNamespace(
+        __aenter__=AsyncMock(),
+        llm=SimpleNamespace(model=AsyncMock(return_value=lmstudio_model)),
+    )
+    model = AsyncLMStudio(client)
+
+    async for chunk in model.stream("hello"):
+        assert chunk == "first"
+        break
 
 
 @pytest.mark.asyncio

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -8,6 +8,7 @@ Each provider section can be run independently:
     pytest tests/test_exceptions.py -k "ollama"
     pytest tests/test_exceptions.py -k "tgi"
     pytest tests/test_exceptions.py -k "dottxt"
+    pytest tests/test_exceptions.py -k "lmstudio"
     pytest tests/test_exceptions.py -k "vllm"
     pytest tests/test_exceptions.py -k "sglang"
 """
@@ -725,6 +726,24 @@ class TestExceptionMapDottxt:
     def test_new_connection_error(self):
         from urllib3.exceptions import NewConnectionError
         _check_mapping(NewConnectionError, "dottxt", APIConnectionError)
+
+
+class TestExceptionMapLMStudio:
+    def test_connection_error(self):
+        _check_mapping(ConnectionError, "lmstudio", APIConnectionError)
+
+    def test_timeout_error(self):
+        _check_mapping(TimeoutError, "lmstudio", APITimeoutError)
+
+    def test_status_code_fallback(self):
+        class LMStudioError(Exception):
+            status_code = 429
+
+        result = normalize_provider_exception(
+            LMStudioError("rate limited"),
+            "lmstudio",
+        )
+        assert isinstance(result, RateLimitError)
 
 
 # vLLM and SGLang both reuse the OpenAI SDK client, so they share the OpenAI


### PR DESCRIPTION
# Thank you for opening a PR!

A few important guidelines and requirements before we can merge your PR:

- [x] We should be able to understand what the PR does from its title only;
- [x] There is a high-level description of the changes;
- [x] *If I add a new feature*, there is an issue discussing it already;
- [x] There are links to *all* the relevant issues, discussions and PRs;
- [x] The branch is rebased on the latest `main` commit;
- [x] **Commit messages** follow these guidelines;
- [x] One commit per logical change;
- [x] The code respects the current **naming conventions**;
- [x] Docstrings follow the numpy style guide;
- [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
- [x] There are tests covering the changes;
- [x] The documentation is up-to-date;

## Description

Follow-up to #1823 / #1658.

#1823 added the shared exception hierarchy and provider error normalization for most client-backed model wrappers. After that merge, LM Studio still appears to be missing from the provider normalization path: runtime transport failures can escape as raw exceptions from the LM Studio client.

This PR adds LM Studio to the shared provider exception mapping and wraps LM Studio sync and async client calls with `normalize_provider_errors("lmstudio")`.

## Changes

- Map LM Studio `ConnectionError` failures to `APIConnectionError`.
- Map LM Studio `TimeoutError` failures to `APITimeoutError`.
- Continue using status-code fallback for provider errors that expose HTTP-like status codes, including rate limits.
- Wrap sync and async LM Studio model lookup, generation, and streaming calls.
- Preserve the original provider exception through `original_exception` and Python exception chaining.
- Keep local validation and programmer errors, such as `ValueError`, passing through unchanged.

## Compatibility

This keeps the existing LM Studio public API unchanged. It only standardizes provider/runtime failures under the existing Outlines exception hierarchy, while preserving the underlying exception for debugging.

Streaming is covered for both provider failures and early consumer cancellation. Since `normalize_provider_errors` catches `Exception`, `GeneratorExit` and other `BaseException` subclasses are not wrapped when a caller stops consuming a stream early.

## Verification

- `pre-commit run --all-files`
- `python -m pytest tests/test_exceptions.py -k lmstudio`
- `python -m pytest tests/models/test_lmstudio.py`
