### PR TITLE
fix(models): handle nullable object type (list form) in additionalProperties pass

### DIFF
--- a/src/outlines/models/utils.py
+++ b/src/outlines/models/utils.py
@@ -18,9 +18,15 @@ def set_additional_properties_false_json_schema(schema: dict) -> dict:
     jsonpath_expr = jsonpath_ng.parse('$..*')
     matches = jsonpath_expr.find(schema)
 
-    # Go over all nodes and set additionalProperties to False if it's an object
+    # Go over all nodes and set additionalProperties to False if it's an
+    # object. `type` can either be the bare string "object" or, per the JSON
+    # Schema spec, a list of type names (e.g. ["object", "null"]) used to
+    # express nullable objects, so both forms must be checked.
     for match in matches:
-        if match.value == 'object':
+        is_object_type = match.value == 'object' or (
+            isinstance(match.value, list) and 'object' in match.value
+        )
+        if is_object_type:
             if 'additionalProperties' not in match.context.value:
                 match.context.value['additionalProperties'] = False
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -48,3 +48,43 @@ def test_set_additional_properties_false_json_schema():
     }
     modified_schema = set_additional_properties_false_json_schema(schema)
     assert modified_schema == schema
+
+
+def test_set_additional_properties_false_json_schema_nested_object():
+    # nested object with a plain "type": "object" gets additionalProperties too
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "address": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+        "required": ["name"],
+    }
+    modified_schema = set_additional_properties_false_json_schema(schema)
+    assert modified_schema["additionalProperties"] is False
+    assert modified_schema["properties"]["address"]["additionalProperties"] is False
+
+
+def test_set_additional_properties_false_json_schema_nullable_type_array():
+    """Regression test: "type" can be a list (e.g. ["object", "null"]) per the
+    JSON Schema spec, used to express a nullable object. Previously only the
+    bare string "object" was checked, so nested nullable objects silently
+    never got additionalProperties set, which OpenAI/Mistral strict mode
+    rejects."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "address": {
+                "type": ["object", "null"],
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+        "required": ["name"],
+    }
+    modified_schema = set_additional_properties_false_json_schema(schema)
+    assert modified_schema["additionalProperties"] is False
+    assert modified_schema["properties"]["address"]["additionalProperties"] is False


### PR DESCRIPTION
## Problem

`set_additional_properties_false_json_schema()` (used by the OpenAI and Mistral backends to satisfy their strict structured-output mode, which requires `additionalProperties: false` on every object node) only matches the bare string form:

```python
if match.value == 'object':
```

JSON Schema also allows `"type"` to be a list of type names, e.g. `["object", "null"]`, the standard way to express a nullable object. When a nested object uses that form, `match.value` is the list itself, so the check is always `False` and that object silently never gets `additionalProperties` set -- while the top-level schema (usually plain `"type": "object"`) does get it. Sending this to OpenAI/Mistral in strict mode then fails validation for any schema with a nullable nested object expressed this way.

Repro:
```python
from outlines.models.utils import set_additional_properties_false_json_schema

schema = {
    "type": "object",
    "properties": {
        "name": {"type": "string"},
        "address": {"type": ["object", "null"], "properties": {"city": {"type": "string"}}},
    },
    "required": ["name"],
}
result = set_additional_properties_false_json_schema(schema)
print(result["additionalProperties"])                       # False -- correct
print("additionalProperties" in result["properties"]["address"])  # False -- missing!
```

## Fix

Also match when `type` is a list containing `"object"`.

## Testing

Added `test_set_additional_properties_false_json_schema_nullable_type_array` for the list-type case, plus `test_set_additional_properties_false_json_schema_nested_object` as a baseline for plain nested objects (wasn't previously covered either way). All 3 tests in `tests/models/test_utils.py` pass.