### PR TITLE
fix(types): don't treat instance methods on Enum output types as choices

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -822,15 +822,36 @@ def python_types_to_terms(ptype: Any, recursion_depth: int = 0) -> Term:
 
 
 def _get_enum_members(ptype: EnumMeta) -> List[Any]:
+    """Get the members of an enum, including "enum of callables" members.
+
+    Regular Enum members (including ones whose value is a `functools.partial`)
+    are returned via normal iteration. An enum can also have a plain function
+    assigned directly as a member's value (e.g. ``c = some_function``);
+    Python's Enum machinery treats a bare function assigned in the class body
+    as a method rather than a member, so those don't show up through
+    iteration and we have to pick them out of `__dict__` instead.
+
+    The tricky part is telling that case apart from an actual instance method
+    defined with ``def`` directly in the class body (e.g. a `describe(self)`
+    helper) - both end up as plain `FunctionType` objects in `__dict__`. We
+    use `__qualname__` to distinguish them: a method defined inside the
+    class body is qualified with the class's own qualname (e.g.
+    ``"SomeEnum.describe"``), while a function that was defined elsewhere and
+    merely assigned as a member's value keeps its original qualname (e.g.
+    ``"some_function"``). Only the latter should be treated as a member.
+    """
     regular_members = [member.value for member in ptype]  # type: ignore
-    function_members = []
-    for key, value in ptype.__dict__.items():
+    class_member_prefix = f"{ptype.__qualname__}."
+    function_members = [
+        value
+        for key, value in ptype.__dict__.items()
         if (
             isinstance(value, FunctionType)
             and not (key.startswith('__') and key.endswith('__'))
             and key != '_generate_next_value_'  # Skip this specific method that causes issues
-        ):
-            function_members.append(value)
+            and not value.__qualname__.startswith(class_member_prefix)
+        )
+    ]
     return regular_members + function_members
 
 

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -663,6 +663,27 @@ def test_dsl_python_types_to_terms():
         python_types_to_terms(bytes)
 
 
+def test_dsl_enum_with_instance_method_is_not_a_choice():
+    """A plain instance method defined in the enum's class body must not be
+    picked up as a generation choice. Both this method and a bare function
+    assigned as a member's value (`SomeEnum.c` above) show up as the same
+    `FunctionType` in `__dict__`, so the two have to be told apart by more
+    than just their type."""
+
+    class Color(Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
+
+        def describe(self) -> str:
+            return f"This color is {self.value}"
+
+    result = python_types_to_terms(Color)
+    assert isinstance(result, Alternatives)
+    assert len(result.terms) == 3
+    assert result.terms == [String("red"), String("green"), String("blue")]
+
+
 def test_dsl_handle_literal():
     literal = Literal["a", 1]
     result = _handle_literal(get_args(literal))


### PR DESCRIPTION
Fixes #1915.

`_get_enum_members` scans an Enum class's `__dict__` for plain `FunctionType` values to support enums whose members are assigned as bare functions (e.g. `c = some_function`), since Python's Enum machinery treats a plain function assigned in the class body as a method rather than a member - it doesn't show up through normal iteration.

The scan had no way to tell that pattern apart from an actual instance method defined with `def` directly in the class body (e.g. `describe(self)`). Both end up as plain `FunctionType` objects in `__dict__`, so any Enum used as an output type that happened to also define a helper method crashed:

```python
from enum import Enum
from outlines.types.dsl import python_types_to_terms

class Color(Enum):
    RED = "red"
    GREEN = "green"
    BLUE = "blue"

    def describe(self) -> str:
        return f"This color is {self.value}"

python_types_to_terms(Color)
# ValueError: Each argument must have a type annotation
```

`describe` gets swept up as a "member," and building a JSON schema from its signature fails on the unannotated `self` - a misleading error unrelated to the actual problem.

## Fix

`__qualname__` distinguishes the two cases: a method defined directly in the class body is qualified with the enclosing class's own name (`"Color.describe"`), while a function defined elsewhere and merely assigned as a member's value keeps its original qualname (`"some_function"`). Filtering on `__qualname__` excludes real instance methods while still picking up the bare-function-member pattern that `test_dsl_python_types_to_terms`'s `SomeEnum.c = func` case already covers.

I initially proposed restricting the scan to `functools.partial` values only (mentioned in the issue), but that turned out to be too narrow - it broke the existing `SomeEnum.c = func` test, which assigns a plain function directly without `partial`. Left a correction comment on the issue with the details; the `__qualname__` approach here preserves that pattern.

## Testing

Added `test_dsl_enum_with_instance_method_is_not_a_choice` to `tests/types/test_dsl.py`, covering the crash case from the issue.

Ran the full `tests/types/` suite locally (233 tests, all passing), plus `tests/types/test_dsl.py` and `tests/types/test_types_utils.py` specifically to make sure the existing `SomeEnum`/enum-related coverage still passes unchanged.