### PR TITLE
docs: fix the constr() calls in the dating profiles example

### DIFF
--- a/docs/examples/dating_profiles.md
+++ b/docs/examples/dating_profiles.md
@@ -37,8 +37,8 @@ Users need to provide a short biography, with a minimum of 10 and a maximum of 3
 
 ```python
 class DatingProfile(BaseModel):
-    bio: constr(str, min_length=10, max_length=300)
-    job: constr(str, max_lengt=50)
+    bio: constr(min_length=10, max_length=300)
+    job: constr(max_length=50)
     interests: conlist(str, min_length=1, max_length=5)  # type: ignore
     qna1: QuestionAnswer
     qna2: QuestionAnswer


### PR DESCRIPTION
## What

The `DatingProfile` model in `docs/examples/dating_profiles.md` cannot be defined. Both `constr()` calls pass the type positionally, and in pydantic v2 `constr()` is keyword-only:

```python
constr(strip_whitespace=None, to_upper=None, to_lower=None, strict=None,
       min_length=None, max_length=None, pattern=None, ascii_only=None)
```

so evaluating the class body raises before anything else on the page runs:

```python
>>> from pydantic import constr
>>> constr(str, min_length=10, max_length=300)
TypeError: constr() takes 0 positional arguments but 1 positional argument (and 1 keyword-only argument) were given
```

The second call has a second problem behind the first one. `max_lengt` is missing its `h`, which surfaces as soon as the positional argument is gone:

```python
>>> constr(str, max_lengt=50)
TypeError: constr() got an unexpected keyword argument 'max_lengt'
```

## Fix

Drop the positional `str` from both calls and correct the typo. The constraints are unchanged and still match what the paragraph above the block describes, a bio of 10 to 300 characters and a job of at most 50.

```python
class DatingProfile(BaseModel):
    bio: constr(min_length=10, max_length=300)
    job: constr(max_length=50)
    interests: conlist(str, min_length=1, max_length=5)  # type: ignore
    qna1: QuestionAnswer
    qna2: QuestionAnswer
```

`conlist` on the third line is left alone. It genuinely does take its item type positionally, so `conlist(str, min_length=1, max_length=5)` is correct as written.

## Verification

The corrected model builds:

```python
>>> class Ok(BaseModel):
...     bio: constr(min_length=10, max_length=300)
...     job: constr(max_length=50)
...     interests: conlist(str, min_length=1, max_length=5)
>>> sorted(Ok.model_fields)
['bio', 'interests', 'job']
```

I found this while running the fenced Python blocks in `docs/` to see which ones a reader could copy and execute. This was the only failure on the page that was not caused by needing a model or a checkout-relative file path.
