### PR TITLE
Add MiniMax as a first-class API model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ print(few_shot_prompt)
 |---------|-------------|:-------------:|
 | **Server Support** | vLLM and Ollama | [Server Integrations →](https://dottxt-ai.github.io/outlines/latest/features/models/) |
 | **Local Model Support** | transformers and llama.cpp | [Model Integrations →](https://dottxt-ai.github.io/outlines/latest/features/models/) |
-| **API Support** | OpenAI, Gemini, and [Dottxt](https://h1xbpbfsf0w.typeform.com/to/fwQNWmS8?utm_source=github&utm_medium=organic&utm_campaign=outlines) | [API Integrations →](https://dottxt-ai.github.io/outlines/latest/features/models/) |
+| **API Support** | OpenAI, Gemini, MiniMax, and [Dottxt](https://h1xbpbfsf0w.typeform.com/to/fwQNWmS8?utm_source=github&utm_medium=organic&utm_campaign=outlines) | [API Integrations →](https://dottxt-ai.github.io/outlines/latest/features/models/) |
 
 ## Core Features
 

--- a/docs/features/models/index.md
+++ b/docs/features/models/index.md
@@ -120,6 +120,7 @@ The server-based models available are the following:
 - Dottxt
 - Gemini
 - LM Studio
+- MiniMax
 - Mistral
 - Ollama
 - OpenAI

--- a/docs/features/models/minimax.md
+++ b/docs/features/models/minimax.md
@@ -1,0 +1,142 @@
+# MiniMax
+
+!!! Installation
+
+    MiniMax exposes an OpenAI-compatible API, so Outlines uses the `openai` library to communicate with it. Install all optional dependencies of the `OpenAI` model with: `pip install "outlines[openai]"`.
+
+    You also need a MiniMax API key. This key must either be set as an environment variable called `OPENAI_API_KEY` or be provided to the `openai.OpenAI` class when instantiating it.
+
+## Model Initialization
+
+To create a MiniMax model instance, use the `from_minimax` function. It takes 2 arguments:
+
+- `client`: an `openai.OpenAI` or `openai.AsyncOpenAI` instance whose `base_url` is set to a MiniMax endpoint
+- `model_name`: the name of the model you want to use (optional)
+
+MiniMax provides two OpenAI-compatible regional endpoints, exposed as `MINIMAX_BASE_URLS`:
+
+- `global_en`: `https://api.minimax.io/v1`
+- `cn_zh`: `https://api.minimaxi.com/v1`
+
+For instance:
+
+```python
+import outlines
+import openai
+from outlines.models.minimax import MINIMAX_BASE_URLS
+
+# Create the client pointing at the region that matches your account
+client = openai.OpenAI(
+    api_key="MINIMAX_API_KEY",
+    base_url=MINIMAX_BASE_URLS["global_en"],
+)
+
+# Create the model
+model = outlines.from_minimax(
+    client,
+    "MiniMax-M3"
+)
+```
+
+Available models include `MiniMax-M3` (1,000,000 token context window, with text, image and video input) and `MiniMax-M2.7` (204,800 token context window, text input). Check the [MiniMax documentation](https://platform.minimax.io/docs/api-reference/api-overview) for an up-to-date list of available models.
+
+## Text Generation
+
+Once you've created your Outlines `MiniMax` model instance, you can generate text by calling the model with a prompt.
+
+```python
+import outlines
+import openai
+from outlines.models.minimax import MINIMAX_BASE_URLS
+
+model = outlines.from_minimax(
+    openai.OpenAI(base_url=MINIMAX_BASE_URLS["global_en"]),
+    "MiniMax-M3",
+)
+
+result = model("What's the capital of Latvia?", max_tokens=20)
+print(result) # 'Riga'
+```
+
+#### Vision
+
+`MiniMax-M3` supports image input. To use this feature, provide a list containing a text prompt and `Image` instances.
+
+```python
+import io
+import requests
+import PIL
+import outlines
+import openai
+from outlines.inputs import Image
+from outlines.models.minimax import MINIMAX_BASE_URLS
+
+model = outlines.from_minimax(
+    openai.OpenAI(base_url=MINIMAX_BASE_URLS["global_en"]),
+    "MiniMax-M3",
+)
+
+def get_image(url):
+    r = requests.get(url)
+    return PIL.Image.open(io.BytesIO(r.content))
+
+prompt = [
+    "Describe the image",
+    Image(get_image("https://picsum.photos/id/237/400/300"))
+]
+
+response = model(prompt, max_tokens=50)
+print(response)
+```
+
+#### Video
+
+`MiniMax-M3` also supports video input. Provide a list containing a text prompt and `Video` instances holding the URL of the video to analyze.
+
+```python
+import outlines
+import openai
+from outlines.inputs import Video
+from outlines.models.minimax import MINIMAX_BASE_URLS
+
+model = outlines.from_minimax(
+    openai.OpenAI(base_url=MINIMAX_BASE_URLS["global_en"]),
+    "MiniMax-M3",
+)
+
+prompt = [
+    "Describe the video",
+    Video("https://example.com/clip.mp4"),
+]
+
+response = model(prompt, max_tokens=50)
+print(response)
+```
+
+## Structured Generation
+
+MiniMax uses the same OpenAI-compatible `response_format` payload as the `OpenAI` model, so JSON schema and JSON mode structured outputs are supported. Regex and grammar-based output types are not available.
+
+```python
+import outlines
+import openai
+from pydantic import BaseModel
+from outlines.models.minimax import MINIMAX_BASE_URLS
+
+class Character(BaseModel):
+    name: str
+    age: int
+
+model = outlines.from_minimax(
+    openai.OpenAI(base_url=MINIMAX_BASE_URLS["global_en"]),
+    "MiniMax-M3",
+)
+
+result = model("Create a character.", Character)
+print(result) # '{"name": "Aurora", "age": 34}'
+```
+
+## Related Documentation
+
+- [OpenAI](./openai.md): the OpenAI model that MiniMax builds upon
+- [OpenAI compatible API](./openai_compatible.md): details on OpenAI-compatible APIs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
                     - Gemini: features/models/gemini.md
                     - Llamacpp: features/models/llamacpp.md
                     - LM Studio: features/models/lmstudio.md
+                    - MiniMax: features/models/minimax.md
                     - Mlx-lm: features/models/mlxlm.md
                     - Ollama: features/models/ollama.md
                     - OpenAI: features/models/openai.md

--- a/src/outlines/exceptions.py
+++ b/src/outlines/exceptions.py
@@ -245,7 +245,7 @@ def _build_exception_map(provider: str) -> dict[type, type[APIError]]:
 
 
 def _provider_exception_map(provider: str) -> dict[type, type[APIError]]:
-    if provider in ("openai", "vllm", "sglang"):  # vLLM and SGLang use the OpenAI SDK client
+    if provider in ("openai", "vllm", "sglang", "minimax"):  # vLLM, SGLang and MiniMax use the OpenAI SDK client
         import openai
         return {
             openai.AuthenticationError: AuthenticationError,

--- a/src/outlines/models/__init__.py
+++ b/src/outlines/models/__init__.py
@@ -14,6 +14,7 @@ from .dottxt import AsyncDottxt, Dottxt, from_dottxt
 from .gemini import Gemini, from_gemini
 from .llamacpp import LlamaCpp, from_llamacpp
 from .lmstudio import AsyncLMStudio, LMStudio, from_lmstudio
+from .minimax import AsyncMiniMax, MiniMax, from_minimax
 from .mistral import AsyncMistral, Mistral, from_mistral
 from .mlxlm import MLXLM, from_mlxlm
 from .ollama import AsyncOllama, Ollama, from_ollama
@@ -35,6 +36,7 @@ BlackBoxModel = Union[
     Dottxt,
     Gemini,
     LMStudio,
+    MiniMax,
     Ollama,
     OpenAI,
     Mistral,
@@ -46,6 +48,7 @@ BlackBoxModel = Union[
 AsyncBlackBoxModel = Union[
     AsyncDottxt,
     AsyncLMStudio,
+    AsyncMiniMax,
     AsyncMistral,
     AsyncOllama,
     AsyncOpenAI,
@@ -70,6 +73,9 @@ __all__ = [
     "AsyncLMStudio",
     "LMStudio",
     "from_lmstudio",
+    "AsyncMiniMax",
+    "MiniMax",
+    "from_minimax",
     "AsyncMistral",
     "Mistral",
     "from_mistral",

--- a/src/outlines/models/minimax.py
+++ b/src/outlines/models/minimax.py
@@ -1,0 +1,486 @@
+"""Integration with MiniMax's API.
+
+MiniMax exposes an OpenAI-compatible chat completions API, so this module
+wraps the ``openai`` Python SDK and points it at a MiniMax endpoint. Two
+regional endpoints are available and share the same request format:
+
+* ``global_en`` -- ``https://api.minimax.io/v1``
+* ``cn_zh`` -- ``https://api.minimaxi.com/v1``
+
+The base URLs are exposed as :data:`MINIMAX_BASE_URLS` so callers can select a
+region when instantiating their ``openai`` client.
+
+Available models include ``MiniMax-M3`` (1,000,000 token context window, with
+text, image and video input) and ``MiniMax-M2.7`` (204,800 token context
+window, text input). ``MiniMaxTypeAdapter`` formats text, image and video
+inputs into the content parts expected by the OpenAI-compatible endpoint.
+"""
+
+from functools import singledispatchmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Iterator,
+    Optional,
+    Union,
+)
+
+from outlines.exceptions import GenerationError, normalize_provider_errors
+from outlines.inputs import Chat, Image, Video
+from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
+from outlines.models.openai import OpenAITypeAdapter
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI, OpenAI
+
+PROVIDER = "minimax"
+
+__all__ = ["AsyncMiniMax", "MiniMax", "from_minimax", "MINIMAX_BASE_URLS"]
+
+# OpenAI-compatible base URLs for each MiniMax region. Point your `openai`
+# client at the endpoint that matches your account region.
+MINIMAX_BASE_URLS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+
+
+class MiniMaxTypeAdapter(ModelTypeAdapter):
+    """Type adapter for the `MiniMax` and `AsyncMiniMax` models.
+
+    `MiniMaxTypeAdapter` prepares the `messages` argument to the MiniMax
+    chat completions endpoint. It reuses the OpenAI output-type formatting
+    (JSON schema and JSON mode) and adds support for image and video assets
+    in addition to text prompts.
+
+    """
+
+    @singledispatchmethod
+    def format_input(self, model_input):
+        """Generate the `messages` argument to pass to the client.
+
+        Parameters
+        ----------
+        model_input
+            The input provided by the user.
+
+        Returns
+        -------
+        list
+            The formatted input to be passed to the client.
+
+        """
+        raise TypeError(
+            f"The input type {type(model_input)} is not available with "
+            "MiniMax. The only available types are `str`, `list` and `Chat`."
+        )
+
+    @format_input.register(str)
+    def format_str_model_input(self, model_input: str) -> list:
+        """Format a text-only prompt."""
+        return [self._create_message("user", model_input)]
+
+    @format_input.register(list)
+    def format_list_model_input(self, model_input: list) -> list:
+        """Format a prompt provided along with image and/or video assets."""
+        return [self._create_message("user", model_input)]
+
+    @format_input.register(Chat)
+    def format_chat_model_input(self, model_input: Chat) -> list:
+        """Format a `Chat` instance into a list of messages."""
+        return [
+            self._create_message(message["role"], message["content"])
+            for message in model_input.messages
+        ]
+
+    def _create_message(self, role: str, content: Union[str, list]) -> dict:
+        """Create a message, expanding image and video assets into content
+        parts.
+
+        """
+        if isinstance(content, str):
+            return {
+                "role": role,
+                "content": content,
+            }
+
+        elif isinstance(content, list):
+            prompt = content[0]
+            assets = content[1:]
+
+            if not all(
+                isinstance(asset, (Image, Video)) for asset in assets
+            ):
+                raise ValueError(
+                    "All assets provided must be of type Image or Video"
+                )
+
+            asset_parts = [
+                self._create_asset_content(asset) for asset in assets
+            ]
+
+            return {
+                "role": role,
+                "content": [
+                    {"type": "text", "text": prompt},
+                    *asset_parts,
+                ],
+            }
+
+        else:
+            raise ValueError(
+                f"Invalid content type: {type(content)}. "
+                "The content must be a string or a list containing a string "
+                "and a list of image and/or video assets."
+            )
+
+    def _create_asset_content(self, asset: Union[Image, Video]) -> dict:
+        """Create the content part for an image or video asset."""
+        if isinstance(asset, Image):
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{asset.image_format};base64,{asset.image_str}"  # noqa: E501
+                },
+            }
+        else:  # Video
+            return {
+                "type": "video_url",
+                "video_url": {"url": asset.video},
+            }
+
+    def format_output_type(self, output_type: Optional[Any] = None) -> dict:
+        """Generate the `response_format` argument to pass to the client.
+
+        MiniMax uses the same OpenAI-compatible `response_format` payload,
+        so the OpenAI output-type formatting is reused as-is.
+
+        Parameters
+        ----------
+        output_type
+            The output type provided by the user.
+
+        Returns
+        -------
+        dict
+            The formatted output type to be passed to the client.
+
+        """
+        return OpenAITypeAdapter().format_output_type(output_type)
+
+
+class MiniMax(Model):
+    """Thin wrapper around the `openai.OpenAI` client configured for MiniMax.
+
+    This wrapper is used to convert the input and output types specified by
+    the users at a higher level to arguments to the `openai.OpenAI` client
+    pointed at a MiniMax endpoint.
+
+    """
+
+    def __init__(self, client, model_name: Optional[str] = None):
+        """
+        Parameters
+        ----------
+        client
+            An `openai.OpenAI` client instance whose `base_url` is set to a
+            MiniMax endpoint (see `MINIMAX_BASE_URLS`).
+        model_name
+            The name of the model to use, e.g. `"MiniMax-M3"`.
+
+        """
+        self.client = client
+        self.model_name = model_name
+        self.type_adapter = MiniMaxTypeAdapter()
+
+    def generate(
+        self,
+        model_input: Union[Chat, list, str],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> Union[str, list[str]]:
+        """Generate text using MiniMax.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The desired format of the response generated by the model.
+        **inference_kwargs
+            Additional keyword arguments to pass to the client.
+
+        Returns
+        -------
+        Union[str, list[str]]
+            The text generated by the model.
+
+        """
+        client_args = self._build_client_args(
+            model_input, output_type, **inference_kwargs,
+        )
+
+        with normalize_provider_errors(PROVIDER):
+            response = self.client.chat.completions.create(**client_args)
+
+        messages = [choice.message for choice in response.choices]
+        for message in messages:
+            if message.refusal is not None:  # pragma: no cover
+                raise GenerationError(
+                    f"MiniMax refused to answer the request: "
+                    f"{message.refusal}",
+                    provider=PROVIDER,
+                )
+
+        if len(messages) == 1:
+            return messages[0].content
+        else:
+            return [message.content for message in messages]
+
+    def generate_batch(
+        self,
+        model_input,
+        output_type=None,
+        **inference_kwargs,
+    ):
+        raise NotImplementedError(
+            "MiniMax does not support batch inference."
+        )
+
+    def generate_stream(
+        self,
+        model_input: Union[Chat, list, str],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> Iterator[str]:
+        """Stream text using MiniMax.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The desired format of the response generated by the model.
+        **inference_kwargs
+            Additional keyword arguments to pass to the client.
+
+        Returns
+        -------
+        Iterator[str]
+            An iterator that yields the text generated by the model.
+
+        """
+        client_args = self._build_client_args(
+            model_input, output_type, **inference_kwargs,
+        )
+
+        with normalize_provider_errors(PROVIDER):
+            stream = self.client.chat.completions.create(
+                **client_args, stream=True,
+            )
+            for chunk in stream:  # pragma: no cover
+                if chunk.choices and chunk.choices[0].delta.content is not None:
+                    yield chunk.choices[0].delta.content
+
+    def _build_client_args(
+        self,
+        model_input: Union[Chat, str, list],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> dict:
+        """Build the arguments to pass to the MiniMax client."""
+        messages = self.type_adapter.format_input(model_input)
+        output_type_args = self.type_adapter.format_output_type(output_type)
+        inference_kwargs.update(output_type_args)
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
+
+        return {
+            "messages": messages,
+            **inference_kwargs,
+        }
+
+
+class AsyncMiniMax(AsyncModel):
+    """Thin async wrapper around the `openai.AsyncOpenAI` client configured
+    for MiniMax.
+
+    This wrapper is used to convert the input and output types specified by
+    the users at a higher level to arguments to the `openai.AsyncOpenAI`
+    client pointed at a MiniMax endpoint.
+
+    """
+
+    def __init__(self, client, model_name: Optional[str] = None):
+        """
+        Parameters
+        ----------
+        client
+            An `openai.AsyncOpenAI` client instance whose `base_url` is set to
+            a MiniMax endpoint (see `MINIMAX_BASE_URLS`).
+        model_name
+            The name of the model to use, e.g. `"MiniMax-M3"`.
+
+        """
+        self.client = client
+        self.model_name = model_name
+        self.type_adapter = MiniMaxTypeAdapter()
+
+    async def generate(
+        self,
+        model_input: Union[Chat, str, list],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> Union[str, list[str]]:
+        """Generate text using MiniMax asynchronously.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The desired format of the response generated by the model.
+        **inference_kwargs
+            Additional keyword arguments to pass to the client.
+
+        Returns
+        -------
+        Union[str, list[str]]
+            The text generated by the model.
+
+        """
+        client_args = self._build_client_args(
+            model_input, output_type, **inference_kwargs,
+        )
+
+        with normalize_provider_errors(PROVIDER):
+            response = await self.client.chat.completions.create(
+                **client_args
+            )
+
+        messages = [choice.message for choice in response.choices]
+        for message in messages:
+            if message.refusal is not None:  # pragma: no cover
+                raise GenerationError(
+                    f"MiniMax refused to answer the request: "
+                    f"{message.refusal}",
+                    provider=PROVIDER,
+                )
+
+        if len(messages) == 1:
+            return messages[0].content
+        else:
+            return [message.content for message in messages]
+
+    async def generate_batch(
+        self,
+        model_input,
+        output_type=None,
+        **inference_kwargs,
+    ):
+        raise NotImplementedError(
+            "MiniMax does not support batch inference."
+        )
+
+    async def generate_stream(  # type: ignore
+        self,
+        model_input: Union[Chat, str, list],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Stream text using MiniMax asynchronously.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The desired format of the response generated by the model.
+        **inference_kwargs
+            Additional keyword arguments to pass to the client.
+
+        Returns
+        -------
+        AsyncIterator[str]
+            An async iterator that yields the text generated by the model.
+
+        """
+        client_args = self._build_client_args(
+            model_input, output_type, **inference_kwargs,
+        )
+
+        with normalize_provider_errors(PROVIDER):
+            stream = await self.client.chat.completions.create(
+                **client_args, stream=True,
+            )
+            async for chunk in stream:  # pragma: no cover
+                if chunk.choices and chunk.choices[0].delta.content is not None:
+                    yield chunk.choices[0].delta.content
+
+    def _build_client_args(
+        self,
+        model_input: Union[Chat, str, list],
+        output_type: Optional[Any] = None,
+        **inference_kwargs: Any,
+    ) -> dict:
+        """Build the arguments to pass to the MiniMax client."""
+        messages = self.type_adapter.format_input(model_input)
+        output_type_args = self.type_adapter.format_output_type(output_type)
+        inference_kwargs.update(output_type_args)
+
+        if "model" not in inference_kwargs and self.model_name is not None:
+            inference_kwargs["model"] = self.model_name
+
+        return {
+            "messages": messages,
+            **inference_kwargs,
+        }
+
+
+def from_minimax(
+    client: Union["OpenAI", "AsyncOpenAI"],
+    model_name: Optional[str] = None,
+) -> Union[MiniMax, AsyncMiniMax]:
+    """Create a `MiniMax` or `AsyncMiniMax` instance from an `openai.OpenAI`
+    or `openai.AsyncOpenAI` instance.
+
+    MiniMax exposes an OpenAI-compatible API, so an `openai` client pointed at
+    a MiniMax endpoint is used. To get started::
+
+        import openai
+        import outlines
+        from outlines.models.minimax import MINIMAX_BASE_URLS
+
+        client = openai.OpenAI(
+            api_key="MINIMAX_API_KEY",
+            base_url=MINIMAX_BASE_URLS["global_en"],
+        )
+        model = outlines.from_minimax(client, "MiniMax-M3")
+
+    Parameters
+    ----------
+    client
+        An `openai.OpenAI` or `openai.AsyncOpenAI` instance whose `base_url`
+        is set to a MiniMax endpoint (see `MINIMAX_BASE_URLS`).
+    model_name
+        The name of the model to use, e.g. `"MiniMax-M3"` or `"MiniMax-M2.7"`.
+
+    Returns
+    -------
+    Union[MiniMax, AsyncMiniMax]
+        An Outlines `MiniMax` or `AsyncMiniMax` model instance.
+
+    """
+    from openai import AsyncOpenAI, OpenAI
+
+    if isinstance(client, OpenAI):
+        return MiniMax(client, model_name)
+    elif isinstance(client, AsyncOpenAI):
+        return AsyncMiniMax(client, model_name)
+    else:
+        raise ValueError(
+            f"Unsupported client type: {type(client)}.\n"
+            "Please provide an OpenAI or AsyncOpenAI instance."
+        )

--- a/tests/models/test_minimax.py
+++ b/tests/models/test_minimax.py
@@ -1,0 +1,235 @@
+import io
+import warnings
+from typing import AsyncGenerator, Generator
+
+import pytest
+from PIL import Image as PILImage
+from openai import AsyncOpenAI, OpenAI
+
+from outlines.inputs import Chat, Image, Video
+from outlines.models.minimax import (
+    AsyncMiniMax,
+    MiniMax,
+    MINIMAX_BASE_URLS,
+    from_minimax,
+)
+from outlines.types import JsonSchema
+from tests.test_utils.mock_openai_client import (
+    MockAsyncOpenAIClient,
+    MockOpenAIClient,
+)
+
+
+MODEL_NAME = "MiniMax-M3"
+
+# Image for testing
+width, height = 1, 1
+white_background = (255, 255, 255)
+image = PILImage.new("RGB", (width, height), white_background)
+buffer = io.BytesIO()
+image.save(buffer, format="PNG")
+buffer.seek(0)
+image = PILImage.open(buffer)
+image_input = Image(image)
+
+
+openai_client = MockOpenAIClient()
+async_openai_client = MockAsyncOpenAIClient()
+
+mock_responses = [
+    (
+        {
+            'messages': [
+                {'role': "user", 'content': 'Respond with a single word.'}
+            ],
+            'model': MODEL_NAME,
+        },
+        "foo"
+    ),
+    (
+        {
+            'messages': [
+                {'role': "user", 'content': 'Respond with a single word.'}
+            ],
+            'model': MODEL_NAME,
+            'stream': True
+        },
+        ["foo", "bar"]
+    ),
+    (
+        {
+            'messages': [
+                {'role': "user", 'content': 'Respond with a single word.'}
+            ],
+            'n': 2,
+            'model': MODEL_NAME,
+        },
+        ["foo", "bar"]
+    ),
+    (
+        {
+            'messages': [{'role': "user", 'content': 'foo?'}],
+            'model': MODEL_NAME,
+            'max_tokens': 10,
+            'response_format': {
+                'type': 'json_schema',
+                'json_schema': {
+                    'name': 'default',
+                    'strict': True,
+                    'schema': {
+                        'type': 'object',
+                        'properties': {'bar': {'type': 'string'}},
+                        'additionalProperties': False
+                    }
+                }
+            }
+        },
+        '{"bar": "baz"}'
+    ),
+    (
+        {
+            'messages': [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{image_input.image_str}"
+                            },
+                        },
+                    ]
+                }
+            ],
+            'model': MODEL_NAME,
+            'max_tokens': 10,
+        },
+        "foo"
+    ),
+    (
+        {
+            'messages': [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "video_url",
+                            "video_url": {
+                                "url": "https://example.com/clip.mp4"
+                            },
+                        },
+                    ]
+                }
+            ],
+            'model': MODEL_NAME,
+            'max_tokens': 10,
+        },
+        "foo"
+    ),
+]
+
+async_openai_client.add_mock_responses(mock_responses)
+openai_client.add_mock_responses(mock_responses)
+
+
+@pytest.fixture
+def sync_model():
+    return MiniMax(openai_client, model_name=MODEL_NAME)
+
+
+@pytest.fixture
+def async_model():
+    return AsyncMiniMax(async_openai_client, model_name=MODEL_NAME)
+
+
+def test_minimax_base_urls():
+    # Both regional endpoints must be exposed.
+    assert MINIMAX_BASE_URLS["global_en"] == "https://api.minimax.io/v1"
+    assert MINIMAX_BASE_URLS["cn_zh"] == "https://api.minimaxi.com/v1"
+
+
+def test_minimax_init_from_client():
+    # We do not rely on the mock server here because we need an object
+    # of type OpenAI and AsyncOpenAI to test the init function.
+    client = OpenAI(
+        base_url=MINIMAX_BASE_URLS["global_en"], api_key="foo"
+    )
+    async_client = AsyncOpenAI(
+        base_url=MINIMAX_BASE_URLS["cn_zh"], api_key="foo"
+    )
+
+    model = from_minimax(client, MODEL_NAME)
+    assert isinstance(model, MiniMax)
+    assert model.client == client
+    assert model.model_name == MODEL_NAME
+
+    model = from_minimax(client)
+    assert isinstance(model, MiniMax)
+    assert model.model_name is None
+
+    model = from_minimax(async_client, MODEL_NAME)
+    assert isinstance(model, AsyncMiniMax)
+    assert model.client == async_client
+    assert model.model_name == MODEL_NAME
+
+    with pytest.raises(ValueError, match="Unsupported client type"):
+        from_minimax("foo")
+
+
+def test_minimax_sync_simple_call(sync_model):
+    result = sync_model("Respond with a single word.")
+    assert isinstance(result, str)
+    assert result == "foo"
+
+
+def test_minimax_sync_multiple_samples(sync_model):
+    result = sync_model("Respond with a single word.", n=2)
+    assert isinstance(result, list)
+    assert result == ["foo", "bar"]
+
+
+def test_minimax_sync_streaming(sync_model):
+    result = sync_model.stream("Respond with a single word.")
+    assert isinstance(result, Generator)
+    assert isinstance(next(result), str)
+
+
+def test_minimax_sync_json_schema(sync_model):
+    schema = JsonSchema(
+        '{"type": "object", "properties": {"bar": {"type": "string"}}}'
+    )
+    result = sync_model("foo?", schema, max_tokens=10)
+    assert result == '{"bar": "baz"}'
+
+
+def test_minimax_sync_vision(sync_model):
+    result = sync_model(["hello", image_input], max_tokens=10)
+    assert result == "foo"
+
+
+def test_minimax_sync_video(sync_model):
+    video_input = Video("https://example.com/clip.mp4")
+    result = sync_model(["describe", video_input], max_tokens=10)
+    assert result == "foo"
+
+
+def test_minimax_batch_not_supported(sync_model):
+    with pytest.raises(NotImplementedError, match="batch inference"):
+        sync_model.batch(["foo", "bar"])
+
+
+@pytest.mark.asyncio
+async def test_minimax_async_simple_call(async_model):
+    result = await async_model("Respond with a single word.")
+    assert isinstance(result, str)
+    assert result == "foo"
+
+
+@pytest.mark.asyncio
+async def test_minimax_async_streaming(async_model):
+    result = async_model.stream("Respond with a single word.")
+    assert isinstance(result, AsyncGenerator)
+    async for chunk in result:
+        assert isinstance(chunk, str)

--- a/tests/models/test_minimax_type_adapter.py
+++ b/tests/models/test_minimax_type_adapter.py
@@ -1,0 +1,200 @@
+import io
+import json
+
+import pytest
+from dataclasses import dataclass
+
+from PIL import Image as PILImage
+
+from outlines.inputs import Chat, Image, Video
+from outlines.models.minimax import MiniMaxTypeAdapter
+from outlines.types import CFG, JsonSchema, Regex
+
+
+CFG_STRING = """
+?start: expr
+?expr: NUMBER
+"""
+
+JSON_SCHEMA_STRING = """
+{
+    "type": "object",
+    "properties": {
+        "answer": {"type": "number"}
+    }
+}
+"""
+
+
+@pytest.fixture
+def type_adapter():
+    return MiniMaxTypeAdapter()
+
+
+@pytest.fixture
+def cfg_instance():
+    return CFG(CFG_STRING)
+
+
+@pytest.fixture
+def json_schema_instance():
+    return JsonSchema(JSON_SCHEMA_STRING)
+
+
+@pytest.fixture
+def image():
+    width, height = 1, 1
+    white_background = (255, 255, 255)
+    image = PILImage.new("RGB", (width, height), white_background)
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+    image = PILImage.open(buffer)
+
+    return image
+
+
+def test_minimax_type_adapter_input_text(type_adapter):
+    message = "prompt"
+    result = type_adapter.format_input(message)
+    assert result == [{"role": "user", "content": message}]
+
+
+def test_minimax_type_adapter_input_vision(type_adapter, image):
+    image_input = Image(image)
+    result = type_adapter.format_input(["hello", image_input])
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image_input.image_str}"
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def test_minimax_type_adapter_input_video(type_adapter):
+    video_input = Video("https://example.com/clip.mp4")
+    result = type_adapter.format_input(["describe", video_input])
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "https://example.com/clip.mp4"},
+                },
+            ],
+        }
+    ]
+
+
+def test_minimax_type_adapter_input_image_and_video(type_adapter, image):
+    image_input = Image(image)
+    video_input = Video("https://example.com/clip.mp4")
+    result = type_adapter.format_input(["hello", image_input, video_input])
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image_input.image_str}"
+                    },
+                },
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "https://example.com/clip.mp4"},
+                },
+            ],
+        }
+    ]
+
+
+def test_minimax_type_adapter_input_chat(type_adapter, image):
+    image_input = Image(image)
+    model_input = Chat(messages=[
+        {"role": "system", "content": "prompt"},
+        {"role": "user", "content": [
+            "hello",
+            image_input,
+        ]},
+        {"role": "assistant", "content": "response"},
+    ])
+    result = type_adapter.format_input(model_input)
+    assert result == [
+        {"role": "system", "content": "prompt"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image_input.image_str}"
+                    },
+                },
+            ],
+        },
+        {"role": "assistant", "content": "response"},
+    ]
+
+
+def test_minimax_type_adapter_input_invalid(type_adapter):
+    @dataclass
+    class Audio:
+        file: str
+
+    prompt = Audio("file")
+    with pytest.raises(TypeError, match="The input type"):
+        _ = type_adapter.format_input(prompt)
+
+
+def test_minimax_type_adapter_input_invalid_asset(type_adapter):
+    with pytest.raises(
+        ValueError, match="must be of type Image or Video"
+    ):
+        _ = type_adapter.format_input(["hello", "not an asset"])
+
+
+def test_minimax_type_adapter_output_type(
+    type_adapter,
+    cfg_instance,
+    json_schema_instance,
+):
+    assert type_adapter.format_output_type(None) == {}
+    assert type_adapter.format_output_type(json_schema_instance) == {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "default",
+                "strict": True,
+                "schema": {
+                    **json.loads(JSON_SCHEMA_STRING),
+                    "additionalProperties": False,
+                },
+            },
+        }
+    }
+    assert type_adapter.format_output_type(dict) == {
+        "response_format": {"type": "json_object"}
+    }
+
+
+def test_minimax_type_adapter_output_type_unsupported(
+    type_adapter, cfg_instance
+):
+    with pytest.raises(TypeError, match="Neither regex-based"):
+        type_adapter.format_output_type(Regex(r"[0-9]{3}"))
+    with pytest.raises(TypeError, match="CFG-based structured outputs"):
+        type_adapter.format_output_type(cfg_instance)


### PR DESCRIPTION
Reason: Outlines has first-class API model adapters but no MiniMax adapter.

## Summary

Adds MiniMax as a first-class API model provider. MiniMax exposes an
OpenAI-compatible chat completions API, so `MiniMax` / `AsyncMiniMax` wrap the
`openai` SDK, mirroring the existing `SGLang` and `OpenAI` integrations.

## Changes

- `src/outlines/models/minimax.py`: new `MiniMax`, `AsyncMiniMax`,
  `from_minimax`, and `MiniMaxTypeAdapter`.
  - `MiniMaxTypeAdapter` formats text, image and video inputs into the content
    parts expected by the OpenAI-compatible endpoint, and reuses the OpenAI
    `response_format` handling for JSON schema / JSON mode structured outputs.
  - `MINIMAX_BASE_URLS` exposes both regional OpenAI-compatible endpoints
    (global `https://api.minimax.io/v1` and cn `https://api.minimaxi.com/v1`)
    so callers select the region on their `openai` client.
- `src/outlines/models/__init__.py`: register `MiniMax` / `AsyncMiniMax` /
  `from_minimax` in the package and the `BlackBoxModel` / `AsyncBlackBoxModel`
  unions.
- `src/outlines/exceptions.py`: route MiniMax through the OpenAI SDK exception
  map (it uses the `openai` client), matching vLLM and SGLang.
- Docstrings and docs document `MiniMax-M3` (1,000,000 token context window;
  text, image and video input) and `MiniMax-M2.7` (204,800 token context
  window; text input).
- `tests/models/test_minimax.py` and
  `tests/models/test_minimax_type_adapter.py`: unit tests for the model
  wrappers (mocked client) and the type adapter, including image and video
  inputs and structured output formatting.
- Docs: new `docs/features/models/minimax.md`, mkdocs nav entry, README API
  support line and the model index list.

## Testing

- `ruff check --config=pyproject.toml` (repo-pinned ruff 0.9.1) on all changed
  Python files: passes.
- `pytest tests/models/test_minimax.py tests/models/test_minimax_type_adapter.py`:
  20 passed.
- `pytest tests/models/test_openai_type_adapter.py tests/models/test_sglang_type_adapter.py`:
  passes (regression on the reused OpenAI formatting).
