### PR TITLE
fix(types): map anyOf/oneOf to a Union instead of dropping to Any

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -42,6 +42,20 @@ def schema_type_to_python(
         # widening the value back to its bare type.
         return Literal[schema["const"]]
 
+    for union_keyword in ("anyOf", "oneOf"):
+        branches = schema.get(union_keyword)
+        if branches:
+            # Pydantic emits ``anyOf`` for ``Optional[T]`` and ``Union[...]``, so a schema
+            # coming back from ``model_json_schema()`` carries the field's types here rather
+            # than under ``type``. Without this the branch types are lost and the field
+            # widens to ``Any``, which constrains nothing. ``oneOf`` maps to the same
+            # ``Union``: Python typing cannot express the exclusivity, but keeping the set of
+            # allowed types is strictly narrower than ``Any``.
+            members = tuple(
+                schema_type_to_python(branch, caller_target_type) for branch in branches
+            )
+            return Union[members] if members else Any  # type: ignore
+
     t = schema.get("type")
 
     if isinstance(t, list):

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -2,6 +2,7 @@ import sys
 from dataclasses import is_dataclass
 from typing import Any, List, Literal, Optional, Union
 
+import pytest
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticUndefined
 
@@ -415,3 +416,60 @@ def test_json_schema_dict_to_dataclass_optional_before_required():
     instance = result(user_id=5)
     assert instance.user_id == 5
     assert instance.nickname is None
+
+
+@pytest.mark.parametrize("union_keyword", ["anyOf", "oneOf"])
+def test_union_keyword_maps_to_union(union_keyword):
+    """`anyOf`/`oneOf` carry the branch types; dropping them widens the field to `Any`."""
+    schema = {union_keyword: [{"type": "integer"}, {"type": "string"}]}
+
+    assert schema_type_to_python(schema, "pydantic") == Union[int, str]
+
+
+@pytest.mark.parametrize("union_keyword", ["anyOf", "oneOf"])
+def test_union_keyword_with_null_branch_is_optional(union_keyword):
+    """A `null` branch is what Pydantic emits for `Optional[T]`."""
+    schema = {union_keyword: [{"type": "boolean"}, {"type": "null"}]}
+
+    assert schema_type_to_python(schema, "pydantic") == Optional[bool]
+
+
+def test_union_keyword_matches_the_type_array_spelling():
+    """The two spellings of the same constraint must not diverge."""
+    as_any_of = schema_type_to_python(
+        {"anyOf": [{"type": "integer"}, {"type": "string"}]}, "pydantic"
+    )
+    as_type_array = schema_type_to_python({"type": ["integer", "string"]}, "pydantic")
+
+    assert as_any_of == as_type_array
+
+
+def test_union_branches_are_mapped_recursively():
+    """Branches are full schemas, not just type names."""
+    schema = {
+        "anyOf": [
+            {"type": "array", "items": {"type": "integer"}},
+            {"type": "string"},
+        ]
+    }
+
+    assert schema_type_to_python(schema, "pydantic") == Union[List[int], str]
+
+
+def test_optional_and_union_fields_survive_the_round_trip():
+    """Pydantic emits `anyOf`, so these fields lost their types on the way through."""
+
+    class Source(BaseModel):
+        maybe_int: Optional[int]
+        either: Union[int, str]
+        plain: int
+
+    rebuilt = json_schema_dict_to_pydantic(Source.model_json_schema())
+
+    assert rebuilt.model_fields["maybe_int"].annotation == Optional[int]
+    assert rebuilt.model_fields["either"].annotation == Union[int, str]
+    assert rebuilt.model_fields["plain"].annotation is int
+    assert (
+        rebuilt.model_json_schema()["properties"]
+        == Source.model_json_schema()["properties"]
+    )


### PR DESCRIPTION
Closes #1950.

## What

`schema_type_to_python` dispatches on `enum`, `const`, `type` and JSON Schema type arrays, but not on `anyOf` / `oneOf`. A property spelled with either union keyword falls through every branch and returns `Any`, so the field ends up with no constraint.

That matters more than a hand-written schema suggests, because Pydantic emits `anyOf` for `Optional[T]` and `Union[...]`. A model round-tripped through `json_schema_dict_to_pydantic` loses exactly those fields:

```python
class Source(BaseModel):
    maybe_int: Optional[int]
    either: Union[int, str]
    plain: int
```

| field | before | after |
|---|---|---|
| `maybe_int` | `Any` | `Optional[int]` |
| `either` | `Any` | `Union[int, str]` |
| `plain` | `int` | `int` |

and the regenerated schema goes from `{"title": "Maybe Int"}` back to `{"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "Maybe Int"}` — identical to what Pydantic produced, so the round trip is lossless for these fields now.

The same constraint written as a type array already worked, which is what made the gap easy to miss:

```
{"type": ["integer", "string"]}                       -> Union[int, str]
{"anyOf": [{"type": "integer"}, {"type": "string"}]}  -> Any        (before)
```

## How

Handle both keywords before the `type` dispatch, mapping each branch through `schema_type_to_python` recursively and combining with `Union` — the same shape the existing type-array branch uses.

`oneOf` maps to the same `Union`. Python typing can't express exclusivity, so an input matching two branches will validate where the schema says it shouldn't; that's a widening, but a far smaller one than `Any`, which accepts values no branch allows. Called out in a comment so the trade-off isn't silently inherited.

## Tests

Five tests: both keywords to `Union`, both with a `null` branch to `Optional`, the two spellings agreeing, recursive branch mapping (`anyOf` of `array`/`string` to `Union[List[int], str]`), and the Pydantic round trip above.

They fail 7/30 on `main` and pass 30/30 with the change. `tests/types/test_dsl.py` is unchanged at 52 passed. `ruff check` is clean.

`tests/types/test_custom_types.py` fails to import in my environment because `airportsdata` isn't installed; that's unrelated and identical on a clean checkout.

## Note

`schema_type_to_python` is also touched by #1970 (the `additionalProperties` branch inside `elif t == "object"`). These are different branches of the same function, so they'll conflict textually but not semantically if both land.
