### PR TITLE
fix(types): get_enum_from_literal/get_enum_from_choice drop values that collide under str()

### DIFF
--- a/src/outlines/types/utils.py
+++ b/src/outlines/types/utils.py
@@ -151,17 +151,38 @@ def is_callable(value: Any) -> bool:
 # Type conversion
 
 
+def _unique_str_keys(values) -> dict:
+    """Build a name -> value mapping for an Enum's functional API, keyed by str(value)
+    as before, but disambiguating with the value's type name whenever two values would
+    otherwise collide on the same str() (e.g. the string "1" and the int 1 both stringify
+    to "1"), which previously caused the dict comprehension to silently drop all but the
+    last colliding value.
+    """
+    by_str: dict = {}
+    for value in values:
+        by_str.setdefault(str(value), []).append(value)
+
+    result = {}
+    for key, group in by_str.items():
+        if len(group) == 1:
+            result[key] = group[0]
+        else:
+            for value in group:
+                result[f"{type(value).__name__}_{value}"] = value
+    return result
+
+
 def get_enum_from_literal(value) -> Enum:
     return Enum(
         value.__name__,
-        {str(arg): arg for arg in get_args(value)}
+        _unique_str_keys(get_args(value))
     )
 
 
 def get_enum_from_choice(value) -> Enum:
     return Enum(
         'Choice',
-        {str(item): item for item in value.items}
+        _unique_str_keys(value.items)
     )
 
 

--- a/tests/types/test_types_utils.py
+++ b/tests/types/test_types_utils.py
@@ -392,6 +392,26 @@ def test_get_enum_from_literal(sample_enum):
     assert getattr(complex_enum, "SampleEnum.A").value == sample_enum.A
 
 
+def test_get_enum_from_literal_str_int_collision_preserves_both_members():
+    """str(1) == str("1") == "1" previously made the naive `{str(x): x for x in ...}`
+    dict comprehension silently drop one of the two values -- whichever came first was
+    overwritten by the other. Both must survive as distinct enum members."""
+    enum = get_enum_from_literal(Literal["1", 1])
+    assert is_enum(enum)
+    values = {member.value for member in enum}
+    assert values == {"1", 1}
+    assert len(list(enum)) == 2
+
+
+def test_get_enum_from_choice_str_int_collision_preserves_both_members():
+    choice = Choice(["1", 1])
+    enum = get_enum_from_choice(choice)
+    assert is_enum(enum)
+    values = {member.value for member in enum}
+    assert values == {"1", 1}
+    assert len(list(enum)) == 2
+
+
 def test_get_schema_from_signature(sample_function, sample_function_missing_type):
     result = get_schema_from_signature(sample_function)
     assert result["type"] == "object"


### PR DESCRIPTION
## Problem

Both `get_enum_from_literal` and `get_enum_from_choice` built their `Enum`'s name→value mapping with `{str(x): x for x in values}`. Since `str(1) == str("1") == "1"`, `Literal["1", 1]` or `Choice(["1", 1])` silently collapsed to a single enum member — whichever value came last in iteration order won, and the other was overwritten in the dict comprehension before `Enum` ever saw it.

Reachable in production via `models/gemini.py`'s structured-output enum construction (Gemini `text/x.enum` response schemas) for any `Literal`/`Choice` mixing a string and a numeric value that happen to stringify the same way.

## Fix

Only disambiguate when a genuine `str()`-collision is detected, prefixing the colliding values' keys with their type name (e.g. `"str_1"` vs `"int_1"`). Non-colliding values keep their original `str()`-based member name unchanged, preserving existing behavior and the existing test's attribute-access assertions (`getattr(complex_enum, "1")`, `"True"`, `"None"`, etc.) — this was checked and deliberately preserved rather than switching to an always-prefixed scheme, since that would've silently changed the public member-naming contract for the (much more common) non-colliding case.

## Testing

- Added two new tests covering the `str()`-collision case for both functions, verifying both values survive as distinct members.
- Confirmed red→green: reverting only `utils.py` reproduces `{1} == {1, '1'}` (the string value silently dropped, only the int survives); reapplying passes.
- Full `tests/types/` suite: 234 passed.
- `ruff` and `mypy` clean via `pre-commit run`.
- xref: no open PR touches `types/utils.py`.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `outlines/src/outlines/types/`. I personally reproduced the value-dropping collision, checked the existing test's attribute-name assertions to make sure my fix wouldn't silently break the non-colliding naming contract, verified the fix, and ran the relevant test suite plus lint/type checks before submitting.