### PR TITLE
fix(types): keep optional JSON Schema fields non-nullable

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -146,7 +146,10 @@ def json_schema_dict_to_pydantic(
     for property, details in properties.items():
         typ = schema_type_to_python(details, "pydantic")
         if property not in required:
-            field_definitions[property] = (Optional[typ], None)
+            # Omittable key, but keep the value type non-nullable unless the
+            # schema itself allows null (e.g. type: ["integer","null"]).
+            # Optional[typ] would widen generation to accept null.
+            field_definitions[property] = (typ, None)
         else:
             field_definitions[property] = (typ, ...)
 

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -2,7 +2,8 @@ import sys
 from dataclasses import is_dataclass
 from typing import Any, List, Literal, Optional, Union
 
-from pydantic import BaseModel, TypeAdapter
+import pytest
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic_core import PydanticUndefined
 
 from outlines.types.json_schema_utils import (
@@ -447,10 +448,7 @@ def test_json_schema_dict_to_pydantic_optional_not_nullable():
     # omit ok, null rejected
     assert M(name="x").age is None
     assert M(name="x", age=3).age == 3
-    try:
+    with pytest.raises(ValidationError):
         M(name="x", age=None)
-        raise AssertionError("expected validation error for age=null")
-    except Exception:
-        pass
     # note may be null because schema allows it
     assert M(name="x", note=None).note is None

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -66,7 +66,7 @@ def test_schema_type_to_python_object():
     assert issubclass(pydantic_result, BaseModel)
     assert pydantic_result.__name__ == "TestObject"
     assert pydantic_result.model_fields["name"].annotation is str
-    assert pydantic_result.model_fields["age"].annotation == Optional[int]
+    assert pydantic_result.model_fields["age"].annotation is int
 
     # Typeddict caller
     typeddict_result = schema_type_to_python(schema, "typeddict")
@@ -228,9 +228,9 @@ def test_json_schema_dict_to_pydantic_basic():
     assert result.__name__ == "Person"
 
     assert result.model_fields["name"].annotation is str
-    assert result.model_fields["age"].annotation == Optional[int]
+    assert result.model_fields["age"].annotation is int
     assert result.model_fields["name"].default == PydanticUndefined
-    result.model_fields["age"].default is None
+    assert result.model_fields["age"].default is None
 
 
 def test_json_schema_dict_to_pydantic_nullable_type_array():
@@ -285,7 +285,7 @@ def test_json_schema_dict_to_pydantic_array_enum():
     assert issubclass(result, BaseModel)
     assert result.__name__ == "AnonymousPydanticModel"
 
-    assert result.model_fields["tags"].annotation == Optional[List[str]]
+    assert result.model_fields["tags"].annotation == List[str]
     assert result.model_fields["status"].annotation == Literal[("active", "inactive", "pending")]
     assert result.model_fields["tags"].default is None
     assert result.model_fields["status"].default == PydanticUndefined
@@ -316,7 +316,7 @@ def test_json_schema_dict_to_pydantic_nested_object():
 
     field = result.model_fields["field"].annotation
     assert field.model_fields["name"].annotation is str
-    assert field.model_fields["age"].annotation == Optional[int]
+    assert field.model_fields["age"].annotation is int
     assert field.model_fields["name"].default == PydanticUndefined
     assert field.model_fields["age"].default is None
 
@@ -415,3 +415,42 @@ def test_json_schema_dict_to_dataclass_optional_before_required():
     instance = result(user_id=5)
     assert instance.user_id == 5
     assert instance.nickname is None
+
+
+def test_json_schema_dict_to_pydantic_optional_not_nullable():
+    """Non-required fields must stay non-nullable unless schema allows null.
+
+    JSON Schema ``required`` only controls key presence. Wrapping optional
+    fields in ``Optional`` widens generation to accept null values the source
+    schema forbids (#1948).
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "note": {"type": ["string", "null"]},
+        },
+        "required": ["name"],
+    }
+
+    M = json_schema_dict_to_pydantic(schema, "Person")
+    assert M.model_fields["age"].annotation is int
+    assert M.model_fields["tags"].annotation == List[str]
+    # Explicitly nullable schema keeps null.
+    assert M.model_fields["note"].annotation == Optional[str]
+
+    emitted = M.model_json_schema()
+    assert "null" not in str(emitted["properties"]["age"])
+    assert emitted["properties"]["age"]["type"] == "integer"
+    # omit ok, null rejected
+    assert M(name="x").age is None
+    assert M(name="x", age=3).age == 3
+    try:
+        M(name="x", age=None)
+        raise AssertionError("expected validation error for age=null")
+    except Exception:
+        pass
+    # note may be null because schema allows it
+    assert M(name="x", note=None).note is None


### PR DESCRIPTION
## Summary
`json_schema_dict_to_pydantic` treated every non-`required` field as `Optional[T]`, which makes the **value** nullable. In JSON Schema, `required` only controls whether a key may be omitted — not whether `null` is legal.

That widened constrained generation: a schema with `"age": {"type": "integer"}` (not required) could emit `"age": null`.

The TypedDict converter already documents and implements the correct distinction (`NotRequired` vs value nullability). Align the Pydantic path.

## Fix
```python
# before
field_definitions[property] = (Optional[typ], None)
# after
field_definitions[property] = (typ, None)
```

Explicitly nullable schemas (`"type": ["string", "null"]` / `anyOf`) are unchanged — `schema_type_to_python` still produces `Optional[...]` independently of `required`.

## Test plan
- [x] `pytest tests/types/test_json_schema_utils.py`
- [x] New regression: optional int rejects `null`, allows omit; explicit nullable still accepts `null`

Fixes #1948