### PR TITLE
fix(vllm): _build_client_args mutates caller's extra_body dict across calls

### DIFF
--- a/src/outlines/models/vllm.py
+++ b/src/outlines/models/vllm.py
@@ -199,7 +199,11 @@ class VLLM(Model):
         """Build the arguments to pass to the OpenAI client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
-        extra_body = inference_kwargs.pop("extra_body", {})
+        # Copy the caller-provided dict so we never mutate it in place when
+        # merging structured_outputs below. Reusing the same `extra_body` dict
+        # across calls previously leaked the previous call's constraints into
+        # later unconstrained calls (see GH#1931).
+        extra_body = dict(inference_kwargs.pop("extra_body", {}))
         extra_body.update(output_type_args)
 
         if "model" not in inference_kwargs and self.model_name is not None:
@@ -340,7 +344,11 @@ class AsyncVLLM(AsyncModel):
         """Build the arguments to pass to the OpenAI client."""
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
-        extra_body = inference_kwargs.pop("extra_body", {})
+        # Copy the caller-provided dict so we never mutate it in place when
+        # merging structured_outputs below. Reusing the same `extra_body` dict
+        # across calls previously leaked the previous call's constraints into
+        # later unconstrained calls (see GH#1931).
+        extra_body = dict(inference_kwargs.pop("extra_body", {}))
         extra_body.update(output_type_args)
 
         if "model" not in inference_kwargs and self.model_name is not None:

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -370,3 +370,43 @@ async def test_vllm_async_cfg(async_model):
     result = await async_model("foo?", CFG(YES_NO_GRAMMAR), max_tokens=10)
     assert isinstance(result, str)
     assert result in ["yes", "no"]
+
+
+@pytest.mark.parametrize("model_fixture", ["sync_model", "async_model"])
+def test_vllm_build_client_args_does_not_mutate_caller_extra_body(request, model_fixture):
+    """Regression test for https://github.com/outlines-dev/outlines/issues/1931.
+
+    ``_build_client_args`` must not mutate the caller-provided ``extra_body``
+    dict in place when merging ``structured_outputs``. Reusing the same dict
+    across calls previously leaked the previous call's constraints into later
+    unconstrained calls.
+    """
+    model = request.getfixturevalue(model_fixture)
+
+    shared_extra_body = {"top_k": 5}
+    snapshot = dict(shared_extra_body)
+
+    # Call 1: a Regex output type adds `structured_outputs` to the merged
+    # extra_body that gets forwarded to the OpenAI client.
+    args_with_constraint = model._build_client_args(
+        "prompt one",
+        Regex(r"[0-9]{3}"),
+        extra_body=shared_extra_body,
+    )
+
+    # The caller's dict must be untouched, and the merged dict must be a
+    # separate object carrying the constraint.
+    assert shared_extra_body == snapshot
+    assert args_with_constraint["extra_body"] is not shared_extra_body
+    assert "structured_outputs" in args_with_constraint["extra_body"]
+
+    # Call 2: no output type — the stale constraint from call 1 must not
+    # leak through the shared dict into this unconstrained call.
+    args_without_constraint = model._build_client_args(
+        "prompt two",
+        None,
+        extra_body=shared_extra_body,
+    )
+
+    assert shared_extra_body == snapshot
+    assert "structured_outputs" not in args_without_constraint["extra_body"]


### PR DESCRIPTION
## Problem

`VLLM._build_client_args` (and the duplicated `AsyncVLLM._build_client_args`) builds the client kwargs with:

```python
extra_body = inference_kwargs.pop("extra_body", {})
extra_body.update(output_type_args)
```

`dict.pop(key, {})` only returns a *fresh* dict when the key is absent. When the caller passes `extra_body=my_dict`, `pop` returns that same object, so the subsequent `.update(output_type_args)` mutates the caller's dict in place — adding `structured_outputs` (or `response_format`) to it permanently.

Concrete failure mode: a caller reusing one `extra_body` dict across calls — a common pattern when keeping a module-level default config and tweaking per call — silently leaks the previous call's `structured_outputs` constraint into later *unconstrained* calls. An "unconstrained" generation is then actually constrained to a stale regex/JSON schema from a prior call. Silent data corruption, hard to debug.

Reporter: #1931. The sibling `sglang.py::_build_client_args` has a different bug (single-call self-clobber via `inference_kwargs.update(output_type_args)`) and is being fixed separately in #1925 — that file is intentionally left untouched here.

## Fix

In both `VLLM._build_client_args` and `AsyncVLLM._build_client_args`, wrap the `pop` in `dict(...)` so we own the dict before merging into it:

```python
extra_body = dict(inference_kwargs.pop("extra_body", {}))
extra_body.update(output_type_args)
```

Shallow copy is sufficient: `output_type_args` only adds top-level keys (`structured_outputs`, `response_format`); nested values are not mutated. `dict({})` is `{}` so the no-arg default path is unchanged.

## Testing

- Added `test_vllm_build_client_args_does_not_mutate_caller_extra_body` (parametrized over `sync_model`/`async_model`) covering both failure modes:
  - Call 1 (`Regex(r"[0-9]{3}")` output type, `extra_body=shared`): caller's dict stays `{"top_k": 5}` (no `structured_outputs` leaked in), and the returned `client_args["extra_body"]` is a separate object that does carry the constraint.
  - Call 2 (`None` output type, same `extra_body=shared`): the returned `client_args["extra_body"]` is `{"top_k": 5}` (no stale `structured_outputs` from call 1).
- Confirmed red→green: reverting only `src/outlines/models/vllm.py` (keeping the new test) reproduces both failures on both parametrizations; reapplying the fix passes.
- Full `tests/models/test_vllm.py` suite: 21 passed (19 existing + 2 new parametrizations).
- `ruff check src/outlines/models/vllm.py tests/models/test_vllm.py` passes.
- (`ruff format` reports pre-existing unrelated drift in this file from prior commits; not addressed here to keep the diff surgical.)

Fixes #1931.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `src/outlines/models/` after issue #1931 was filed. I personally reproduced the cross-call mutation with a minimal repro (caller-provided `extra_body` dict reused across two calls, observing `structured_outputs` leak into the second, unconstrained call), verified the surgical `dict(...)` wrapper against both the `structured_outputs` path (regex/CFG/JSON) and the `response_format` path (JsonSchema) to confirm no regression, confirmed red→green by reverting only `vllm.py`, and ran the full `test_vllm.py` suite before submitting.
