### PR TITLE
Escape regex metacharacters in numeric literal constraints

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -751,7 +751,11 @@ def python_types_to_terms(ptype: Any, recursion_depth: int = 0) -> Term:
     elif is_str_instance(ptype):
         return String(ptype)
     elif is_int_instance(ptype) or is_float_instance(ptype):
-        return Regex(str(ptype))
+        # Escape regex metacharacters so the literal value matches literally.
+        # Without this a float's ``.`` becomes a wildcard (e.g. ``1.5`` would
+        # also match ``1x5``). Kept as a ``Regex`` (not ``String``) so numbers
+        # stay JSON-unquoted inside container types via ``_ensure_json_quoted``.
+        return Regex(re.escape(str(ptype)))
 
     # Structured types
     structured_type_checks = [

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -542,7 +542,7 @@ def test_dsl_python_types_to_terms():
     int_instance = 1
     assert python_types_to_terms(int_instance) == Regex(r"1")
     float_instance = 1.0
-    assert python_types_to_terms(float_instance) == Regex(r"1.0")
+    assert python_types_to_terms(float_instance) == Regex(r"1\.0")
 
     @dataclass
     class DataClass:
@@ -665,6 +665,28 @@ def test_dsl_literal_bool():
     assert result_false.terms == [Regex("False")]
     result_both = python_types_to_terms(Literal[True, False])
     assert result_both == Alternatives([Regex("True"), Regex("False")])
+
+
+def test_dsl_numeric_literal_escapes_regex_metacharacters():
+    # A float's ``.`` must match literally, not act as a regex wildcard.
+    term = python_types_to_terms(1.5)
+    assert to_regex(term) == r"(1\.5)"
+    assert term.matches("1.5") is True
+    assert term.matches("1x5") is False
+
+    # Same guarantee through the common ``Literal`` path...
+    literal_term = python_types_to_terms(Literal[1.5])
+    assert literal_term.matches("1x5") is False
+
+    # ...and for float-valued Enums.
+    class Ratio(float, Enum):
+        HALF = 1.5
+
+    enum_term = python_types_to_terms(Ratio)
+    assert enum_term.matches("1x5") is False
+
+    # Parity with string literals, which were already escaped.
+    assert python_types_to_terms("1.5").matches("1x5") is False
 
 
 def test_dsl_handle_union():


### PR DESCRIPTION
Fixes #1901.

## Problem

In `python_types_to_terms` (`src/outlines/types/dsl.py`), a numeric literal value (int/float instance) was converted to a raw `Regex(str(value))` **without escaping**. For a float the `.` is left unescaped and acts as a regex wildcard, so the constraint silently over-accepts input:

```python
python_types_to_terms(1.5).matches("1x5")            # True  (should be False)
python_types_to_terms(Literal[1.5]).matches("1x5")   # True  (should be False)
```

String literals were already escaped (they go through `String(...)`, which `to_regex` escapes via `re.escape`), so this was an inconsistency between string and numeric literals. It's reachable through common paths: `Literal[<float>]`, float-valued `Enum`s, and bare numeric constants / `Union` members.

## Fix

Escape the value with `re.escape`, while keeping it a `Regex` term (not `String`) so numbers stay JSON-unquoted inside container types via `_ensure_json_quoted`:

```python
elif is_int_instance(ptype) or is_float_instance(ptype):
    return Regex(re.escape(str(ptype)))
```

Ints are unaffected (no metacharacters); the change only bites for floats (`.`) and any future metachar-bearing numeric repr. `re` is already imported.

## Tests

- New `test_dsl_numeric_literal_escapes_regex_metacharacters` asserts the escaped regex (`(1\.5)`), that `"1.5"` matches and `"1x5"` does not, and checks the `Literal[float]`, float-`Enum`, and string-literal-parity paths.
- Updated the existing `test_dsl_python_types_to_terms` assertion, which encoded the old unescaped form (`Regex(r"1.0")` → `Regex(r"1\.0")`) — it only compared the term and never exercised matching.

Red/green verified by stashing the fix (both tests fail on `main`, pass with the fix). Full `tests/types/` suite passes (231); also confirmed `List[Literal[1.5]]` still emits an unquoted number (`\[((1\.5))...`) so there's no JSON-quoting regression. `pre-commit` (ruff + mypy) clean.

## Disclosure

Found by code review and fixed with AI assistance (Claude); the bug and the fix were verified against `main`.
