### PR TITLE
fix(processors): NumpyTensorAdapter.apply_mask doesn't broadcast a lower-rank mask like torch's masked_fill

### DIFF
--- a/src/outlines/processors/tensor_adapters/numpy.py
+++ b/src/outlines/processors/tensor_adapters/numpy.py
@@ -42,9 +42,7 @@ class NumpyTensorAdapter(TensorAdapter):
         return self.numpy.ones_like(tensor, dtype=bool)
 
     def apply_mask(self, tensor, mask, value):
-        result = tensor.copy()
-        result[mask] = value
-        return result
+        return self.numpy.where(mask, value, tensor)
 
     def argsort_descending(self, tensor):
         return self.numpy.argsort(-tensor)

--- a/tests/processors/test_tensor_adapters.py
+++ b/tests/processors/test_tensor_adapters.py
@@ -244,6 +244,33 @@ def test_tensor_adapter_apply_mask(framework):
 
 
 @pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_apply_mask_broadcasts_lower_rank_mask(framework):
+    """A mask with fewer dimensions than the tensor (e.g. the same banned-token
+    mask reused for every row of a batch) must broadcast, matching torch's
+    masked_fill semantics, instead of requiring an exact shape match."""
+    tensor = create_tensor(framework, (2, 3))
+
+    if framework == "torch":
+        mask = torch.tensor([True, False, True])
+    elif framework == "numpy":
+        mask = np.array([True, False, True])
+    elif framework == "mlx":
+        if not HAS_MLX:
+            pytest.skip("MLX not available")
+        mask = mx.array([True, False, True])
+
+    masked = adapters[framework].apply_mask(tensor, mask, float("-inf"))
+
+    assert masked.shape == (2, 3)
+    for i in range(2):
+        for j in range(3):
+            if mask[j]:
+                assert masked[i, j] == float("-inf")
+            else:
+                assert masked[i, j] == tensor[i, j]
+
+
+@pytest.mark.parametrize("framework", frameworks)
 def test_tensor_adapter_argsort_descending(framework):
     tensor = create_tensor(framework, (2, 3))
     indices = adapters[framework].argsort_descending(tensor)


### PR DESCRIPTION
## Problem

`apply_mask` used boolean fancy-index assignment (`result[mask] = value`), which requires the mask's shape to exactly match the tensor's shape — numpy raises `IndexError` instead of broadcasting when the shapes only match under normal broadcasting rules (e.g. a 1D mask applied to a 2D tensor, a common pattern for reusing the same per-token mask across every row of a batch).

`TorchTensorAdapter.apply_mask` already uses `torch.masked_fill`, and `MLXTensorAdapter` already uses `mlx.where`, both of which broadcast correctly. Only the numpy adapter lacked this, making numpy-backed generation crash on a mask shape that works fine on the other two backends.

## Fix

Use `numpy.where(mask, value, tensor)`, matching MLX's approach and torch's `masked_fill`'s broadcasting semantics. Also non-mutating (like `masked_fill`), unlike the previous copy-then-index-assign — a behavior improvement consistent with the other two adapters.

## Testing

- Added `test_tensor_adapter_apply_mask_broadcasts_lower_rank_mask` (parametrized across all three frameworks) using a 1D mask against a 2D tensor.
- Confirmed red→green: reverting only `numpy.py` reproduces `IndexError: boolean index did not match indexed array along axis 0`; reapplying passes.
- Full `tests/processors/test_tensor_adapters.py`: 24 passed, 12 skipped (MLX unavailable in this environment, pre-existing and unrelated to this change).
- `ruff` and `mypy` clean via `pre-commit run`.
- xref: no open PR touches `tensor_adapters/numpy.py`.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `outlines/src/outlines/processors/tensor_adapters/`. I personally compared numpy's implementation against the already-correct torch/mlx siblings, reproduced the broadcasting crash, verified the fix preserves exact-shape-mask behavior while fixing the broadcast case, and ran the relevant test suite plus lint/type checks before submitting.