### PR TITLE
fix(types): resolve Literal[None] instead of raising TypeError

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -766,6 +766,13 @@ def python_types_to_terms(ptype: Any, recursion_depth: int = 0) -> Term:
         return types.datetime
 
     # Basic type instances
+    if ptype is None:
+        # ``None`` used as a literal value (e.g. ``Literal[None]`` or a bare
+        # ``None`` member) maps to the bare ``None`` keyword, mirroring how
+        # ``Optional``/``Union`` render their None member in ``_handle_union``.
+        # Kept as a ``Regex`` (like ``True``/``False``) so it stays unquoted
+        # when the value ends up nested inside a container type.
+        return Regex("None")
     if isinstance(ptype, bool):
         return Regex(str(ptype))
     elif is_str_instance(ptype):

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -704,6 +704,23 @@ def test_dsl_literal_bool():
     assert result_both == Alternatives([Regex("True"), Regex("False")])
 
 
+def test_dsl_literal_none():
+    # Literal[None] previously raised "Type None is currently not supported"
+    # because the None value was recursed into as if it were a type. It should
+    # resolve to the bare ``None`` keyword, the same way Optional/Union render
+    # their None member.
+    result_none = python_types_to_terms(Literal[None])
+    assert isinstance(result_none, Alternatives)
+    assert result_none.terms == [Regex("None")]
+
+    # None mixed with other literal values must resolve too.
+    result_mixed = python_types_to_terms(Literal["active", None])
+    assert result_mixed == Alternatives([String("active"), Regex("None")])
+
+    # A bare None value maps to the same bare keyword as it does in a union.
+    assert python_types_to_terms(None) == Regex("None")
+
+
 def test_dsl_numeric_literal_escapes_regex_metacharacters():
     # A float's ``.`` must match literally, not act as a regex wildcard.
     term = python_types_to_terms(1.5)
@@ -1184,6 +1201,20 @@ def test_e2e_optional_none_not_quoted_in_containers():
     literal_pattern = to_regex(python_types_to_terms(list[Literal["None"]]))
     assert _re.fullmatch(literal_pattern, '["None"]')
     assert not _re.fullmatch(literal_pattern, "[None]")
+
+
+def test_e2e_list_literal_none():
+    """``Literal[None]`` renders the bare ``None`` keyword, both standalone and
+    nested in a container, consistently with ``Optional``/``Union``."""
+    standalone = to_regex(python_types_to_terms(Literal[None]))
+    assert _re.fullmatch(standalone, "None")
+    assert not _re.fullmatch(standalone, '"None"')
+
+    list_pattern = to_regex(python_types_to_terms(list[Literal["yes", None]]))
+    assert _re.fullmatch(list_pattern, "[None]")
+    assert _re.fullmatch(list_pattern, '["yes", None]')
+    # The None branch stays a bare keyword and is not JSON-quoted like a string.
+    assert not _re.fullmatch(list_pattern, '["None"]')
 
 
 def test_to_regex():


### PR DESCRIPTION
While using `Literal` output types I hit a crash whenever `None` was one of the values. `python_types_to_terms` treats a bare `None` as a type and recurses into it, so any of these raise `TypeError: Type None is currently not supported`:

```python
from typing import Literal
from outlines.types.dsl import python_types_to_terms

python_types_to_terms(Literal[None])
python_types_to_terms(Literal["active", None])
python_types_to_terms(list[Literal["yes", None]])
```

This is inconsistent with the rest of the DSL: `Optional[...]`/`Union[..., None]` already render their `None` member as the bare `None` keyword (via `_handle_union`), and `Literal[True]`/`Literal[False]` were previously fixed the same way. Only the `None` literal was left out.

## Fix

Map a `None` value to `Regex("None")` in `python_types_to_terms`, so it resolves to the bare `None` keyword and stays unquoted when nested inside a container type - exactly what the union path already does. `Literal[None]` now becomes `(None)`, matching `Optional`.

## Testing

Added unit and end-to-end tests in `tests/types/test_dsl.py` covering `Literal[None]`, `Literal[..., None]`, a bare `None` value, and `list[Literal[..., None]]` (the `None` branch stays a bare keyword and is not JSON-quoted). Ran `pytest tests/types` (all green, coverage of `dsl.py` stays at 100%) and `pre-commit run --all-files`.