### PR TITLE
fix(types): make non-required dataclass fields Optional, matching the pydantic converter

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -180,10 +180,16 @@ def json_schema_dict_to_dataclass(
 
     for property, details in properties.items():
         typ = schema_type_to_python(details, "dataclass")
-        annotations[property] = typ
 
         if property not in required:
+            # Mirror the pydantic converter: a non-required field is nullable,
+            # so wrap the annotation in Optional rather than leaving a bare type
+            # with a None default (which contradicts its own annotation and
+            # loses the optionality the schema declared).
+            typ = Optional[typ]
             defaults[property] = None
+
+        annotations[property] = typ
 
     class_dict = {
         '__annotations__': annotations,

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import is_dataclass
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union, get_type_hints
 
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticUndefined
@@ -81,7 +81,8 @@ def test_schema_type_to_python_object():
     assert hasattr(dataclass_result, "__dataclass_fields__")
     assert dataclass_result.__annotations__["name"] is str
     assert not hasattr(dataclass_result, "name")
-    assert dataclass_result.__annotations__["age"] is int
+    # Non-required field is nullable, matching the pydantic/typeddict callers above.
+    assert dataclass_result.__annotations__["age"] == Optional[int]
     assert dataclass_result.age is None
 
 
@@ -337,7 +338,7 @@ def test_json_schema_dict_to_dataclass_basic():
 
     annotations = result.__annotations__
     assert annotations["name"] is str
-    assert annotations["age"] is int
+    assert annotations["age"] == Optional[int]
     assert not hasattr(result, "name")
     assert result.age is None
 
@@ -362,7 +363,8 @@ def test_json_schema_dict_to_dataclass_array_enum():
     assert result.__name__ == "AnonymousDataclass"
 
     annotations = result.__annotations__
-    assert annotations["tags"] == List[str]
+    # `tags` is not required, so its annotation is nullable.
+    assert annotations["tags"] == Optional[List[str]]
     assert annotations["status"] == Literal[("active", "inactive", "pending")]
     assert not hasattr(result, "status")
     assert result.tags is None
@@ -394,7 +396,7 @@ def test_json_schema_dict_to_dataclass_nested_object():
 
     field = annotations["field"]
     assert field.__annotations__["name"] is str
-    assert field.__annotations__["age"] is int
+    assert field.__annotations__["age"] == Optional[int]
     assert not hasattr(field, "name")
     assert field.age is None
 
@@ -415,3 +417,39 @@ def test_json_schema_dict_to_dataclass_optional_before_required():
     instance = result(user_id=5)
     assert instance.user_id == 5
     assert instance.nickname is None
+
+
+def test_json_schema_dict_to_dataclass_optional_field_is_nullable():
+    # A non-required field must be annotated Optional[...], not a bare type with
+    # a None default. Otherwise the annotation and default contradict each other
+    # and the dataclass converter loses the optionality the pydantic converter
+    # keeps, so the two disagree for the same input schema.
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name"],
+    }
+
+    dataclass_result = json_schema_dict_to_dataclass(schema)
+    hints = get_type_hints(dataclass_result)
+    assert hints["age"] == Optional[int]
+
+    # The three converters are offered for the same schema, so they must agree
+    # on whether the optional field accepts null. Compare against the pydantic
+    # converter, which already produces a nullable field.
+    def allows_null(field_schema: dict) -> bool:
+        if field_schema.get("type") == "null":
+            return True
+        if "anyOf" in field_schema:
+            return any(m.get("type") == "null" for m in field_schema["anyOf"])
+        return False
+
+    dataclass_age = TypeAdapter(dataclass_result).json_schema()["properties"]["age"]
+    pydantic_age = json_schema_dict_to_pydantic(schema).model_json_schema()[
+        "properties"
+    ]["age"]
+    assert allows_null(dataclass_age)
+    assert allows_null(pydantic_age)


### PR DESCRIPTION
Closes #1938.

## What

`json_schema_dict_to_dataclass` left a non-required field's annotation as the bare type and only added a `None` default. So a field that isn't in the schema's `required` list came out as `age: int = None`, where the annotation (`int`) and the default (`None`) contradict each other, and the optionality the schema declared was lost.

The two sibling converters in the same file already handle this correctly: `json_schema_dict_to_pydantic` wraps the value in `Optional[typ]`, and `json_schema_dict_to_typeddict` marks the key `NotRequired[typ]`. Only the dataclass path left it as a bare type.

## Why it matters

`JsonSchema.convert_to(schema, ["dataclass", "typeddict", "pydantic"])` is meant to let a caller pick a container for the *same* schema, so the containers shouldn't disagree on what's accepted. But they did. Round-tripping the generated type back through `TypeAdapter(...).json_schema()` (which is the path an outline dataclass output type takes into grammar generation) shows the divergence for an optional `age: integer` field:

| converter | `age` after round-trip | allows `null`? |
|---|---|---|
| pydantic  | `anyOf: [{integer}, {null}]`, `default: null` | yes |
| dataclass (before) | `type: integer`, `default: null` | no |

The dataclass path both loses the null option (so constrained generation can never emit `null` for a field the schema said is optional) and carries a `default: null` that doesn't validate against its own `type: integer`.

## Fix

Wrap the annotation in `Optional[...]` for non-required fields, mirroring the pydantic converter:

```python
if property not in required:
    typ = Optional[typ]
    defaults[property] = None
annotations[property] = typ
```

After this, the dataclass path produces the same `anyOf: [integer, null]` the pydantic path does.

## Tests

- Updated the existing tests that asserted the old bare-type behavior (`test_schema_type_to_python_object`, `test_json_schema_dict_to_dataclass_basic`, `_array_enum`, `_nested_object`). Notably `test_schema_type_to_python_object` was already documenting the divergence: it asserted `Optional[int]` for pydantic, `NotRequired[int]` for typeddict, and `int` for dataclass on the same optional field.
- Added `test_json_schema_dict_to_dataclass_optional_field_is_nullable`, which asserts the annotation is `Optional[int]` and that the dataclass and pydantic converters agree on optional-field nullability after a round-trip.

RED/GREEN verified: the new test fails on `main` (annotation comes out as bare `int`) and passes with the fix. Full `tests/types/test_json_schema_utils.py` passes (24 passed), and the wider `tests/types/` suite passes except for pre-existing unrelated skips (`test_custom_types.py` needs the optional `airportsdata` extra; some `from_file` tests hit a Windows temp-file permission issue that reproduces on `main` without this change).
