### PR TITLE
Fix the JsonSchema whitespace_pattern being ignored by the backend

### DIFF
--- a/docs/features/core/output_types.md
+++ b/docs/features/core/output_types.md
@@ -178,7 +178,7 @@ output_type = JsonSchema(schema_dict)
 ```
 
 `JsonSchema` accepts two optional parameters:
-- `whitespace_pattern` (defaults to `None`): specifies the pattern to use for JSON syntactic whitespace. If none is provided, the default permissive JSON whitespace rules are used.
+- `whitespace_pattern` (defaults to `None`): specifies the pattern to use for JSON syntactic whitespace. If none is provided, the default permissive JSON whitespace rules are used. It is applied by the `outlines_core` backend; the `llguidance` and `xgrammar` backends do not support it and raise an error if one is set.
 - `ensure_ascii` (defaults to `True`): defines the value to use for the argument `ensure_ascii` of the `json.dumps` method. If false, non-ASCII characters will be turned into unicodes.
 
 ### Regex Patterns

--- a/src/outlines/backends/__init__.py
+++ b/src/outlines/backends/__init__.py
@@ -59,6 +59,7 @@ def get_json_schema_logits_processor(
     backend_name: str | None,
     model: SteerableModel,
     json_schema: str,
+    whitespace_pattern: str | None = None,
 ) -> LogitsProcessorType:
     """Create a logits processor from a JSON schema.
 
@@ -70,6 +71,9 @@ def get_json_schema_logits_processor(
         The Outlines model of the user.
     json_schema: str
         The JSON schema to create a logits processor from.
+    whitespace_pattern: str | None
+        The pattern to use to control the whitespace allowed between JSON
+        tokens. `None` uses the backend default.
 
     Returns
     -------
@@ -81,7 +85,9 @@ def get_json_schema_logits_processor(
         backend_name or JSON_SCHEMA_DEFAULT_BACKEND,
         model,
     )
-    return backend.get_json_schema_logits_processor(json_schema)
+    return backend.get_json_schema_logits_processor(
+        json_schema, whitespace_pattern
+    )
 
 
 def get_regex_logits_processor(

--- a/src/outlines/backends/base.py
+++ b/src/outlines/backends/base.py
@@ -17,7 +17,7 @@ class BaseBackend(ABC):
 
     @abstractmethod
     def get_json_schema_logits_processor(
-        self, json_schema: str
+        self, json_schema: str, whitespace_pattern: str | None = None
     ) -> LogitsProcessorType:
         """Create a logits processor from a JSON schema.
 
@@ -25,6 +25,9 @@ class BaseBackend(ABC):
         ----------
         json_schema: str
             The JSON schema to create a logits processor from.
+        whitespace_pattern: str | None
+            The pattern to use to control the whitespace allowed between JSON
+            tokens. `None` uses the backend default.
 
         Returns
         -------

--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -235,7 +235,7 @@ class LLGuidanceBackend(BaseBackend):
             )
 
     def get_json_schema_logits_processor(
-        self, json_schema: str
+        self, json_schema: str, whitespace_pattern: str | None = None
     ) -> LLGuidanceLogitsProcessor:
         """Create a logits processor from a JSON schema.
 
@@ -243,6 +243,8 @@ class LLGuidanceBackend(BaseBackend):
         ----------
         json_schema: str
             The JSON schema to create a logits processor from.
+        whitespace_pattern: str | None
+            Not supported by the llguidance backend; must be `None`.
 
         Returns
         -------
@@ -250,6 +252,12 @@ class LLGuidanceBackend(BaseBackend):
             The logits processor to use to constrain the generation.
 
         """
+        if whitespace_pattern is not None:
+            raise NotImplementedError(
+                "The llguidance backend does not support the "
+                "`whitespace_pattern` argument. Use the `outlines_core` "
+                "backend to control JSON whitespace."
+            )
         grammar_spec = self.llg.grammar_from("json_schema", json_schema)
         return LLGuidanceLogitsProcessor(
             grammar_spec, self.llg_tokenizer, self.tensor_library_name

--- a/src/outlines/backends/outlines_core.py
+++ b/src/outlines/backends/outlines_core.py
@@ -211,13 +211,18 @@ class OutlinesCoreBackend(BaseBackend):
         )
         self.tensor_library_name = model.tensor_library_name
 
-    def get_json_schema_logits_processor(self, json_schema: str):
+    def get_json_schema_logits_processor(
+        self, json_schema: str, whitespace_pattern: str | None = None
+    ):
         """Create a logits processor from a JSON schema.
 
         Parameters
         ----------
         json_schema: str
             The JSON schema to create a logits processor from.
+        whitespace_pattern: str | None
+            The pattern to use to control the whitespace allowed between JSON
+            tokens. `None` uses the outlines_core default.
 
         Returns
         -------
@@ -225,7 +230,7 @@ class OutlinesCoreBackend(BaseBackend):
             The logits processor to use to constrain the generation.
 
         """
-        regex = build_regex_from_schema(json_schema)
+        regex = build_regex_from_schema(json_schema, whitespace_pattern)
         return self.get_regex_logits_processor(regex)
 
     def get_regex_logits_processor(self, regex: str):

--- a/src/outlines/backends/xgrammar.py
+++ b/src/outlines/backends/xgrammar.py
@@ -141,7 +141,7 @@ class XGrammarBackend(BaseBackend):
         self.tensor_library_name = model.tensor_library_name
 
     def get_json_schema_logits_processor(
-        self, json_schema: str
+        self, json_schema: str, whitespace_pattern: str | None = None
     ) -> XGrammarLogitsProcessor:
         """Create a logits processor from a JSON schema.
 
@@ -149,6 +149,8 @@ class XGrammarBackend(BaseBackend):
         ----------
         json_schema: str
             The JSON schema to create a logits processor from.
+        whitespace_pattern: str | None
+            Not supported by the xgrammar backend; must be `None`.
 
         Returns
         -------
@@ -156,6 +158,12 @@ class XGrammarBackend(BaseBackend):
             The logits processor to use to constrain the generation.
 
         """
+        if whitespace_pattern is not None:
+            raise NotImplementedError(
+                "The xgrammar backend does not support the "
+                "`whitespace_pattern` argument. Use the `outlines_core` "
+                "backend to control JSON whitespace."
+            )
         compiled_grammar = self.grammar_compiler.compile_json_schema(
             json_schema
         )

--- a/src/outlines/generator.py
+++ b/src/outlines/generator.py
@@ -247,6 +247,7 @@ class SteerableGenerator:
                     backend_name,
                     model,
                     term.schema,
+                    term.whitespace_pattern,
                 )
             else:
                 regex_string = to_regex(term)

--- a/tests/backends/test_llguidance.py
+++ b/tests/backends/test_llguidance.py
@@ -201,3 +201,11 @@ def test_llguidance_backend(model, tensor_library_name, json_schema, regex, cfg_
         else:
             response = generator("Create a character", max_tokens=20)
             assert response[0] == "{"
+
+
+def test_json_schema_logits_processor_rejects_whitespace_pattern():
+    """The llguidance backend does not support whitespace_pattern and raises."""
+    backend = object.__new__(LLGuidanceBackend)
+    schema = '{"type": "object"}'
+    with pytest.raises(NotImplementedError, match="whitespace_pattern"):
+        backend.get_json_schema_logits_processor(schema, whitespace_pattern=" ")

--- a/tests/backends/test_outlines_core.py
+++ b/tests/backends/test_outlines_core.py
@@ -279,3 +279,45 @@ def test_create_vocabulary_duplicate_decoded_strings():
     assert captured["hi"] == [3]
     assert len(captured) == 2
     assert sum(len(ids) for ids in captured.values()) == 3
+
+
+def test_json_schema_logits_processor_applies_whitespace_pattern():
+    """A user-provided whitespace_pattern is forwarded to the regex builder.
+
+    Regression: the pattern was dropped before reaching the backend, so setting
+    it had no effect on the whitespace of the generated JSON.
+    """
+    backend = object.__new__(OutlinesCoreBackend)
+    schema = '{"type": "object", "properties": {"a": {"type": "integer"}}}'
+
+    with (
+        patch(
+            "outlines.backends.outlines_core.build_regex_from_schema",
+            return_value=r"\{\}",
+        ) as build_regex,
+        patch.object(
+            backend, "get_regex_logits_processor", return_value="processor"
+        ),
+    ):
+        backend.get_json_schema_logits_processor(schema, whitespace_pattern="")
+
+    build_regex.assert_called_once_with(schema, "")
+
+
+def test_json_schema_logits_processor_defaults_whitespace_pattern_to_none():
+    """When no whitespace_pattern is given, None is forwarded to the builder."""
+    backend = object.__new__(OutlinesCoreBackend)
+    schema = '{"type": "object"}'
+
+    with (
+        patch(
+            "outlines.backends.outlines_core.build_regex_from_schema",
+            return_value=r"\{\}",
+        ) as build_regex,
+        patch.object(
+            backend, "get_regex_logits_processor", return_value="processor"
+        ),
+    ):
+        backend.get_json_schema_logits_processor(schema)
+
+    build_regex.assert_called_once_with(schema, None)

--- a/tests/backends/test_xgrammar.py
+++ b/tests/backends/test_xgrammar.py
@@ -166,3 +166,11 @@ def test_xgrammar_backend_invalid_model():
         match="The xgrammar backend only supports Transformers and MLXLM models",
     ):
         XGrammarBackend(model_llamacpp())
+
+
+def test_json_schema_logits_processor_rejects_whitespace_pattern():
+    """The xgrammar backend does not support whitespace_pattern and raises."""
+    backend = object.__new__(XGrammarBackend)
+    schema = '{"type": "object"}'
+    with pytest.raises(NotImplementedError, match="whitespace_pattern"):
+        backend.get_json_schema_logits_processor(schema, whitespace_pattern=" ")


### PR DESCRIPTION
## Problem

When you set `whitespace_pattern` on a `JsonSchema` output type, it has no effect during generation on the default `outlines_core` backend. The JSON is always produced with the default whitespace, whatever pattern you pass.

The cause is a dropped argument. When the generator builds the logits processor for a `JsonSchema`, it passes only `term.schema` to the backend and never passes `term.whitespace_pattern` (`src/outlines/generator.py`). The backend then calls `build_regex_from_schema(json_schema)` without the pattern (`src/outlines/backends/outlines_core.py`). Calling `to_regex(JsonSchema(...))` directly does apply the pattern, so the two paths disagree.

`whitespace_pattern` is a documented parameter (`docs/features/core/output_types.md`) and worked in v0, where it was added to control JSON whitespace (#916). It stopped being applied when JSON-schema handling moved to the backend layer in the v1 refactor.

## Fix

Pass `whitespace_pattern` through to the backend so it is actually used:

- The generator now passes `term.whitespace_pattern` when it builds the JSON-schema logits processor.
- `get_json_schema_logits_processor` (the backend dispatcher, `BaseBackend`, and `OutlinesCoreBackend`) takes an optional `whitespace_pattern` and forwards it to `build_regex_from_schema`.
- The `llguidance` and `xgrammar` backends build the grammar their own way and cannot use this pattern, so they raise `NotImplementedError` if one is set instead of ignoring it.

The default (`whitespace_pattern=None`) behaves exactly as before.

## Tests

Two new tests in `tests/backends/test_outlines_core.py`:

- one checks that a pattern you pass reaches `build_regex_from_schema`,
- one checks that the default passes `None`.

Both fail on `main` and pass with this change (verified by stashing the fix). The `tests/backends/test_outlines_core.py` suite passes (one MLX test is skipped). `ruff` and `mypy` are clean.

## Docs

`docs/features/core/output_types.md` now says `whitespace_pattern` is applied by the `outlines_core` backend, and that `llguidance` / `xgrammar` do not support it.
