### PR TITLE
Support PEP 604 unions (int | str) as output types

### DIFF
--- a/src/outlines/types/utils.py
+++ b/src/outlines/types/utils.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import inspect
 import sys
+import types
 import warnings
 from enum import Enum, EnumMeta
 from typing import (
@@ -113,7 +114,7 @@ def is_typing_tuple(value: Any) -> bool:
 
 
 def is_union(value: Any) -> bool:
-    return get_origin(value) is Union
+    return get_origin(value) is Union or isinstance(value, types.UnionType)
 
 
 def is_literal(value: Any) -> bool:

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -638,6 +638,10 @@ def test_dsl_python_types_to_terms():
     # convert to terms are tested in distinct tests below
     assert python_types_to_terms(Literal["a", "b"]) == _handle_literal(("a", "b"))
     assert python_types_to_terms(Union[int, str]) == _handle_union((int, str), recursion_depth=0)
+    # PEP 604 unions must dispatch the same way as typing.Union/Optional
+    assert python_types_to_terms(int | str) == python_types_to_terms(Union[int, str])
+    assert python_types_to_terms(str | None) == python_types_to_terms(PyOptional[str])
+    assert python_types_to_terms(list[int | str]) == python_types_to_terms(list[Union[int, str]])
     assert python_types_to_terms(list[int]) == _handle_list((int,), recursion_depth=0)
     assert python_types_to_terms(tuple[int, str]) == _handle_tuple((int, str), recursion_depth=0)
     assert python_types_to_terms(dict[int, str]) == _handle_dict((int, str), recursion_depth=0)

--- a/tests/types/test_types_utils.py
+++ b/tests/types/test_types_utils.py
@@ -274,6 +274,8 @@ def test_is_typing_tuple():
 def test_is_union():
     assert is_union(Union[int, str])
     assert is_union(Optional[int])
+    assert is_union(int | str)
+    assert is_union(str | None)
     assert not is_union(list)
     assert not is_union(["a", "b"])
     assert not is_union(Literal[int, str])


### PR DESCRIPTION
## What this PR does

Fixes `python_types_to_terms` rejecting PEP 604 unions as output types. Passing `int | str`, `str | None`, or a nested form like `list[int | str]` currently raises:

```
TypeError: Type int | str is currently not supported. Please open an issue: https://github.com/dottxt-ai/outlines/issues
```

while the semantically identical `typing.Union[int, str]` / `Optional[str]` work fine.

## Root cause

`is_union` in `src/outlines/types/utils.py` only checks `get_origin(value) is typing.Union`. For a PEP 604 union, `get_origin(int | str)` returns `types.UnionType` instead, so `is_union` returns `False` and `python_types_to_terms` (`src/outlines/types/dsl.py`) falls through every handler into the generic unsupported-type error.

## Fix

Make `is_union` also accept `types.UnionType` instances:

```python
def is_union(value: Any) -> bool:
    return get_origin(value) is Union or isinstance(value, types.UnionType)
```

No version guard is needed: `pyproject.toml` requires Python `>=3.10` and `types.UnionType` exists since 3.10. `get_args` already treats both union forms identically, so `_handle_union` needs no changes — PEP 604 unions now produce terms string-identical to their `typing.Union`/`Optional` equivalents.

## Tests

- `tests/types/test_types_utils.py::test_is_union`: added `is_union(int | str)` and `is_union(str | None)` assertions.
- `tests/types/test_dsl.py::test_dsl_python_types_to_terms`: added assertions that `int | str`, `str | None`, and `list[int | str]` dispatch identically to `Union[int, str]`, `Optional[str]`, and `list[Union[int, str]]`.

Both tests fail on `main` without the one-line fix and pass with it. Full `pytest tests/types/` passes: 232 passed.
