### PR TITLE
Docs/fix reorg broken links

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -66,7 +66,7 @@ Outlines provides optional dependencies for different supported backends, which 
 pip install ".[vllm]"
 ```
 
-A list of supported optional dependencies can be found in the [installation guide](/installation).
+A list of supported optional dependencies can be found in the [installation guide](../guide/installation.md).
 
 ### Using VSCode DevContainer / GitHub Codespaces
 

--- a/docs/community/versioning.md
+++ b/docs/community/versioning.md
@@ -15,7 +15,7 @@ Each part of the version number (`major.minor.patch`) conveys information about 
 
 !!! note "Breaking Changes"
 
-    Outlines v1.0 introduced several breaking changes to the core interface. See [the migration guide](/user_guide/migration) for more details.
+    Outlines v1.0 introduced several breaking changes to the core interface. See [the migration guide](../guide/migration.md) for more details.
 
 ## Releases
 

--- a/docs/features/core/output_types.md
+++ b/docs/features/core/output_types.md
@@ -201,7 +201,7 @@ print(type(sentence)) # outlines.types.dsl.Regex
 print(sentence.pattern) # [A-Z].*\s*[.!?]
 ```
 
-To help you create complex regex patterns yourself, you can use the Outlines [regex DSL](../../utility/regex_dsl).
+To help you create complex regex patterns yourself, you can use the Outlines [regex DSL](../utility/regex_dsl.md).
 
 ### Context-Free Grammars
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,7 +13,7 @@ This section presents in details the different features of Outlines.
 ## Utilities
 
 - [Applications](./utility/application.md)
-- [Templates](./utility/templates.md)
+- [Templates](./utility/template.md)
 - [Regex DSL](./utility/regex_dsl.md)
 
 ## Advanced

--- a/docs/features/models/index.md
+++ b/docs/features/models/index.md
@@ -84,7 +84,7 @@ print(response) # ['Riga', 'Tallinn']
 
 In alphabetical order:
 
-| | [Anthropic](../../models/anthropic) | [Dottxt](../../models/dottxt) | [Gemini](../../models/gemini) | [LlamaCpp](../../models/llamacpp) | [LM Studio](../../models/lmstudio) | [MLXLM](../../models/mlxlm) | [Mistral](../../models/mistral) | [Ollama](../../models/ollama) | [OpenAI](../../models/openai) | [SGLang](../../models/sglang) | [TGI](../../models/tgi) | [Transformers](../../models/transformers) | [Transformers MultiModal](../../models/transformers_multimodal) | [VLLM](../../models/vllm) | [VLLMOffline](../../models/vllm_offline) |
+| | [Anthropic](anthropic.md) | [Dottxt](dottxt.md) | [Gemini](gemini.md) | [LlamaCpp](llamacpp.md) | [LM Studio](lmstudio.md) | [MLXLM](mlxlm.md) | [Mistral](mistral.md) | [Ollama](ollama.md) | [OpenAI](openai.md) | [SGLang](sglang.md) | [TGI](tgi.md) | [Transformers](transformers.md) | [Transformers MultiModal](transformers_multimodal.md) | [VLLM](vllm.md) | [VLLMOffline](vllm_offline.md) |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **Output Types** | | | | | | | | | | | | | | | |
 | Simple Types | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -18,11 +18,11 @@ or the classic `pip`:
 pip install 'outlines[transformers]'
 ```
 
-For more information, see the [installation guide](./installation).
+For more information, see the [installation guide](installation.md).
 
 ## Creating a Model
 
-Outlines contains a variety of models that wrap LLM inference engines/clients. For each of them, you need to install the model's associated library as described in the [installation guide](../installation).
+Outlines contains a variety of models that wrap LLM inference engines/clients. For each of them, you need to install the model's associated library as described in the [installation guide](installation.md).
 
 The full list of available models along with detailed explanation on how to use them can be found in the [models page](../features/models/index.md) of the Features section of the documentation.
 
@@ -201,13 +201,13 @@ Outlines follows a simple pattern that mirrors Python's own type system for stru
 
 Supported output types can be organized in 5 categories:
 
-- [Basic Types](../../features/core/output_types#basic-python-types): `int`, `float`, `bool`...
-- [Multiple Choices](../../features/core/output_types#multiple-choices): using `Literal` or `Enum`
-- [JSON Schemas](../../features/core/output_types#json-schemas): using a wide range of possible objects including Pydantic models and dataclasses
-- [Regex](../../features/core/output_types#regex-patterns): through the Outlines's `Regex` object
-- [Context-free Grammars](../../features/core/output_types#context-free-grammars): through the Outlines's `CFG` object
+- [Basic Types](../features/core/output_types.md#basic-python-types): `int`, `float`, `bool`...
+- [Multiple Choices](../features/core/output_types.md#multiple-choices): using `Literal` or `Enum`
+- [JSON Schemas](../features/core/output_types.md#json-schemas): using a wide range of possible objects including Pydantic models and dataclasses
+- [Regex](../features/core/output_types.md#regex-patterns): through the Outlines's `Regex` object
+- [Context-free Grammars](../features/core/output_types.md#context-free-grammars): through the Outlines's `CFG` object
 
-Consult the section on [Output Types](../../features/core/output_types.md) in the features documentation for more detailed information on all supported types for each output type category.
+Consult the section on [Output Types](../features/core/output_types.md) in the features documentation for more detailed information on all supported types for each output type category.
 
 In the meantime, you can find below examples of using each of the five output type categories:
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -36,19 +36,19 @@ To use Outlines models, you need to install the Python libraries for the associa
 
 Outlines models with the installation of their associated additional depencies:
 
-- [Anthropic](features/models/anthropic.md): `pip install anthropic`
-- [Dottxt](features/models/dottxt.md): `pip install dottxt`
-- [Gemini](features/models/gemini.md): `pip install google-generativeai`
-- [Llamacpp](features/models/llamacpp.md): `pip install llama-cpp-python`
-- [Mlx-lm](features/models/mlxlm.md): `pip install mlx mlx-lm`
-- [Ollama](features/models/ollama.md): `pip install ollama` (after having downloaded Ollama in your system)
-- [OpenAI](features/models/openai.md): `pip install openai`
-- [SGLang](features/models/sglang.md): `pip install openai`
-- [TGI](features/models/tgi.md): `pip install huggingface_hub`
-- [Transformers](features/models/transformers.md): `pip install transformers`
-- [TransformersMultiModal](features/models/transformers_multimodal.md): `pip install transformers`
-- [vLLM (online server)](features/models/vllm.md): `pip install openai`
-- [vLLM (offline)](features/models/vllm_offline.md): `pip install vllm`
+- [Anthropic](../features/models/anthropic.md): `pip install anthropic`
+- [Dottxt](../features/models/dottxt.md): `pip install dottxt`
+- [Gemini](../features/models/gemini.md): `pip install google-generativeai`
+- [Llamacpp](../features/models/llamacpp.md): `pip install llama-cpp-python`
+- [Mlx-lm](../features/models/mlxlm.md): `pip install mlx mlx-lm`
+- [Ollama](../features/models/ollama.md): `pip install ollama` (after having downloaded Ollama in your system)
+- [OpenAI](../features/models/openai.md): `pip install openai`
+- [SGLang](../features/models/sglang.md): `pip install openai`
+- [TGI](../features/models/tgi.md): `pip install huggingface_hub`
+- [Transformers](../features/models/transformers.md): `pip install transformers`
+- [TransformersMultiModal](../features/models/transformers_multimodal.md): `pip install transformers`
+- [vLLM (online server)](../features/models/vllm.md): `pip install openai`
+- [vLLM (offline)](../features/models/vllm_offline.md): `pip install vllm`
 
 If you encounter any problems using Outlines with these libraries, take a look at their installation instructions. The installation of `openai` and `transformers` should be straightforward, but other libraries have specific hardware requirements.
 
@@ -70,4 +70,4 @@ This can be useful, for instance, when a fix has been merged but not yet release
 
 ## Installing for Development
 
-See the [contributing documentation](community/contribute.md) for instructions on how to install Outlines for development, including an example using the `dot-install` method for one of the backends.
+See the [contributing documentation](../community/contribute.md) for instructions on how to install Outlines for development, including an example using the `dot-install` method for one of the backends.


### PR DESCRIPTION
The models and guide reorg (pages moved into `features/models/` and `guide/`)
left a bunch of relative links pointing at the old paths. `mkdocs build`
doesn't run with `--strict`, so these just log warnings instead of failing CI.

Fixed ~40 links across 7 files — mostly wrong `../` depth after the move, plus
a couple of absolute links (`/installation`, `/user_guide/migration`) and one
filename mismatch (`templates.md` vs the actual `template.md`).

Verified by rebuilding the docs and checking the mkdocs warning output before
and after, the targeted warnings are gone. Also spot-checked a few of the
ambiguous ones against the live site to make sure I was pointing at the right
page.

Used an AI assistant to find and fix these; reviewed and tested every change myself.