### PR TITLE
fix(llguidance): raise a clear error for CFG literals matching special tokens

### DIFF
--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -226,9 +226,13 @@ class LLGuidanceBackend(BaseBackend):
             Every token string the tokenizer treats as atomic.
 
         """
+        # `added_tokens_decoder` was added in transformers 4.34; guard against
+        # older installations so a CFG-only feature doesn't break JSON-schema
+        # and regex users who happen to have an older tokenizer.
+        added_tokens_decoder = getattr(hf_tokenizer, "added_tokens_decoder", {})
         added = {
             added_token.content
-            for added_token in hf_tokenizer.added_tokens_decoder.values()
+            for added_token in added_tokens_decoder.values()
         }
         return frozenset(hf_tokenizer.all_special_tokens) | frozenset(added)
 
@@ -401,7 +405,11 @@ class LLGuidanceBackend(BaseBackend):
         -------
         set[str]
             The decoded text of every double- or single-quoted literal found
-            outside of a `//` comment.
+            outside of a `//` comment. Note: the scanner matches quoted runs
+            by syntax alone and does not distinguish Lark string literals from
+            quoted content embedded inside regexp terminals (e.g. the `"[^"`
+            portion of `STR: /"[^"]*"/`). Such fragments cannot equal a real
+            token string, so they cannot produce false positives.
 
         """
         literals = set()

--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -1,5 +1,6 @@
 """Backend class for LLGuidance."""
 
+import re
 import warnings
 from typing import TYPE_CHECKING
 
@@ -193,6 +194,11 @@ class LLGuidanceBackend(BaseBackend):
         self.llg = llg
         self.tensor_library_name = model.tensor_library_name
         self.llg_tokenizer = self._create_llg_tokenizer(model)
+        self._special_tokens: frozenset[str] = (
+            frozenset(model.hf_tokenizer.all_special_tokens)
+            if isinstance(model, Transformers)
+            else frozenset()
+        )
 
     def _create_llg_tokenizer(self, model: SteerableModel) -> "LLGTokenizer":
         """Create an llg tokenizer from the Outlines model's tokenizer.
@@ -300,6 +306,7 @@ class LLGuidanceBackend(BaseBackend):
             The logits processor to use to constrain the generation.
 
         """
+        self._check_grammar_literals_against_special_tokens(grammar)
         # We try both lark and ebnf
         try:
             grammar_spec = self.llg.grammar_from("grammar", grammar)
@@ -308,3 +315,37 @@ class LLGuidanceBackend(BaseBackend):
         return LLGuidanceLogitsProcessor(
             grammar_spec, self.llg_tokenizer, self.tensor_library_name
         )
+
+    def _check_grammar_literals_against_special_tokens(self, grammar: str) -> None:
+        """Raise a clear error if a grammar literal matches a special token.
+
+        When a quoted literal in the grammar exactly matches one of the
+        tokenizer's special tokens (e.g. `<think>`), llguidance's parser can
+        fail with an opaque `ParserTooComplex` error at generation time: the
+        model may emit the literal as a single atomic special token, which
+        the parser cannot match against a literal-string terminal the way it
+        matches ordinary, byte-decomposable tokens. Surfacing this at grammar
+        compilation time, with the actual conflicting token named, is far
+        more actionable than the downstream parser failure.
+
+        Parameters
+        ----------
+        grammar: str
+            The context-free grammar to check.
+
+        """
+        if not self._special_tokens:
+            return
+        literals = set(re.findall(r'"((?:[^"\\]|\\.)*)"', grammar))
+        conflicts = sorted(literals & self._special_tokens)
+        if conflicts:
+            raise ValueError(
+                "The grammar contains the literal(s) "
+                f"{conflicts} which exactly match special token(s) in the "
+                "tokenizer's vocabulary. The llguidance backend cannot "
+                "reliably constrain generation around a special token used "
+                "as ordinary grammar text, as the model may emit it as a "
+                "single atomic token that the parser cannot match against a "
+                "literal-string terminal. Avoid embedding the text of a "
+                "special token as a literal in your grammar."
+            )

--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -348,6 +348,72 @@ class LLGuidanceBackend(BaseBackend):
             grammar_spec, self.llg_tokenizer, self.tensor_library_name
         )
 
+    # Matches a Lark grammar's double- or single-quoted string literals, or a
+    # `//`-to-end-of-line comment. Alternation order matters: a string
+    # alternative always starts matching at its opening quote, so a `//`
+    # occurring inside a literal (e.g. `"http://foo"`) is consumed as part of
+    # that literal rather than being mistaken for the start of a comment, and
+    # a literal written inside a real comment is never extracted at all,
+    # since only the `dq`/`sq` groups are inspected by the caller.
+    _LITERAL_OR_COMMENT_RE = re.compile(
+        r'"(?P<dq>(?:[^"\\]|\\.)*)"'
+        r"|'(?P<sq>(?:[^'\\]|\\.)*)'"
+        r"|//[^\n]*"
+    )
+    # The backslash escapes a grammar author can realistically write inside a
+    # Lark string literal: \\, \", \', \n, \t, \r, and \uXXXX.
+    _ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})|\\(.)")
+    _SIMPLE_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", '"': '"', "'": "'"}
+
+    @classmethod
+    def _decode_literal_escapes(cls, literal: str) -> str:
+        """Decode backslash escapes in a raw grammar string literal.
+
+        Parameters
+        ----------
+        literal: str
+            The literal's source text, as captured between its quotes.
+
+        Returns
+        -------
+        str
+            The string the literal denotes, so it can be compared against
+            actual token text rather than against its escaped source form.
+
+        """
+        def _replace(match: "re.Match[str]") -> str:
+            hex_digits, other = match.groups()
+            if hex_digits is not None:
+                return chr(int(hex_digits, 16))
+            return cls._SIMPLE_ESCAPES.get(other, other)
+
+        return cls._ESCAPE_RE.sub(_replace, literal)
+
+    def _extract_grammar_literals(self, grammar: str) -> set[str]:
+        """Extract every quoted string literal's decoded text from a grammar.
+
+        Parameters
+        ----------
+        grammar: str
+            The context-free grammar to scan.
+
+        Returns
+        -------
+        set[str]
+            The decoded text of every double- or single-quoted literal found
+            outside of a `//` comment.
+
+        """
+        literals = set()
+        for match in self._LITERAL_OR_COMMENT_RE.finditer(grammar):
+            raw = match.group("dq")
+            if raw is None:
+                raw = match.group("sq")
+            if raw is None:
+                continue  # a `//` comment match; its contents are not grammar text
+            literals.add(self._decode_literal_escapes(raw))
+        return literals
+
     def _check_grammar_literals_against_special_tokens(self, grammar: str) -> None:
         """Raise a clear error if a grammar literal matches an atomic token.
 
@@ -364,6 +430,13 @@ class LLGuidanceBackend(BaseBackend):
         conflicting token named, is far more actionable than the downstream
         parser failure.
 
+        The check considers both `"..."` and `'...'` literals (Lark accepts
+        either), decodes standard backslash escapes before comparing, and
+        ignores literal-looking text inside `//` comments. It only catches an
+        *exact* match between a literal and an atomic token — a literal that
+        merely embeds the token's text as a substring (e.g. `"<think>: go"`)
+        is not detected.
+
         Parameters
         ----------
         grammar: str
@@ -372,7 +445,7 @@ class LLGuidanceBackend(BaseBackend):
         """
         if not self._atomic_literal_tokens:
             return
-        literals = set(re.findall(r'"((?:[^"\\]|\\.)*)"', grammar))
+        literals = self._extract_grammar_literals(grammar)
         conflicts = sorted(literals & self._atomic_literal_tokens)
         if conflicts:
             raise ValueError(

--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -194,11 +194,43 @@ class LLGuidanceBackend(BaseBackend):
         self.llg = llg
         self.tensor_library_name = model.tensor_library_name
         self.llg_tokenizer = self._create_llg_tokenizer(model)
-        self._special_tokens: frozenset[str] = (
-            frozenset(model.hf_tokenizer.all_special_tokens)
+        self._atomic_literal_tokens: frozenset[str] = (
+            self._get_atomic_literal_tokens(model.hf_tokenizer)
             if isinstance(model, Transformers)
             else frozenset()
         )
+
+    @staticmethod
+    def _get_atomic_literal_tokens(hf_tokenizer) -> frozenset[str]:
+        """Return every token string the tokenizer always emits atomically.
+
+        This is `all_special_tokens` (e.g. `<|endoftext|>`) plus every entry
+        in `added_tokens_decoder`, regardless of its individual `special`
+        flag. Reasoning-model chat templates commonly register tokens like
+        `<think>`/`</think>` as added-but-not-special (`special=False`) so
+        they survive `skip_special_tokens=True` decoding, but the tokenizer
+        still pulls them out of the input via its added-tokens split before
+        ordinary BPE merging runs — the same atomic, non-byte-decomposable
+        behavior that makes `all_special_tokens` entries conflict with a
+        grammar literal. The `special` flag only governs decode-time
+        stripping; it isn't a marker of which tokens bypass BPE.
+
+        Parameters
+        ----------
+        hf_tokenizer
+            The Hugging Face tokenizer to inspect.
+
+        Returns
+        -------
+        frozenset[str]
+            Every token string the tokenizer treats as atomic.
+
+        """
+        added = {
+            added_token.content
+            for added_token in hf_tokenizer.added_tokens_decoder.values()
+        }
+        return frozenset(hf_tokenizer.all_special_tokens) | frozenset(added)
 
     def _create_llg_tokenizer(self, model: SteerableModel) -> "LLGTokenizer":
         """Create an llg tokenizer from the Outlines model's tokenizer.
@@ -317,16 +349,20 @@ class LLGuidanceBackend(BaseBackend):
         )
 
     def _check_grammar_literals_against_special_tokens(self, grammar: str) -> None:
-        """Raise a clear error if a grammar literal matches a special token.
+        """Raise a clear error if a grammar literal matches an atomic token.
 
-        When a quoted literal in the grammar exactly matches one of the
-        tokenizer's special tokens (e.g. `<think>`), llguidance's parser can
-        fail with an opaque `ParserTooComplex` error at generation time: the
-        model may emit the literal as a single atomic special token, which
-        the parser cannot match against a literal-string terminal the way it
-        matches ordinary, byte-decomposable tokens. Surfacing this at grammar
-        compilation time, with the actual conflicting token named, is far
-        more actionable than the downstream parser failure.
+        When a quoted literal in the grammar exactly matches a token the
+        tokenizer always emits atomically — a "true" special token (e.g.
+        `<|endoftext|>`) or an added-but-not-special token (e.g. `<think>` on
+        reasoning-model tokenizers, which is commonly registered with
+        `special=False` so `skip_special_tokens=True` doesn't strip it) —
+        llguidance's parser can fail with an opaque `ParserTooComplex` error
+        at generation time: the model may emit the literal as a single atomic
+        token, which the parser cannot match against a literal-string
+        terminal the way it matches ordinary, byte-decomposable tokens.
+        Surfacing this at grammar compilation time, with the actual
+        conflicting token named, is far more actionable than the downstream
+        parser failure.
 
         Parameters
         ----------
@@ -334,18 +370,18 @@ class LLGuidanceBackend(BaseBackend):
             The context-free grammar to check.
 
         """
-        if not self._special_tokens:
+        if not self._atomic_literal_tokens:
             return
         literals = set(re.findall(r'"((?:[^"\\]|\\.)*)"', grammar))
-        conflicts = sorted(literals & self._special_tokens)
+        conflicts = sorted(literals & self._atomic_literal_tokens)
         if conflicts:
             raise ValueError(
                 "The grammar contains the literal(s) "
-                f"{conflicts} which exactly match special token(s) in the "
-                "tokenizer's vocabulary. The llguidance backend cannot "
-                "reliably constrain generation around a special token used "
-                "as ordinary grammar text, as the model may emit it as a "
+                f"{conflicts} which exactly match a token the tokenizer "
+                "always emits atomically. The llguidance backend cannot "
+                "reliably constrain generation around such a token used as "
+                "ordinary grammar text, as the model may emit it as a "
                 "single atomic token that the parser cannot match against a "
                 "literal-string terminal. Avoid embedding the text of a "
-                "special token as a literal in your grammar."
+                "special or added token as a literal in your grammar."
             )

--- a/tests/backends/test_llguidance.py
+++ b/tests/backends/test_llguidance.py
@@ -249,3 +249,48 @@ def test_cfg_logits_processor_rejects_literal_matching_added_non_special_token()
     grammar = '?start: "<think>" "yes"'
     with pytest.raises(ValueError, match="<think>"):
         backend.get_cfg_logits_processor(grammar)
+
+
+def test_cfg_logits_processor_rejects_single_quoted_literal_matching_special_token():
+    """Lark accepts single- and double-quoted string literals interchangeably,
+    so the check must scan both quote styles, not just double quotes.
+    """
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    grammar = "?start: '<|endoftext|>' \"yes\""
+    with pytest.raises(ValueError, match="<\\|endoftext\\|>"):
+        backend.get_cfg_logits_processor(grammar)
+
+
+def test_cfg_logits_processor_rejects_escaped_literal_matching_special_token():
+    """A literal's source text can differ from the text it denotes (e.g. a
+    \\uXXXX escape), so the check must decode escapes before comparing
+    against token text rather than comparing raw source characters.
+    """
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    grammar = '?start: "\\u003c|endoftext|\\u003e" "yes"'
+    with pytest.raises(ValueError, match="<\\|endoftext\\|>"):
+        backend.get_cfg_logits_processor(grammar)
+
+
+def test_cfg_logits_processor_ignores_literal_inside_comment(cfg_ebnf):
+    """A special token's text appearing inside a `//` comment is not grammar
+    text and must not trigger a false-positive rejection.
+    """
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    grammar = f'// example: "<|endoftext|>"\n{cfg_ebnf}'
+    processor = backend.get_cfg_logits_processor(grammar)
+    assert isinstance(processor, LLGuidanceLogitsProcessor)
+
+
+def test_cfg_logits_processor_allows_literal_containing_special_token_as_url():
+    """A `//` inside a string literal (e.g. a URL scheme) is part of the
+    literal's text, not the start of a comment, and must not be truncated.
+    """
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    grammar = '?start: "http://example.com" "yes"'
+    processor = backend.get_cfg_logits_processor(grammar)
+    assert isinstance(processor, LLGuidanceLogitsProcessor)

--- a/tests/backends/test_llguidance.py
+++ b/tests/backends/test_llguidance.py
@@ -232,3 +232,20 @@ def test_cfg_logits_processor_allows_literal_not_matching_special_token(cfg_ebnf
     backend = LLGuidanceBackend(model)
     processor = backend.get_cfg_logits_processor(cfg_ebnf)
     assert isinstance(processor, LLGuidanceLogitsProcessor)
+
+
+def test_cfg_logits_processor_rejects_literal_matching_added_non_special_token():
+    """Reasoning-model tokenizers commonly register tokens like `<think>` as
+    added-but-not-special (`special=False`), e.g. Qwen3-4B-Thinking, so that
+    `skip_special_tokens=True` decoding doesn't strip them. Such a token is
+    absent from `all_special_tokens` but is still emitted atomically by the
+    tokenizer, so it conflicts with a grammar literal exactly like a true
+    special token does. This is the exact scenario reported in #1771.
+    """
+    model = model_transformers()
+    model.hf_tokenizer.add_tokens(["<think>"], special_tokens=False)
+    assert "<think>" not in model.hf_tokenizer.all_special_tokens
+    backend = LLGuidanceBackend(model)
+    grammar = '?start: "<think>" "yes"'
+    with pytest.raises(ValueError, match="<think>"):
+        backend.get_cfg_logits_processor(grammar)

--- a/tests/backends/test_llguidance.py
+++ b/tests/backends/test_llguidance.py
@@ -209,3 +209,26 @@ def test_json_schema_logits_processor_rejects_whitespace_pattern():
     schema = '{"type": "object"}'
     with pytest.raises(NotImplementedError, match="whitespace_pattern"):
         backend.get_json_schema_logits_processor(schema, whitespace_pattern=" ")
+
+
+def test_cfg_logits_processor_rejects_literal_matching_special_token():
+    """A grammar literal exactly matching a special token (e.g. the `<think>`
+    tag on reasoning-model tokenizers) can make llguidance's parser fail with
+    an opaque `ParserTooComplex` error at generation time, since the model
+    may emit the literal as a single atomic special token that the parser
+    can't match against a literal-string terminal. The backend should catch
+    this at grammar-compile time instead. See #1771.
+    """
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    grammar = '?start: "<|endoftext|>" "yes"'
+    with pytest.raises(ValueError, match="<\\|endoftext\\|>"):
+        backend.get_cfg_logits_processor(grammar)
+
+
+def test_cfg_logits_processor_allows_literal_not_matching_special_token(cfg_ebnf):
+    """A grammar with no literal matching a special token compiles as usual."""
+    model = model_transformers()
+    backend = LLGuidanceBackend(model)
+    processor = backend.get_cfg_logits_processor(cfg_ebnf)
+    assert isinstance(processor, LLGuidanceLogitsProcessor)


### PR DESCRIPTION
## Problem

Fixes #1771.

A CFG literal that exactly matches one of the tokenizer's special tokens (e.g. `<think>` on reasoning-model tokenizers like Qwen3-4B-Thinking) makes llguidance's parser fail with an opaque `ParserTooComplex` error at generation time:

```
Parser Error: token "<think>[151667]" doesn't satisfy the grammar; forced bytes: got '<'; applying 'ÿ'
Stop: ParserTooComplex
```

Root cause: the grammar's literal terminal (`"<think>"`) is written for byte-level matching, but the tokenizer emits `<think>` as a single atomic token rather than as decomposable byte fragments. llguidance's parser can't reconcile an atomic token against a literal-string terminal, and bails out with a hard-to-diagnose error deep in generation.

## What this does

This doesn't attempt to fix llguidance's parser itself (that lives in a separate compiled dependency, `guidance-ai/llguidance`, and reasoning-model support there looks like a bigger design effort — the maintainer's comment on the issue mentions this is being worked on). Instead, it detects the conflict at grammar-compile time, where we have both the grammar and the tokenizer's vocabulary available, and raises a clear `ValueError` naming the conflicting literal(s) instead of letting the confusing runtime parser failure surface later during generation.

Scoped to the `Transformers` backend (where the tokenizer's vocabulary is available) since that's what's reported and what I could verify. `LlamaCpp` and `MLXLM` tokenizers expose this differently and aren't covered here.

**Update:** the initial version of this fix only checked `all_special_tokens`, which misses tokens registered with `special=False`. Reasoning-model tokenizers commonly register `<think>`/`</think>` exactly this way (verified against the real `Qwen/Qwen3-4B-Thinking-2507` tokenizer — `<think>` is absent from `all_special_tokens`) specifically so `skip_special_tokens=True` decoding doesn't strip them mid-generation, but the tokenizer still emits them atomically, bypassing ordinary BPE merging exactly like a true special token does. Without this, the guard would have silently let the original issue's exact grammar through to the same opaque `ParserTooComplex` failure it was meant to catch. The check now covers the union of `all_special_tokens` and every token in `added_tokens_decoder`, since the `special` flag only governs decode-time stripping, not which tokens bypass BPE merging.

## Testing

- Reproduced the original issue locally: built the llguidance matcher directly from the real `Qwen/Qwen3-4B-Thinking-2507` tokenizer (no model weights needed for the grammar-compile-time check — confirmed separately end-to-end with the actual model loaded too) and confirmed the exact `ParserTooComplex` failure from the issue, then confirmed the fix raises a clear `ValueError` instead.
- Added `test_cfg_logits_processor_rejects_literal_matching_special_token`, using the existing lightweight `erwanf/gpt2-mini` fixture already in this test file (its `<|endoftext|>` special token stands in for `<think>`, so the test doesn't need network access to a 4B+ model).
- Added `test_cfg_logits_processor_allows_literal_not_matching_special_token` to confirm ordinary grammars are unaffected.
- Added `test_cfg_logits_processor_rejects_literal_matching_added_non_special_token`, reproducing the added-but-not-special gap via `tokenizer.add_tokens(["<think>"], special_tokens=False)` on the same lightweight fixture — no network access to the 4B model needed here either.
- Ran the full `test_llguidance_backend[model_transformers-torch]` parametrization (the one exercising `get_cfg_logits_processor` with the existing `cfg_lark`/`cfg_ebnf` fixtures end-to-end through real generation) to confirm no regression.
- `ruff check` clean on both changed files (matches the pinned pre-commit ruff version, 0.9.1). `pre-commit run` mypy reports two pre-existing, unrelated `urllib3` stub errors in `src/outlines/exceptions.py` present identically without this change (confirmed by re-running against the base commit) — not introduced by this PR.
