### PR TITLE
fix(sglang): _build_client_args clobbers user's extra_body instead of merging

### DIFF
--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -210,6 +210,10 @@ class SGLang(Model):
         """Build the arguments to pass to the SGLang client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
+        if "extra_body" in output_type_args:
+            extra_body = inference_kwargs.pop("extra_body", {})
+            extra_body.update(output_type_args.pop("extra_body"))
+            inference_kwargs["extra_body"] = extra_body
         inference_kwargs.update(output_type_args)
 
         if "model" not in inference_kwargs and self.model_name is not None:
@@ -355,6 +359,10 @@ class AsyncSGLang(AsyncModel):
         """Build the arguments to pass to the SGLang client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
+        if "extra_body" in output_type_args:
+            extra_body = inference_kwargs.pop("extra_body", {})
+            extra_body.update(output_type_args.pop("extra_body"))
+            inference_kwargs["extra_body"] = extra_body
         inference_kwargs.update(output_type_args)
 
         if "model" not in inference_kwargs and self.model_name is not None:

--- a/tests/models/test_sglang.py
+++ b/tests/models/test_sglang.py
@@ -229,6 +229,20 @@ def test_sglang_init():
         from_sglang("foo")
 
 
+@pytest.mark.parametrize("model_cls", [SGLang, AsyncSGLang])
+def test_sglang_build_client_args_merges_user_extra_body(model_cls):
+    # `_build_client_args` must merge the structured-output payload into the
+    # user's own `extra_body`, not clobber it wholesale.
+    model = model_cls(openai_client, sglang_model_name)
+
+    client_args = model._build_client_args(
+        "foo?", output_type=Regex(r"[0-9]{3}"), extra_body={"user_key": "user_value"}
+    )
+
+    assert client_args["extra_body"]["user_key"] == "user_value"
+    assert client_args["extra_body"]["regex"] == "([0-9]{3})"
+
+
 def test_sglang_sync_simple_call(sync_model):
     result = sync_model("Respond with a single word.",)
     assert isinstance(result, str)


### PR DESCRIPTION
## Problem

`SGLang._build_client_args` (and the duplicated `AsyncSGLang._build_client_args`) builds the client kwargs with a shallow `inference_kwargs.update(output_type_args)`. When `output_type` is `Regex` or `CFG`, `format_output_type` returns `{"extra_body": {...}}` for the structured-output payload. The blanket `.update()` then **replaces** the user's own `extra_body=` kwarg wholesale instead of merging into it — any keys the caller passed in `extra_body` are silently dropped.

The sibling `vllm.py::_build_client_args` already handles this correctly: it pops the user's `extra_body`, merges the structured-output payload into it, and reassigns. `sglang.py` never got the same treatment.

## Fix

In both `SGLang._build_client_args` and `AsyncSGLang._build_client_args`: when `output_type_args` contains an `extra_body` key, merge it into the user's existing `extra_body` dict instead of letting `.update()` clobber it. Other top-level keys (e.g. `response_format` for `JsonSchema` output types) are unaffected and still applied normally via the existing `.update()` path.

## Testing

- Added `test_sglang_build_client_args_merges_user_extra_body` (parametrized over `SGLang`/`AsyncSGLang`) asserting both the user's key and the structured-output payload survive in the merged `extra_body`.
- Confirmed red→green: reverting only `src/outlines/models/sglang.py` (not the test file) reproduces the failure (`KeyError: 'user_key'`) on both parametrizations; reapplying the fix passes.
- Full `tests/models/test_sglang.py` suite: 21 passed.
- `ruff check` and `pre-commit run --files src/outlines/models/sglang.py tests/models/test_sglang.py` (mypy + ruff + hygiene hooks) all pass.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) across `outlines/src/outlines/models/`. I personally reproduced the clobbering with a minimal repro, verified the fix against both the `extra_body` path (CFG/regex) and the `response_format` path (JsonSchema) to confirm no regression, and ran the full test suite before submitting.