### PR TITLE
Add the credit_card custom type

### DIFF
--- a/src/outlines/types/__init__.py
+++ b/src/outlines/types/__init__.py
@@ -88,6 +88,7 @@ __all__ = [
     "mac_address",
     "hex_color",
     "slug",
+    "credit_card",
     # Document-specific types
     "sentence",
     "paragraph",
@@ -173,6 +174,22 @@ hex_color = Regex(r"#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})")
 # hyphens. Uppercase letters, underscores, and leading, trailing, or
 # consecutive hyphens are excluded, as is the empty string.
 slug = Regex(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+# Payment card numbers (PANs) for common card networks, matched by issuer prefix
+# and length. The same prefixes may cover credit, debit and prepaid cards, so
+# this validates the number format only, not the Luhn checksum. Each branch is
+# annotated below.
+credit_card = Regex(
+    r"4[0-9]{12}(?:[0-9]{3}(?:[0-9]{3})?)?"  # Visa (13, 16 or 19 digits)
+    r"|5[1-5][0-9]{14}"  # Mastercard (51-55)
+    r"|2(?:22[1-9]|2[3-9][0-9]|[3-6][0-9]{2}|7[01][0-9]|720)[0-9]{12}"  # Mastercard (2221-2720)
+    r"|3[47][0-9]{13}"  # American Express
+    r"|3(?:0[0-5]|[68][0-9])[0-9]{11}"  # Diners Club
+    r"|6(?:011[0-9]{12}|4[4-9][0-9]{13}|5[0-9]{14})"  # Discover (6011, 644-649, 65)
+    r"|(?:2131|1800|35[0-9]{3})[0-9]{11}"  # JCB
+    r"|(?:5018|5020|5038|5893|6304|6759|676[1-3])[0-9]{8,15}"  # Maestro
+    r"|62[0-9]{14,17}"  # UnionPay 62-prefix; includes Discover 622126-622925 co-brand
+)
 
 # Document-specific types
 sentence = Regex(r"[A-Z].*\s*[.!?]")

--- a/tests/types/test_custom_types.py
+++ b/tests/types/test_custom_types.py
@@ -145,6 +145,32 @@ from outlines.types.dsl import to_regex
         (types.slug, "double--hyphen", False),
         (types.slug, "under_score", False),
         (types.slug, "", False),
+        (types.credit_card, "4111111111111111", True),  # Visa 16
+        (types.credit_card, "4222222222222", True),  # Visa 13
+        (types.credit_card, "4111111111111111111", True),  # Visa 19
+        (types.credit_card, "5555555555554444", True),  # Mastercard 51-55
+        (types.credit_card, "2223003122003222", True),  # Mastercard 2221-2720
+        (types.credit_card, "378282246310005", True),  # American Express
+        (types.credit_card, "30569309025904", True),  # Diners Club
+        (types.credit_card, "6011111111111117", True),  # Discover 6011
+        (types.credit_card, "6440000000000007", True),  # Discover 644-649
+        (types.credit_card, "6490000000000009", True),  # Discover 644-649
+        (types.credit_card, "6512345678901234", True),  # Discover 65
+        (types.credit_card, "3530111333300000", True),  # JCB
+        (types.credit_card, "6759649826438453", True),  # Maestro
+        (types.credit_card, "6200000000000005", True),  # UnionPay
+        (types.credit_card, "6221260000000000", True),  # Discover 622126-622925 co-brand
+        (types.credit_card, "4111 1111 1111 1111", False),  # spaces
+        (types.credit_card, "4111-1111-1111-1111", False),  # hyphens
+        (types.credit_card, "1234567890123456", False),  # unknown prefix
+        (types.credit_card, "6430000000000000", False),  # 643 not a Discover prefix
+        (types.credit_card, "2220003122003222", False),  # below Mastercard 2-range
+        (types.credit_card, "2721003122003222", False),  # above Mastercard 2-range
+        (types.credit_card, "411111111111", False),  # too short
+        (types.credit_card, "4111a11111111111", False),  # non-digit character
+        (types.credit_card, "41111111111111111111", False),  # too long (20 digits)
+        (types.credit_card, "3782822463100050", False),  # Amex prefix, wrong length
+        (types.credit_card, "", False),
     ],
 )
 def test_type_regex(custom_type, test_string, should_match):


### PR DESCRIPTION
Adds a `credit_card` custom type, in the same spirit as #1863 (semver, mac) and #1934 (hex_color, slug). It was proposed in a comment on #1303 but hadn't been picked up yet.

**What it does**

Matches payment card numbers for the common networks by issuer prefix and length: Visa (13/16/19), Mastercard (51-55 and 2221-2720), American Express, Diners Club, Discover (6011, 644-649, 65, with the 622126-622925 co-brand covered through the shared 62 prefix), JCB, Maestro and UnionPay. Since these prefixes are shared by credit, debit and prepaid cards, it validates the number format only, not the Luhn checksum or whether a card actually exists.

I kept it to the common network prefixes to match the lightweight style of the existing types; broader regional coverage could be a follow-up if you'd like it. Named `credit_card` per the #1303 proposal, but happy to rename to `card_number` if you prefer something more precise.

**Tests**

Added parametrized cases in `tests/types/test_custom_types.py`: accepted examples across the supported networks, the Mastercard 2-series and Discover 643/644 boundaries, and rejected inputs (separators, non-digit characters, unknown prefix, wrong length, empty). They fail on `main` and pass with the change. `ruff` is clean.