### PR TITLE
fix: reject negative counts in exactly/at_least/at_most/between

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -574,6 +574,10 @@ class QuantifyExact(Term):
     term: Term
     count: int
 
+    def __post_init__(self):
+        if self.count < 0:
+            raise ValueError("QuantifyExact: `count` must be a non-negative integer.")
+
     def _display_node(self) -> str:
         return f"Quantify({{{self.count}}})"
 
@@ -588,6 +592,12 @@ class QuantifyExact(Term):
 class QuantifyMinimum(Term):
     term: Term
     min_count: int
+
+    def __post_init__(self):
+        if self.min_count < 0:
+            raise ValueError(
+                "QuantifyMinimum: `min_count` must be a non-negative integer."
+            )
 
     def _display_node(self) -> str:
         return f"Quantify({{{self.min_count},}})"
@@ -605,6 +615,12 @@ class QuantifyMinimum(Term):
 class QuantifyMaximum(Term):
     term: Term
     max_count: int
+
+    def __post_init__(self):
+        if self.max_count < 0:
+            raise ValueError(
+                "QuantifyMaximum: `max_count` must be a non-negative integer."
+            )
 
     def _display_node(self) -> str:
         return f"Quantify({{,{self.max_count}}})"
@@ -625,6 +641,10 @@ class QuantifyBetween(Term):
     max_count: int
 
     def __post_init__(self):
+        if self.min_count < 0:
+            raise ValueError(
+                "QuantifyBetween: `min_count` must be a non-negative integer."
+            )
         if self.min_count > self.max_count:
             raise ValueError(
                 "QuantifyBetween: `max_count` must be greater than `min_count`."

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -138,6 +138,15 @@ def test_dsl_init():
     assert repr(maximum) == "QuantifyMaximum(term=String(value='test'), max_count=3)"
     assert maximum.display_ascii_tree() == "└── Quantify({,3})\n    └── String('test')\n"
 
+    with pytest.raises(ValueError, match="`count` must be a non-negative integer"):
+        QuantifyExact(string, -1)
+
+    with pytest.raises(ValueError, match="`min_count` must be a non-negative integer"):
+        QuantifyMinimum(string, -1)
+
+    with pytest.raises(ValueError, match="`max_count` must be a non-negative integer"):
+        QuantifyMaximum(string, -1)
+
     between = QuantifyBetween(string, 1, 3)
     assert between.term == string
     assert between.min_count == 1
@@ -152,6 +161,9 @@ def test_dsl_init():
         ValueError, match="`max_count` must be greater than `min_count`"
     ):
         QuantifyBetween(string, 3, 1)
+
+    with pytest.raises(ValueError, match="`min_count` must be a non-negative integer"):
+        QuantifyBetween(string, -2, -1)
 
 
 def test_dsl_term_methods():


### PR DESCRIPTION
## What
`QuantifyExact`, `QuantifyMinimum`, and `QuantifyMaximum` (backing `exactly()`, `at_least()`, `at_most()`) accepted negative counts with no validation. `QuantifyBetween` (backing `between()`) validated `min_count <= max_count` but was also missing a non-negative check.

## Why this matters
A negative count silently produces a regex quantifier that Python's `re` engine doesn't recognize as a quantifier at all (e.g. `{-1}`), so `re` falls back to treating it as **literal text**:

```python
from outlines.types.dsl import exactly, to_regex
import re

term = exactly(-1, "a")
pattern = to_regex(term)          # '(a){-1}'
re.compile(pattern).fullmatch("a")        # False
re.compile(pattern).fullmatch("a{-1}")    # True  <- silently changed meaning
```

Instead of failing at construction time with a clear error, the term silently becomes something that matches a completely different (and almost certainly unintended) string.

## Fix
Add a `__post_init__` guard to all four `Quantify*` dataclasses, mirroring the existing `min_count <= max_count` check already on `QuantifyBetween`.

## Testing
- Added regression tests to `tests/types/test_dsl.py::test_dsl_init` covering all four classes; confirmed they fail without the fix (`DID NOT RAISE ValueError`) and pass with it.
- Ran `pytest tests/types/` (232 passed) and `pre-commit run --files src/outlines/types/dsl.py tests/types/test_dsl.py` (mypy + ruff clean).
- Searched the codebase for other direct construction sites of these four classes — none found; all usage goes through the `exactly`/`at_least`/`at_most`/`between` factory functions and `Term` instance methods, which pass through unchanged.

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I reviewed the diff, wrote/ran the regression tests, and ran the full local test suite + pre-commit before opening this PR.