### PR TITLE
fix: raise clearly instead of asserting on a rejected XGrammar token

### DIFF
--- a/src/outlines/backends/xgrammar.py
+++ b/src/outlines/backends/xgrammar.py
@@ -105,7 +105,10 @@ class XGrammarLogitsProcessor(OutlinesLogitsProcessor):
                     last_token_id = self.tensor_adapter.to_scalar(
                         input_ids[i][-1] # type: ignore
                     )
-                    assert self._matchers[i].accept_token(last_token_id)
+                    if not self._matchers[i].accept_token(last_token_id):
+                        raise RuntimeError(
+                            f"XGrammar matcher rejected token {last_token_id}"
+                        )
 
         return self._bias_logits(input_ids, logits)
 

--- a/tests/backends/test_xgrammar.py
+++ b/tests/backends/test_xgrammar.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import MagicMock
 
 import llama_cpp
 import outlines
@@ -174,3 +175,21 @@ def test_json_schema_logits_processor_rejects_whitespace_pattern():
     schema = '{"type": "object"}'
     with pytest.raises(NotImplementedError, match="whitespace_pattern"):
         backend.get_json_schema_logits_processor(schema, whitespace_pattern=" ")
+
+
+def test_xgr_processor_raises_on_rejected_token():
+    """A token the grammar matcher rejects must raise clearly, not rely on
+    `assert` (which `python -O` strips entirely, silently leaving the
+    matcher's state un-advanced for the rest of generation)."""
+    processor = object.__new__(XGrammarLogitsProcessor)
+    processor.is_first_token = False
+    processor.tensor_adapter = MagicMock()
+    processor.tensor_adapter.shape.return_value = (1, 100)
+    processor.tensor_adapter.to_scalar.return_value = 42
+    mock_matcher = MagicMock()
+    mock_matcher.is_terminated.return_value = False
+    mock_matcher.accept_token.return_value = False
+    processor._matchers = [mock_matcher]
+
+    with pytest.raises(RuntimeError, match="rejected token"):
+        processor.process_logits(input_ids=[[1, 2, 3]], logits=MagicMock())


### PR DESCRIPTION
## Problem

`XGrammarLogitsProcessor.process_logits` advances the grammar matcher's state after each generated token with:

```python
assert self._matchers[i].accept_token(last_token_id)
```

Python's `-O`/`PYTHONOPTIMIZE=1` mode strips **all** `assert` statements at compile time. Under that mode, the matcher's internal state is silently never advanced past the first generated token — no exception, no warning — and structured-output constraints (regex/JSON-schema/CFG) simply stop being enforced for the rest of generation. This is a correctness-under-optimization footgun: code that works correctly in a normal dev/test run can silently produce unconstrained output in a production deployment that runs with `-O` (a common way to strip debug asserts).

## Fix

Replace the `assert` with an explicit check that raises `RuntimeError`, which `-O` cannot strip.

## Testing

- Added `test_xgr_processor_raises_on_rejected_token`, constructing the processor directly with a mocked matcher whose `accept_token` returns `False`. Confirmed it fails with `AssertionError` against the pre-fix code and passes after.
- Re-ran the new test under `python -O` directly (`python -O -m pytest tests/backends/test_xgrammar.py::test_xgr_processor_raises_on_rejected_token`) to confirm the fix is actually optimization-safe — this is the specific mode the original bug only manifests under.
- Ran the full `tests/backends/test_xgrammar.py` suite (4 passed, 1 skipped — MLX test requires Apple Silicon).
- `pre-commit run` (mypy + ruff) clean on both changed files.

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently reproduced the `AssertionError` pre-fix and verified the fix under both normal and `-O` execution modes before opening this PR.