### PR TITLE
fix: exclude instance methods from enum member detection

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -809,6 +809,7 @@ def _get_enum_members(ptype: EnumMeta) -> List[Any]:
             isinstance(value, FunctionType)
             and not (key.startswith('__') and key.endswith('__'))
             and key != '_generate_next_value_'  # Skip this specific method that causes issues
+            and "." not in value.__qualname__.split("<locals>.")[-1]
         ):
             function_members.append(value)
     return regular_members + function_members

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -617,6 +617,9 @@ def test_dsl_python_types_to_terms():
         b = int
         c = func
 
+        def describe(self) -> str:
+            return "describe"
+
     result = python_types_to_terms(SomeEnum)
     assert isinstance(result, Alternatives)
     assert len(result.terms) == 3
@@ -1191,3 +1194,24 @@ def test_to_regex():
 
     with pytest.raises(TypeError):
         to_regex(Term())
+
+
+def test_enum_with_instance_method_not_treated_as_member():
+    # Regression for https://github.com/outlines-dev/outlines/issues/1915.
+    # Instance methods defined in the Enum body must not be picked up as
+    # generation choices by _get_enum_members.
+    class Color(Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
+
+        def describe(self) -> str:
+            return self.value
+
+    result = python_types_to_terms(Color)
+    assert isinstance(result, Alternatives)
+    # Only the three enum values, not the describe method.
+    assert len(result.terms) == 3
+    assert result.terms[0] == String("red")
+    assert result.terms[1] == String("green")
+    assert result.terms[2] == String("blue")


### PR DESCRIPTION
## Problem

Defining an Enum with regular instance methods (e.g. a `describe(self)` helper) and passing it to `python_types_to_terms` crashes with a signature parsing error. `_get_enum_members` in `dsl.py` treats any `FunctionType` found in the class body as an enum member value, so it picks up instance methods alongside the actual enum values.

## Fix

Instance methods defined in a class body have `ClassName.method_name` in their `__qualname__`, while standalone functions used as enum values don't contain a dot. Added a check against `__qualname__` to filter them out.

One-line change in `_get_enum_members`, plus a regression test.

## Testing

- Added `describe(self)` method to the existing `SomeEnum` in `test_dsl_python_types_to_terms`
- Added standalone regression test `test_enum_with_instance_method_not_treated_as_member` covering a standard `Enum` with a helper method
- `pytest tests/types/test_dsl.py` passes (57 passed, 2 pre-existing Windows tempfile failures unrelated to this change)

Fixes #1915