### PR TITLE
feat(types): add iban and bic custom types

### DIFF
--- a/src/outlines/types/__init__.py
+++ b/src/outlines/types/__init__.py
@@ -89,6 +89,8 @@ __all__ = [
     "hex_color",
     "slug",
     "credit_card",
+    "iban",
+    "bic",
     # Document-specific types
     "sentence",
     "paragraph",
@@ -189,6 +191,29 @@ credit_card = Regex(
     r"|(?:2131|1800|35[0-9]{3})[0-9]{11}"  # JCB
     r"|(?:5018|5020|5038|5893|6304|6759|676[1-3])[0-9]{8,15}"  # Maestro
     r"|62[0-9]{14,17}"  # UnionPay 62-prefix; includes Discover 622126-622925 co-brand
+)
+
+# ISO 13616 IBANs in electronic format: a country code, two check digits and a
+# country-specific basic bank account number of up to 30 characters. The check
+# digits are computed with ISO 7064 MOD 97-10 and therefore always fall between
+# 02 and 98. Neither the checksum itself nor the per-country account number
+# length and layout are validated, and the print format with spaces every four
+# characters is excluded.
+iban = Regex(
+    r"[A-Z]{2}"  # country code
+    r"(?:0[2-9]|[1-8][0-9]|9[0-8])"  # check digits
+    r"[A-Z0-9]{11,30}"  # basic bank account number
+)
+
+# ISO 9362 business identifier codes, also known as SWIFT codes. The location
+# code excludes 0 and 1 as its first character and the letter O as its second,
+# per the standard. The country code is only checked for shape here; use
+# `outlines.types.countries.Alpha2` to restrict it to assigned codes.
+bic = Regex(
+    r"[A-Z]{4}"  # institution code
+    r"[A-Z]{2}"  # country code
+    r"[A-Z2-9][A-NP-Z0-9]"  # location code
+    r"(?:[A-Z0-9]{3})?"  # optional branch code, "XXX" for the head office
 )
 
 # Document-specific types

--- a/tests/types/test_custom_types.py
+++ b/tests/types/test_custom_types.py
@@ -171,6 +171,34 @@ from outlines.types.dsl import to_regex
         (types.credit_card, "41111111111111111111", False),  # too long (20 digits)
         (types.credit_card, "3782822463100050", False),  # Amex prefix, wrong length
         (types.credit_card, "", False),
+        (types.iban, "GB82WEST12345698765432", True),
+        (types.iban, "DE89370400440532013000", True),
+        (types.iban, "FR1420041010050500013M02606", True),  # letters in the BBAN
+        (types.iban, "NO9386011117947", True),  # shortest, 15 characters
+        (types.iban, "MT84MALT011000012345MTLCAST001S", True),
+        (types.iban, "GB02WEST12345698765432", True),  # lowest check digits
+        (types.iban, "GB98WEST12345698765432", True),  # highest check digits
+        (types.iban, "GB00WEST12345698765432", False),  # check digits below 02
+        (types.iban, "GB99WEST12345698765432", False),  # check digits above 98
+        (types.iban, "GB82 WEST 1234 5698 7654 32", False),  # print format
+        (types.iban, "gb82west12345698765432", False),  # lowercase
+        (types.iban, "G182WEST12345698765432", False),  # digit in the country code
+        (types.iban, "GB82WEST1234", False),  # too short
+        (types.iban, "GB82WEST123456987654321234567890123", False),  # over 34
+        (types.iban, "", False),
+        (types.bic, "DEUTDEFF", True),  # institution, country and location only
+        (types.bic, "DEUTDEFF500", True),  # with a branch code
+        (types.bic, "NEDSZAJJXXX", True),  # head office branch code
+        (types.bic, "UNCRIT2B912", True),  # digit in the location code
+        (types.bic, "DEUTDE0F", False),  # location code starting with 0
+        (types.bic, "DEUTDE1F", False),  # location code starting with 1
+        (types.bic, "DEUTDEFO", False),  # letter O in the location code
+        (types.bic, "DEUT1EFF", False),  # digit in the country code
+        (types.bic, "DEUTDEF", False),  # too short
+        (types.bic, "DEUTDEFF50", False),  # incomplete branch code
+        (types.bic, "DEUTDEFF5000", False),  # too long
+        (types.bic, "deutdeff", False),  # lowercase
+        (types.bic, "", False),
     ],
 )
 def test_type_regex(custom_type, test_string, should_match):


### PR DESCRIPTION
Adds two custom types requested in #1303: `iban` (ISO 13616) and `bic` (ISO 9362).

## Description

`outlines.types` already ships a catalogue of validated regex types, and #1303 is the standing request to extend it. This adds two banking identifiers:

- **`iban`** — ISO 13616 electronic format. Two-letter country code, check digits constrained to `02`–`98` (per ISO 7064 MOD 97-10, where `00`, `01`, and `99` are not valid check digits), then an 11–30 character alphanumeric BBAN.
- **`bic`** — ISO 9362. Four-letter institution code, two-letter country code, then a two-character location code where the first character excludes `0` and `1` and the second excludes the letter `O`, plus an optional three-character branch code.

Both are module-level `Regex` constants, matching the shape of the three most recently merged type additions: #1863 (`semver`, `mac_address`), #1934 (`hex_color`, `slug`), and #1945 (`credit_card`). Like those PRs, this touches only `src/outlines/types/__init__.py` and `tests/types/test_custom_types.py`.

Duplicate-checked before writing: `iban`, `bic`, and `swift` appear in no open or closed PR and no other issue. I deliberately avoided `e164`, `latitude`/`longitude` (#1966), and the locale types (#1954, #1955, #1956), which are already covered by open PRs.

## Testing

28 parametrized cases covering valid forms, invalid check digits, invalid location codes, wrong lengths, and lowercase input.

Verified red first — with the source change stashed, the tests fail at collection:

```
AttributeError: module 'outlines.types' has no attribute 'iban'
1 error in 0.21s
```

Green:

```
pytest tests/types -q
314 passed in 0.72s

pytest tests -q --ignore=tests/models --ignore=tests/backends --ignore=tests/processors \
               --ignore=tests/test_applications.py --ignore=tests/test_generator.py
444 passed, 67 skipped in 0.74s
```

Lint and typecheck at the exact versions pinned in `.pre-commit-config.yaml`:

```
ruff check --config=pyproject.toml src/outlines/types/__init__.py tests/types/test_custom_types.py
All checks passed!

mypy --allow-redefinition src/outlines/types/__init__.py
Success: no issues found in 1 source file
```

Not run: `tests/models`, `tests/backends`, `tests/processors`, `tests/test_applications.py`, `tests/test_generator.py` — these fail at collection with `ModuleNotFoundError: No module named 'transformers'` and need torch/transformers/vllm. This change adds two module-level regex constants and touches no model or backend code path.

## Checklist

- [x] We should be able to understand what the PR does from its title only
- [x] There is a high-level description of the changes
- [x] *If I add a new feature*, there is an issue discussing it already — #1303
- [x] There are links to *all* the relevant issues, discussions and PRs
- [x] The branch is rebased on the latest `main` commit
- [x] **Commit messages** follow the guidelines
- [x] One commit per logical change
- [x] The code respects the current **naming conventions**
- [x] Docstrings follow the numpy style guide
- [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR
- [x] There are tests covering the changes
- [ ] The documentation is up-to-date — see note below

## Note on documentation

I did **not** update `docs/features/utility/regex_dsl.md`. The three merged precedent PRs above each touched only the source and test files, and that doc has drifted independently of this change: its custom-type catalogue lists nothing added after `ipv4`, so `ipv6`, `semver`, `mac_address`, `hex_color`, `slug`, `credit_card`, `email`, and `isbn` — eight shipped types — are already undocumented.

Adding only `iban`/`bic` there would make the list stranger, not better. Happy to either add them anyway if you prefer, or open a separate PR that brings the whole catalogue back in sync.

Closes #1303 (partially — the issue is an open-ended request for more types).
