### PR TITLE
Generate the API reference from src/outlines

### DIFF
--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -18,7 +18,7 @@ EXCLUDED_FILES = ["_version"]
 
 nav = mkdocs_gen_files.Nav()
 root = Path(__file__).parent.parent
-src = root / CODEBASE_DIR_NAME
+src = root / "src" / CODEBASE_DIR_NAME
 
 for path in sorted(src.rglob("*.py")):
     module_path = path.relative_to(src).with_suffix("")


### PR DESCRIPTION
Fixes #1912

The src layout migration (681009f1) moved the package to `src/outlines` but `scripts/gen_ref_pages.py` kept scanning `root/outlines`, so the generated API reference has been empty in every build since — visible by comparing the released docs (`latest/api_reference/models/`, 200) with any recent PR preview (`pr-preview/pr-1907/api_reference/models/`, 404).

One-line fix. Verified by building the docs locally: before, `api_reference/` contained only the index and nav summary; after, all 12 module sections generate with rendered content. A side benefit is that the edit links on generated pages now point at the real `src/outlines/...` paths.

Used an AI assistant to find and verify this; I reviewed and rebuilt the docs myself before submitting.