### PR TITLE
fix(types): reject non-string values for DSL terms

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -144,7 +144,7 @@ class Term:
     def validate(self, value: str) -> str:
         pattern = to_regex(self)
         compiled = re.compile(pattern)
-        if not compiled.fullmatch(str(value)):
+        if not is_str_instance(value) or not compiled.fullmatch(value):
             raise ValueError(
                 f"Input should be in the language of the regular expression {pattern}"
             )

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -16,7 +16,7 @@ from typing import (
 import jsonschema
 import pytest
 from genson import SchemaBuilder
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from outlines import grammars, types
 from outlines.types.dsl import (
@@ -203,6 +203,20 @@ def test_dsl_term_methods():
     assert a._display_children("") == ""
 
     assert a.__str__() == "└── String('a')\n"
+
+
+def test_dsl_term_pydantic_rejects_non_string_values():
+    digits = Regex("[0-9]+")
+
+    class Model(BaseModel):
+        field: digits
+
+    payload = Model(field="123")
+    assert payload.field == "123"
+    assert isinstance(payload.field, str)
+    with pytest.raises(ValidationError):
+        Model(field=123)
+
 
 def test_dsl_sequence():
     a = String("a")

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -217,6 +217,14 @@ def test_dsl_term_pydantic_rejects_non_string_values():
     with pytest.raises(ValidationError):
         Model(field=123)
 
+    # The guard is an isinstance check rather than an exact type check, so
+    # `str` subclasses remain valid inputs.
+    class Digits(str):
+        pass
+
+    payload = Model(field=Digits("123"))
+    assert isinstance(payload.field, Digits)
+
 
 def test_dsl_sequence():
     a = String("a")


### PR DESCRIPTION
## What

DSL `Term` objects can be used directly as Pydantic field types. They generate a JSON Schema field of `{"type": "string", "pattern": ...}`, but `Term.validate()` converted every input with `str(value)` before applying the regex and then returned the *original* input unchanged.

Matching non-string values therefore passed validation and stayed non-strings in the resulting model:

```python
from pydantic import BaseModel
from outlines.types import Regex

class Payload(BaseModel):
    value: Regex(r"[0-9]+")

Payload(value=123).value      # 123, an int
```

The consequence is not confined to the model instance. The field's declared schema says `string`, so the model serializes to JSON that its own schema rejects:

```python
Payload.model_json_schema()["properties"]["value"]
# {"pattern": "([0-9]+)", "type": "string"}

Payload(value=123).model_dump_json()
# '{"value":123}'
# jsonschema.validate(...) -> ValidationError: 123 is not of type 'string'
```

That same schema is what is handed to providers for structured output.

It also is not limited to numeric input. Because the guard was `str(value)`, any object with a cooperative `__str__` passed and was stored unconverted:

```python
class Sneaky:
    def __str__(self): return "123"

Payload(value=Sneaky()).value   # accepted, still a Sneaky instance
```

## Fix

Require values passed to `Term.validate()` to be strings before applying the compiled regular expression, using the existing `is_str_instance` helper so that `str` subclasses remain valid.

This aligns the runtime with the signature the method has carried since the DSL was introduced in `da1b0db5` (`def validate(self, value: str) -> str`); the `str()` call was added in that same commit and reads as defensive rather than as an intended coercion feature.

## Behaviour change

This is a behaviour change, not only a bug fix. `Term.validate()` also backs the built-in terms in `outlines.types`, which are `Regex` instances. Terms whose pattern happens to match the `str()` form of their Python counterpart previously accepted that value and now reject it:

| annotation | input | before | after |
| --- | --- | --- | --- |
| `types.integer` | `123` | accepted, stays `int` | `ValidationError` |
| `types.number` | `1.5` | accepted, stays `float` | `ValidationError` |
| `types.boolean` | `True` | accepted, stays `bool` | `ValidationError` |
| `types.integer` | `"123"` | accepted | accepted |

Anyone annotating a Pydantic field with `types.integer`, `types.number`, or `types.boolean` and passing the corresponding Python value will see a `ValidationError` where the value was previously accepted.

Two notes on how large that surface actually is:

* The terms already did not accept natural Python values in general. `types.string` is `Regex(r'"[^"]*"')`, so `Model(field="abc")` raises on `main` today and only `'"abc"'` passes. `types.integer` already rejected `123.0` while accepting `123`. The leniency was incidental to `str()`, not designed.
* There is no user-facing documentation example annotating a Pydantic field with these terms. They appear only in `docs/guide/architecture.md`, describing the internal Python-type-to-term mapping.

The alternative resolution is coercion: keep the `str(value)` match and return the string, so `Payload(value=123)` yields `"123"`. That fixes the stated defect with a smaller compatibility surface. I did not take it because the accepted inputs are not only numbers — coercing would silently replace an unrelated object with `"123"` in the `Sneaky` case above, where the current behaviour at least leaves the object intact to be noticed. Happy to switch if maintainers prefer the coercing variant.

## Scope

`Term.validate()` is reachable only through `__get_pydantic_core_schema__` and `__get_validator__`. Nothing else in `src/` calls it and no test calls it directly. `Term.matches()`, `to_regex()`, regex generation, and the model-provider integrations are unchanged — this affects only what happens when an already-produced value is handed to a Pydantic model, not constrained generation.

## Tests

Added a regression test verifying that:

* a matching string is accepted and retained as a string
* a matching integer is rejected with a Pydantic `ValidationError`
* a `str` subclass is still accepted, pinning that the guard is an `isinstance` check rather than an exact type check

Validation performed:

* `tests/types/test_dsl.py`: 60 passed
* `tests/types`: 261 passed
* all configured pre-commit hooks passed, including mypy and Ruff
* `git diff --check` passed

The full provider and model integration suite was not run locally because it requires heavyweight and environment-specific dependencies.
