### PR TITLE
Render Optional enum/nested fields in the schema filter

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -328,5 +328,17 @@ def parse_pydantic_schema_value(name, schema, definitions):
     elif "enum" in schema:
         values = " | ".join(str(value) for value in schema["enum"])
         return f"<{values}>"
+    elif "anyOf" in schema:
+        # `Optional[T]` is rendered as an `anyOf` of `T` and `null`. Recurse into
+        # the single non-null member so the field renders like its underlying type
+        # (e.g. `Optional[Enum]` shows the enum values, not a `<name>` placeholder).
+        # Genuine multi-member unions (e.g. `A | B`) fall through to the `<name>`
+        # placeholder rather than misleadingly advertising only their first branch.
+        non_null = [
+            member for member in schema["anyOf"] if member.get("type") != "null"
+        ]
+        if len(non_null) == 1:
+            return parse_pydantic_schema_value(name, non_null[0], definitions)
+        return f"<{name}>"
     else:
         return f"<{name}>"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -2,7 +2,7 @@ import base64
 from enum import Enum
 import os
 import tempfile
-from typing import Optional
+from typing import Optional, Union
 
 import pytest
 from PIL import Image as PILImage
@@ -56,6 +56,22 @@ class PydanticClassWithEnum(BaseModel):
 class PydanticNestedClass(BaseModel):
     name: str
     inner: PydanticClass
+
+
+class PydanticOptionalClass(BaseModel):
+    name: str
+    armor: Optional[Armor] = None
+    inner: Optional[PydanticClass] = None
+
+
+class Weapon(str, Enum):
+    sword = "sword"
+    axe = "axe"
+
+
+class PydanticUnionClass(BaseModel):
+    name: str
+    equipment: Union[Armor, Weapon]
 
 
 def test_vision_initialization():
@@ -396,6 +412,24 @@ def test_get_schema():
     pydantic_nested_schema_output = get_schema(PydanticNestedClass)
     assert pydantic_nested_schema_output == (
         '{\n  "name": "<name>",\n  "inner": {\n    "foo": "<foo>"\n  }\n}'
+    )
+
+    # Optional[...] fields must render like their underlying type (enum values,
+    # nested properties) rather than falling back to a `<name>` placeholder.
+    pydantic_optional_schema_output = get_schema(PydanticOptionalClass)
+    assert pydantic_optional_schema_output == (
+        '{\n  "name": "<name>",'
+        '\n  "armor": "<leather | chainmail | plate>",'
+        '\n  "inner": {\n    "foo": "<foo>"\n  }\n}'
+    )
+
+    # Genuine multi-member unions cannot be represented by a single branch, so
+    # they fall back to a `<name>` placeholder rather than advertising only the
+    # first member.
+    pydantic_union_schema_output = get_schema(PydanticUnionClass)
+    assert (
+        pydantic_union_schema_output
+        == '{\n  "name": "<name>",\n  "equipment": "<equipment>"\n}'
     )
 
 


### PR DESCRIPTION

`parse_pydantic_schema_value` handled `enum` and `$ref` properties but not
`anyOf`, which is how pydantic renders `Optional[...]` and unions. So the
`schema` filter rendered enum values / nested structure for required fields
but fell back to a `<name>` placeholder for the `Optional` equivalents —
a gap in the enum-rendering support added in d0bbd703.

The fix adds an `anyOf` branch that recurses into the first non-null member,
so an `Optional[T]` field renders exactly like a required `T`. Extended
`test_get_schema` with `Optional[Enum]` and `Optional[NestedModel]` cases
(fail before, pass after). Full `test_templates.py` green; `ruff` clean.

Used an AI assistant to find and fix this; I reviewed, reproduced the issue,
and ran the tests myself before submitting.