### PR TITLE
fix(sglang): copy caller extra_body before merging structured outputs

### DIFF
--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -211,7 +211,9 @@ class SGLang(Model):
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
         if "extra_body" in output_type_args:
-            extra_body = inference_kwargs.pop("extra_body", {})
+            # Copy caller extra_body so structured-output keys cannot leak
+            # into subsequent unconstrained calls (#1931).
+            extra_body = dict(inference_kwargs.pop("extra_body", {}) or {})
             extra_body.update(output_type_args.pop("extra_body"))
             inference_kwargs["extra_body"] = extra_body
         inference_kwargs.update(output_type_args)
@@ -360,7 +362,9 @@ class AsyncSGLang(AsyncModel):
         messages = self.type_adapter.format_input(model_input)
         output_type_args = self.type_adapter.format_output_type(output_type)
         if "extra_body" in output_type_args:
-            extra_body = inference_kwargs.pop("extra_body", {})
+            # Copy caller extra_body so structured-output keys cannot leak
+            # into subsequent unconstrained calls (#1931).
+            extra_body = dict(inference_kwargs.pop("extra_body", {}) or {})
             extra_body.update(output_type_args.pop("extra_body"))
             inference_kwargs["extra_body"] = extra_body
         inference_kwargs.update(output_type_args)

--- a/tests/models/test_sglang.py
+++ b/tests/models/test_sglang.py
@@ -398,3 +398,27 @@ async def test_sglang_async_cfg(async_model):
     result = await async_model("foo?", CFG(EBNF_YES_NO_GRAMMAR), max_tokens=10)
     assert isinstance(result, str)
     assert result in ["yes", "no"]
+
+
+@pytest.mark.parametrize("model_cls", [SGLang, AsyncSGLang])
+def test_sglang_build_client_args_does_not_mutate_caller_extra_body(model_cls):
+    """Caller-provided extra_body must not be mutated across calls (#1931)."""
+    # openai_client / sglang_model_name are module-level mock client globals,
+    # not pytest fixtures (same pattern as test_sglang_build_client_args_merges_*).
+    model = model_cls(openai_client, sglang_model_name)
+
+    shared = {"user_key": "user_value"}
+    snapshot = dict(shared)
+
+    args1 = model._build_client_args(
+        "foo?", output_type=Regex(r"[0-9]{3}"), extra_body=shared
+    )
+    assert shared == snapshot
+    assert args1["extra_body"] is not shared
+    assert args1["extra_body"]["user_key"] == "user_value"
+    assert args1["extra_body"]["regex"] == "([0-9]{3})"
+
+    args2 = model._build_client_args("foo?", output_type=None, extra_body=shared)
+    assert shared == snapshot
+    # unconstrained call must not inherit previous structured-output keys
+    assert "regex" not in args2.get("extra_body", {})


### PR DESCRIPTION
## Summary
#1931 reported that `VLLM/AsyncVLLM._build_client_args` mutated the caller's `extra_body`. That path was fixed in #1933. The same `pop` + in-place `update` pattern remains in `SGLang` / `AsyncSGLang._build_client_args`, so a reused `extra_body` dict still leaks structured-output keys (`regex` / `ebnf`) into later unconstrained calls.

## Change
- Copy the caller `extra_body` with `dict(...)` before merging (sync + async)
- Regression test: shared dict is unchanged after a constrained call; unconstrained follow-up has no `regex`

## Test plan
- [x] Pure logic repro of old vs new `pop`/`update` behavior
- [x] Added `test_sglang_build_client_args_does_not_mutate_caller_extra_body`
- Note: package requires Python `<3.14`; CI on supported versions should run the new test

Fixes #1931
