### PR TITLE
fix(types): map additionalProperties objects to Dict instead of a generated model

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -78,12 +78,14 @@ def schema_type_to_python(
         # class with no fields and drop the value type, so map it to `Dict[str, V]`.
         if "properties" not in schema and "additionalProperties" in schema:
             additional = schema["additionalProperties"]
-            if additional is True:
-                return Dict[str, Any]  # type: ignore
-            if additional is False:
-                return Dict[str, Any]  # type: ignore
-            value_type = schema_type_to_python(additional, caller_target_type)
-            return Dict[str, value_type]  # type: ignore
+            # `additionalProperties: false` is the opposite of a free-form mapping: it
+            # forbids every key, so the only valid instance is `{}`. Fall through to the
+            # model path, which builds a field-less model, rather than widening it.
+            if additional is not False:
+                if additional is True:
+                    return Dict[str, Any]  # type: ignore
+                value_type = schema_type_to_python(additional, caller_target_type)
+                return Dict[str, value_type]  # type: ignore
 
         name = schema.get("title")
         if caller_target_type == "pydantic":

--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -73,6 +73,18 @@ def schema_type_to_python(
             item_type = Any
         return List[item_type]  # type: ignore
     elif t == "object":
+        # A mapping is an object with `additionalProperties` and no `properties`; that's
+        # what Pydantic emits for `Dict[str, V]`. Building a model out of it would give a
+        # class with no fields and drop the value type, so map it to `Dict[str, V]`.
+        if "properties" not in schema and "additionalProperties" in schema:
+            additional = schema["additionalProperties"]
+            if additional is True:
+                return Dict[str, Any]  # type: ignore
+            if additional is False:
+                return Dict[str, Any]  # type: ignore
+            value_type = schema_type_to_python(additional, caller_target_type)
+            return Dict[str, value_type]  # type: ignore
+
         name = schema.get("title")
         if caller_target_type == "pydantic":
             return json_schema_dict_to_pydantic(schema, name)

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -1,7 +1,9 @@
+import dataclasses
 import sys
 from dataclasses import is_dataclass
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union, get_type_hints
 
+import pytest
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticUndefined
 
@@ -415,3 +417,82 @@ def test_json_schema_dict_to_dataclass_optional_before_required():
     instance = result(user_id=5)
     assert instance.user_id == 5
     assert instance.nickname is None
+
+
+def test_json_schema_dict_to_pydantic_mapping():
+    """`{"type": "object", "additionalProperties": S}` is a mapping, not a model."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "by_user": {"type": "object", "additionalProperties": {"type": "integer"}},
+        },
+        "required": ["by_user"],
+    }
+    model = json_schema_dict_to_pydantic(schema)
+    assert model.model_fields["by_user"].annotation == Dict[str, int]
+
+
+def test_json_schema_dict_to_typeddict_mapping():
+    schema = {
+        "type": "object",
+        "properties": {
+            "by_user": {"type": "object", "additionalProperties": {"type": "string"}},
+        },
+        "required": ["by_user"],
+    }
+    assert get_type_hints(json_schema_dict_to_typeddict(schema))["by_user"] == Dict[str, str]
+
+
+def test_json_schema_dict_to_dataclass_mapping():
+    schema = {
+        "type": "object",
+        "properties": {
+            "by_user": {"type": "object", "additionalProperties": {"type": "number"}},
+        },
+        "required": ["by_user"],
+    }
+    fields = {f.name: f.type for f in dataclasses.fields(json_schema_dict_to_dataclass(schema))}
+    assert fields["by_user"] == Dict[str, float]
+
+
+@pytest.mark.parametrize("additional", [True, False])
+def test_mapping_with_boolean_additional_properties(additional):
+    """A boolean `additionalProperties` carries no value type, so the values are `Any`."""
+    schema = {
+        "type": "object",
+        "properties": {"m": {"type": "object", "additionalProperties": additional}},
+        "required": ["m"],
+    }
+    model = json_schema_dict_to_pydantic(schema)
+    assert model.model_fields["m"].annotation == Dict[str, Any]
+
+
+def test_object_with_properties_is_still_a_model():
+    """`properties` wins: an object that declares fields keeps being converted to a model."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "nested": {
+                "type": "object",
+                "title": "Nested",
+                "properties": {"v": {"type": "integer"}},
+                "required": ["v"],
+                "additionalProperties": False,
+            },
+        },
+        "required": ["nested"],
+    }
+    model = json_schema_dict_to_pydantic(schema)
+    nested = model.model_fields["nested"].annotation
+    assert issubclass(nested, BaseModel)
+    assert nested.model_fields["v"].annotation is int
+
+
+def test_pydantic_dict_field_round_trips():
+    """End to end: a `Dict[str, int]` field survives the JSON-Schema round trip."""
+
+    class Scores(BaseModel):
+        by_user: Dict[str, int] = {}
+
+    model = json_schema_dict_to_pydantic(Scores.model_json_schema())
+    assert model.model_fields["by_user"].annotation == Optional[Dict[str, int]]

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -455,16 +455,33 @@ def test_json_schema_dict_to_dataclass_mapping():
     assert fields["by_user"] == Dict[str, float]
 
 
-@pytest.mark.parametrize("additional", [True, False])
-def test_mapping_with_boolean_additional_properties(additional):
-    """A boolean `additionalProperties` carries no value type, so the values are `Any`."""
+def test_mapping_with_additional_properties_true():
+    """`additionalProperties: true` is a free-form mapping with no value type."""
     schema = {
         "type": "object",
-        "properties": {"m": {"type": "object", "additionalProperties": additional}},
+        "properties": {"m": {"type": "object", "additionalProperties": True}},
         "required": ["m"],
     }
     model = json_schema_dict_to_pydantic(schema)
     assert model.model_fields["m"].annotation == Dict[str, Any]
+
+
+def test_additional_properties_false_is_not_a_mapping():
+    """`additionalProperties: false` forbids every key, so `{}` is the only instance.
+
+    Mapping it to `Dict[str, Any]` would accept arbitrary keys, which is the
+    opposite of what the schema says.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"m": {"type": "object", "additionalProperties": False}},
+        "required": ["m"],
+    }
+    model = json_schema_dict_to_pydantic(schema)
+    inner = model.model_fields["m"].annotation
+    assert inner != Dict[str, Any]
+    assert issubclass(inner, BaseModel)
+    assert list(inner.model_fields) == []
 
 
 def test_object_with_properties_is_still_a_model():


### PR DESCRIPTION
Closes #1969.

`schema_type_to_python` routes every `{"type": "object"}` to one of the `json_schema_dict_to_*` builders, so the shape Pydantic emits for `Dict[str, V]` is turned into a model:

```python
class Scores(BaseModel):
    by_user: Dict[str, int] = {}

Scores.model_json_schema()["properties"]["by_user"]
# {"additionalProperties": {"type": "integer"}, "default": {}, "title": "By User", "type": "object"}
```

| converter | before | after |
|---|---|---|
| `json_schema_dict_to_pydantic` | `Optional[...By User]` | `Optional[Dict[str, int]]` |
| `json_schema_dict_to_typeddict` | `NotRequired[...By User]` | `NotRequired[Dict[str, int]]` |
| `json_schema_dict_to_dataclass` | `<class '...By User'>` | `Dict[str, int]` |

The generated class had no fields, so `int` was gone as well, and its name came from `title` — `"By User".isidentifier()` is `False`.

The change detects the mapping shape (`additionalProperties` present, `properties` absent) and returns `Dict[str, V]`. A boolean `additionalProperties` carries no value type, so `True`/`False` both give `Dict[str, Any]`.

Objects that declare `properties` keep going down the model path, including the `properties` + `additionalProperties: False` combination Pydantic emits for `extra="forbid"` — there's a test pinning that so the branch order can't be flipped later.

Tests in `tests/types/test_json_schema_utils.py`: one per converter, a parametrised pair for boolean `additionalProperties`, an end-to-end round trip from a real `BaseModel`, and the `properties`-wins case. Stashing only `json_schema_utils.py` gives `6 failed, 24 passed`; with the change, `30 passed`.

`ruff --config=pyproject.toml` on ruff 0.16.0 reports 35 findings on these two files before the change and 46 after — the 11 new ones are all `UP006`/`UP035` for `Dict[...]`, the same rules the file already trips on its existing `Dict`/`List`/`Optional` usage. I kept the existing style rather than mixing `dict[...]` into it; happy to switch both if you'd rather move the file over.

Separately, the four open PRs against `schema_type_to_python` (#1908, #1949, #1951, #1963) all leave `additionalProperties` alone — I ran this repro against each of them — so this shouldn't collide with any of them.