### PR TITLE
Fix template whitespace collapse merging lines on trailing whitespace

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -137,7 +137,7 @@ def build_template_from_string(
     # Remove extra whitespaces, except those that immediately follow a newline symbol.
     # This is necessary to avoid introducing whitespaces after backslash `\` characters
     # used to continue to the next line without linebreak.
-    cleaned_template = re.sub(r"(?![\r\n])(\b\s+)", " ", cleaned_template)
+    cleaned_template = re.sub(r"(?![\r\n])(\b[^\S\r\n]+)", " ", cleaned_template)
 
     env = create_jinja_env(None, filters)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -397,3 +397,13 @@ def test_get_schema():
     assert pydantic_nested_schema_output == (
         '{\n  "name": "<name>",\n  "inner": {\n    "foo": "<foo>"\n  }\n}'
     )
+
+
+def test_render_trailing_whitespace_preserves_linebreak():
+    # A trailing space before a newline must not swallow the line break.
+    assert build_template_from_string("foo   \nbar").render() == "foo \nbar"
+
+
+def test_render_trailing_whitespace_keeps_next_line_indentation():
+    src = "\n    A test line \n        An indented line\n    "
+    assert build_template_from_string(src).render() == "A test line \n    An indented line"


### PR DESCRIPTION
### What's broken

The whitespace-collapsing regex in `build_template_from_string` uses `\s`, which includes newlines:

```python
# Remove extra whitespaces, except those that immediately follow a newline symbol.
cleaned_template = re.sub(r"(?![\r\n])(\b\s+)", " ", cleaned_template)
```

The run starts after a word boundary (`\b`, so the `(?![\r\n])` lookahead passes), then `\s+` greedily eats the following newline **and the next line's indentation**. So a single, usually invisible, trailing space after a word destroys the line break:

```python
build_template_from_string("foo   \nbar").render()
# 'foo bar'   -- expected 'foo \nbar'
```

An indented multi-line template with one trailing space loses both the newline and the indentation — no user expects a trailing space to merge two lines.

### Fix

Restrict the collapsed run to **horizontal** whitespace (`[^\S\r\n]`) so multi-space runs still collapse to one space while newlines and post-newline indentation are preserved. The existing `\b` guard already preserves post-newline indentation; this stops a collapsed run from crossing a newline.

### Tests

Adds two cases to `tests/test_templates.py` (trailing space preserves the line break; and keeps next-line indentation). Full `tests/test_templates.py` passes (17).