### PR TITLE
fix(models): make TransformerTokenizer.__eq__ agree with __hash__

### DIFF
--- a/src/outlines/models/transformers.py
+++ b/src/outlines/models/transformers.py
@@ -68,6 +68,16 @@ class TransformerTokenizer(Tokenizer):
 
         return string
 
+    def _fingerprint(self) -> str:
+        """Content fingerprint of the wrapped tokenizer.
+
+        Shared by `__eq__` and `__hash__` so the two cannot disagree about
+        what makes two tokenizers the same.
+        """
+        from datasets.fingerprint import Hasher
+
+        return Hasher.hash(self.tokenizer)
+
     def __eq__(self, other):
         if isinstance(other, type(self)):
             if hasattr(self, "model_name") and hasattr(self, "kwargs"):
@@ -75,13 +85,16 @@ class TransformerTokenizer(Tokenizer):
                     other.model_name == self.model_name and other.kwargs == self.kwargs
                 )
             else:
-                return other.tokenizer == self.tokenizer
+                # `PreTrainedTokenizerBase` does not define `__eq__`, so
+                # comparing the wrapped tokenizers directly is an identity
+                # check. Two tokenizers loaded separately from the same model
+                # would compare unequal while hashing equal, since `__hash__`
+                # is content-based. Compare the same fingerprint instead.
+                return self._fingerprint() == other._fingerprint()
         return NotImplemented
 
     def __hash__(self):
-        from datasets.fingerprint import Hasher
-
-        return hash(Hasher.hash(self.tokenizer))
+        return hash(self._fingerprint())
 
     def __getstate__(self):
         state = {"tokenizer": self.tokenizer}

--- a/tests/models/test_transformers_tokenizer.py
+++ b/tests/models/test_transformers_tokenizer.py
@@ -140,3 +140,32 @@ def test_spiece_underline_constant():
     tokenizer.tokenizer.convert_tokens_to_string.return_value = "hello"
 
     assert tokenizer.convert_token_to_string(token) == " hello"
+
+
+@pytest.fixture
+def separately_loaded_transformer_tokenizer():
+    """A second wrapper around an independently loaded copy of TEST_MODEL.
+
+    Distinct from `another_transformer_tokenizer`, which shares the `tokenizer`
+    fixture instance and so compares equal by identity alone.
+    """
+    return TransformerTokenizer(
+        transformers.AutoTokenizer.from_pretrained(TEST_MODEL)
+    )
+
+
+def test_transformer_tokenizer_eq_across_separate_loads(
+    transformer_tokenizer,
+    separately_loaded_transformer_tokenizer,
+):
+    first = transformer_tokenizer
+    second = separately_loaded_transformer_tokenizer
+
+    # Same model, same content, but not the same object.
+    assert first.tokenizer is not second.tokenizer
+    assert first.vocabulary == second.vocabulary
+
+    # `__hash__` is content-based, so `__eq__` has to agree with it.
+    assert hash(first) == hash(second)
+    assert first == second
+    assert not (first != second)


### PR DESCRIPTION
## The problem

`TransformerTokenizer.__hash__` is content-based:

```python
def __hash__(self):
    from datasets.fingerprint import Hasher
    return hash(Hasher.hash(self.tokenizer))
```

`__eq__` is not. When `model_name`/`kwargs` are absent — which is always, since `__init__` never sets them and neither call site passes them — it falls through to:

```python
return other.tokenizer == self.tokenizer
```

`transformers.PreTrainedTokenizerBase` does not define `__eq__`; `object` is the only class in its MRO that does:

```python
>>> [c.__name__ for c in PreTrainedTokenizerBase.__mro__ if "__eq__" in c.__dict__]
['object']
```

So that line is an identity check, and the two dunders disagree about what makes two tokenizers the same.

## Reproduction

```python
M = "hf-internal-testing/llama-tokenizer"
a = TransformerTokenizer(AutoTokenizer.from_pretrained(M))
b = TransformerTokenizer(AutoTokenizer.from_pretrained(M))
```

on `main`:

```
a.tokenizer is b.tokenizer     False
a.vocabulary == b.vocabulary   True
hash(a) == hash(b)             True
a == b                         False   <-
```

Identical vocabularies, identical hashes, not equal.

## Why the existing test doesn't catch it

```python
@pytest.fixture
def transformer_tokenizer(tokenizer):
    return TransformerTokenizer(tokenizer)

@pytest.fixture
def another_transformer_tokenizer(tokenizer):
    return TransformerTokenizer(tokenizer)
```

Both depend on the same `tokenizer` fixture, so within a test they wrap one object and `assert transformer_tokenizer == another_transformer_tokenizer` passes by identity. `test_transformer_tokenizer_hash` doesn't discriminate either, since that pair hashes equal both ways.

## The change

Pull out the fingerprint `__hash__` already computes and compare on it, so the two cannot drift apart:

```python
def _fingerprint(self) -> str:
    from datasets.fingerprint import Hasher
    return Hasher.hash(self.tokenizer)
```

The `model_name`/`kwargs` fast path is untouched — `test_transformer_tokenizer_eq` exercises it by attaching the attributes, and I didn't want to guess at whether something outside this repo relies on it.

## Verification

| case | before | after |
|---|---|---|
| separate loads, same model | `False` | `True` |
| same tokenizer object | `True` | `True` |
| different model | `False` | `False` |
| `model_name`/`kwargs` equal | `True` | `True` |
| `model_name` differs | `False` | `False` |
| `__eq__(1)` | `NotImplemented` | `NotImplemented` |
| `__setstate__` round-trip | equal | equal |
| `hash` equal for same model | `True` | `True` |
| `hash` equal for different models | `False` | `False` |

The new test asserts the pair hashes equal, compares equal, and that `!=` agrees. Reverting just `transformers.py` with the test in place fails it.

## Not related to #1129

That one is about the disk cache key not surviving a restart, which is a serialization question rather than an equality one. This change doesn't address it.

## One thing I deliberately left alone

`if hasattr(self, "model_name") and hasattr(self, "kwargs")` guards on `self` but then reads `other.model_name` and `other.kwargs`, so a comparison where only `self` carries those attributes raises `AttributeError` rather than returning `False`. It's reachable only if a caller attaches them to one instance and not the other, which nothing here does, and fixing it would mean deciding what that case should mean. Happy to add it if you'd like it in the same PR.