### PR TITLE
docs: add Requesty model documentation

### DIFF
--- a/docs/features/models/requesty.md
+++ b/docs/features/models/requesty.md
@@ -1,0 +1,43 @@
+# Requesty
+
+!!! Installation
+
+    [Requesty](https://docs.requesty.ai) uses the same API as OpenAI, so both services are [interoperable](./openai_compatible.md) using the `openai` library. Install all optional dependencies of the `OpenAI` model with: `pip install "outlines[openai]"`.
+
+    You also need to have a Requesty API key. You can create one at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys). This API key must either be set as an environment variable called `OPENAI_API_KEY` or be provided to the `openai.OpenAI` class when instantiating it.
+
+## Model Initialization
+
+To create a model instance, you can use the `from_openai` function. It takes 2 arguments:
+
+- `client`: an `openai.OpenAI` instance
+- `model_name`: the name of the model you want to use, defined as `provider/model`
+
+For instance:
+
+```python
+import os
+import outlines
+import openai
+
+# Create the client
+client = openai.OpenAI(
+    base_url="https://router.requesty.ai/v1",
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+# Create the model
+model = outlines.from_openai(
+    client,
+    "openai/gpt-4o-mini"
+)
+```
+
+The [Requesty](https://app.requesty.ai/router/list) website lists available models. Keep in mind that some models do not support `json_schema` response formats and may return a 400 error code as a result.
+
+## Related Documentation
+
+For specific implementations that use OpenAI-compatible APIs:
+
+- [OpenAI](./openai.md): The original OpenAI API implementation
+- [OpenAI compatible API](./openai_compatible.md): Details on how to use OpenAI-compatible APIs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
                     - OpenAI compatible API: features/models/openai_compatible.md
                     - OpenRouter: features/models/openrouter.md
                     - OrcaRouter: features/models/orcarouter.md
+                    - Requesty: features/models/requesty.md
                     - SGLang: features/models/sglang.md
                     - TGI: features/models/tgi.md
                     - Transformers: features/models/transformers.md


### PR DESCRIPTION
## Summary

Adds a documentation page for [Requesty](https://requesty.ai) — an OpenAI-compatible LLM router — mirroring the existing OpenRouter / OrcaRouter model pages. Requesty exposes 400+ models through one endpoint, addressed as `provider/model`.

Like OpenRouter and OrcaRouter, Requesty has no code shim in outlines — it works through the generic `outlines.from_openai` path with a base URL, so this is a docs-only contribution.

## Changes

- `docs/features/models/requesty.md` — mirrors `openrouter.md` / `orcarouter.md`: base URL `https://router.requesty.ai/v1`, model naming `openai/gpt-4o-mini`, `from_openai` pattern
- `mkdocs.yml` — nav entry after OrcaRouter

## Testing

Ran the exact code from the new docs page end-to-end: `outlines.from_openai(openai.OpenAI(base_url="https://router.requesty.ai/v1", ...), "openai/gpt-4o-mini")` against the live endpoint returned a completion successfully. The code block is copy-paste runnable.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
