### PR TITLE
Stop omitting lmstudio.py from the coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ omit = [
     "src/outlines/models/anthropic.py",
     "src/outlines/models/dottxt.py",
     "src/outlines/models/gemini.py",
-    "src/outlines/models/lmstudio.py",
     "src/outlines/models/mlxlm.py",
     "src/outlines/models/openai.py",
     "src/outlines/models/mistral.py",

--- a/tests/models/test_lmstudio.py
+++ b/tests/models/test_lmstudio.py
@@ -161,6 +161,15 @@ def test_lmstudio_init_from_client():
         assert model.client == client
         assert model.model_name is None
 
+    # `from_lmstudio` must dispatch to `LMStudio` for a sync client regardless
+    # of whether that client can actually reach a server, so this is checked
+    # unconditionally with a client that is never connected to.
+    dispatch_client = lmstudio.Client("http://127.0.0.1:1")
+    dispatched_model = outlines.from_lmstudio(dispatch_client, lmstudio_model_name)
+    assert isinstance(dispatched_model, LMStudio)
+    assert dispatched_model.client == dispatch_client
+    assert dispatched_model.model_name == lmstudio_model_name
+
     # With invalid client
     with pytest.raises(ValueError, match="Invalid client type"):
         outlines.from_lmstudio(object())
@@ -276,6 +285,15 @@ def test_lmstudio_async_init_from_client():
         assert model.client == client
         assert model.model_name is None
 
+    # `from_lmstudio` must dispatch to `AsyncLMStudio` for an async client
+    # regardless of whether that client can actually reach a server, so this
+    # is checked unconditionally with a client that is never connected to.
+    dispatch_client = lmstudio.AsyncClient("http://127.0.0.1:1")
+    dispatched_model = outlines.from_lmstudio(dispatch_client, lmstudio_model_name)
+    assert isinstance(dispatched_model, AsyncLMStudio)
+    assert dispatched_model.client == dispatch_client
+    assert dispatched_model.model_name == lmstudio_model_name
+
 
 @pytest.mark.asyncio
 async def test_lmstudio_async_simple(async_model):
@@ -367,3 +385,37 @@ async def test_lmstudio_async_stream_json(async_model_no_model_name):
 async def test_lmstudio_async_batch(async_model):
     with pytest.raises(NotImplementedError, match="does not support"):
         await async_model.batch(["Respond with one word.", "Respond with one word."])
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_async_close_after_generate_exits_context(async_model):
+    await async_model.generate("Respond with one word. Not more.", None)
+    assert async_model._context_entered is True
+
+    await async_model.close()
+
+    assert async_model._context_entered is False
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_async_close_without_generate_is_a_no_op(async_model):
+    # The client's context is never entered until the model actually makes a
+    # call, so closing beforehand must not try to exit it.
+    await async_model.close()
+
+    assert async_model._context_entered is False
+
+
+@pytest.mark.asyncio
+async def test_lmstudio_async_stream_reuses_context_on_second_call(async_model):
+    first_stream = async_model.stream("Write a sentence about a cat.")
+    async for _ in first_stream:
+        pass
+    assert async_model._context_entered is True
+
+    # A second streaming call while already entered must skip re-entering
+    # the client context instead of calling `__aenter__` again.
+    second_stream = async_model.stream("Write a sentence about a cat.")
+    async for _ in second_stream:
+        pass
+    assert async_model._context_entered is True

--- a/tests/models/test_lmstudio_type_adapter.py
+++ b/tests/models/test_lmstudio_type_adapter.py
@@ -1,6 +1,5 @@
 import io
 import json
-import os
 import sys
 from dataclasses import dataclass
 
@@ -19,16 +18,6 @@ else:
     from typing_extensions import TypedDict
 
 
-# Skip condition for tests that require a running LM Studio server (image tests)
-requires_lmstudio_server = pytest.mark.skipif(
-    not os.environ.get("LMSTUDIO_SERVER_URL"),
-    reason=(
-        "Image tests require a running LM Studio server (lms.prepare_image "
-        + "needs connection)"
-    )
-)
-
-
 @pytest.fixture
 def schema():
     return {
@@ -45,6 +34,19 @@ def schema():
 @pytest.fixture
 def adapter():
     return LMStudioTypeAdapter()
+
+
+# `lms.prepare_image` normally uploads the image bytes to a running LM Studio
+# server and returns a `FileHandle`. The tests that stub it out only care that
+# the type adapter passes whatever it gets back through to `add_user_message`
+# unchanged, so a dict in `FileHandle`'s wire format is enough to stand in for
+# it without needing a real server.
+_FAKE_FILE_HANDLE = {
+    "name": "test.png",
+    "identifier": "test-image",
+    "sizeBytes": 0,
+    "fileType": "image",
+}
 
 
 @pytest.fixture
@@ -69,9 +71,12 @@ def test_lmstudio_type_adapter_input_text(adapter):
     assert result == text_input
 
 
-@requires_lmstudio_server
-def test_lmstudio_type_adapter_input_vision(adapter, image):
+def test_lmstudio_type_adapter_input_vision(adapter, image, monkeypatch):
     import lmstudio as lms
+
+    # `lms.prepare_image` is the only part of this path that needs a live
+    # LM Studio server, so it's the only thing that needs stubbing here.
+    monkeypatch.setattr(lms, "prepare_image", lambda image_bytes: _FAKE_FILE_HANDLE)
 
     image_input = Image(image)
     text_input = "prompt"
@@ -104,9 +109,10 @@ def test_lmstudio_type_adapter_input_chat_no_system(adapter):
     assert isinstance(result, lms.Chat)
 
 
-@requires_lmstudio_server
-def test_lmstudio_type_adapter_input_chat_with_image(adapter, image):
+def test_lmstudio_type_adapter_input_chat_with_image(adapter, image, monkeypatch):
     import lmstudio as lms
+
+    monkeypatch.setattr(lms, "prepare_image", lambda image_bytes: _FAKE_FILE_HANDLE)
 
     image_input = Image(image)
     chat_input = Chat(messages=[
@@ -119,6 +125,17 @@ def test_lmstudio_type_adapter_input_chat_with_image(adapter, image):
     ])
     result = adapter.format_input(chat_input)
     assert isinstance(result, lms.Chat)
+
+
+def test_lmstudio_type_adapter_input_chat_with_image_rejects_non_image_assets(adapter):
+    chat_input = Chat(messages=[
+        {"role": "user", "content": [
+            "What is in this image?",
+            "not an image",
+        ]},
+    ])
+    with pytest.raises(ValueError, match="All assets provided must be of type Image"):
+        adapter.format_input(chat_input)
 
 
 def test_lmstudio_type_adapter_input_invalid(adapter):


### PR DESCRIPTION
Fixes #1506

`src/outlines/models/lmstudio.py` was in the coverage `omit` list because its image-handling paths need a live LM Studio server (`lms.prepare_image` uploads bytes to a running instance), and `from_lmstudio()`'s success branches / `AsyncLMStudio.close()` were never reached by any test that runs without one.

None of that actually requires real hardware or an API key, unlike the GPU/Apple Silicon files also in that list, so this closes the gaps with mocked tests instead:

- Un-skip the two image-input tests in `test_lmstudio_type_adapter.py`by stubbing `lms.prepare_image`, since everything else in those tests only checks the adapter builds the right `lmstudio.Chat` structure. Also added the matching "invalid image asset" test for chat-formatted input, mirroring the one that already existed for list-formatted input.

- Added tests for `AsyncLMStudio.close()`, the context re-entry skip in `generate_stream`, and `from_lmstudio()`'s dispatch for a plain `Client`/`AsyncClient` (both of which can be constructed against a bogus host without connecting, so no real server or mock is needed).
- Removed `src/outlines/models/lmstudio.py` from `[tool.coverage.run] omit` now that it hits 100% branch coverage on its own.
Verified locally with a coverage config that has no omit list: `src/outlines/models/lmstudio.py: 145 stmts, 54 branches, 100% cover`.